### PR TITLE
Initial verify lines in the `build.gradle.kts`

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -36,6 +36,11 @@ intellijPlatform {
             untilBuild = "251.*"
         }
     }
+    pluginVerification {
+        ides {
+            recommended()
+        }
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
Summary from output:
 - Starting the IntelliJ Plugin Verifier 1.388
 - Finished 1 of 1 verifications (in 15.8 s): IC-251.26927.53 against Dart:1: 1 missing mandatory dependency. 6 usages of scheduled for removal API and 67 usages of deprecated API. 12 usages of experimental API. 94 usages of internal API
