### PR TITLE
Add initial verification failure flags for future CI enforcement

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -37,6 +38,22 @@ intellijPlatform {
         }
     }
     pluginVerification {
+        failureLevel = listOf(
+            VerifyPluginTask.FailureLevel.COMPATIBILITY_WARNINGS,
+            VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            //            VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+            //            VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            //            VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
+            //            VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
+            VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
+            VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
+            VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
+            VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,
+            VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
+            VerifyPluginTask.FailureLevel.NOT_DYNAMIC,
+        )
+        verificationReportsFormats = VerifyPluginTask.VerificationReportsFormats.ALL
+        subsystemsToCheck = VerifyPluginTask.Subsystems.ALL
         ides {
             recommended()
         }

--- a/third_party/src/main/resources/META-INF/plugin.xml
+++ b/third_party/src/main/resources/META-INF/plugin.xml
@@ -22,7 +22,6 @@
   <vendor>JetBrains</vendor>
   <category>Languages</category>
   <depends>com.intellij.modules.xml</depends>
-  <depends>com.intellij.modules.spellchecker</depends>
   <depends optional="true" config-file="dart-yaml.xml">org.jetbrains.plugins.yaml</depends>
   <depends optional="true" config-file="dart-copyright.xml">com.intellij.copyright</depends>
 


### PR DESCRIPTION
- Enable 8 VerifyPluginTask.FailureLevel.* enums
- Remove the `com.intellij.modules.spellchecker` from the plugin.xml
