### PR TITLE
Remove calls to the deprecated static methods in the platform FileUtil class

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubBuildDialog.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubBuildDialog.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.ui.ValidationInfo;
-import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -17,6 +16,7 @@ import com.intellij.ui.components.JBRadioButton;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.pubServer.DartWebdev;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.util.PathUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -79,7 +79,7 @@ public class DartPubBuildDialog extends DialogWrapper {
         @Override
         public String getText(JTextField component) {
           final String path = component.getText();
-          if (SystemInfo.isWindows && FileUtil.isWindowsAbsolutePath(path) || !SystemInfo.isWindows && FileUtil.isUnixAbsolutePath(path)) {
+          if (PathUtil.isAbsolutePlatformIndependent(path)) {
             return path;
           }
           return packagePathSlash + path;

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/PathUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/PathUtil.java
@@ -1,0 +1,34 @@
+package com.jetbrains.lang.dart.util;
+
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.OSAgnosticPathUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class PathUtil {
+    private PathUtil() {
+    }
+
+    public static boolean isAbsolutePlatformIndependent(@NotNull String path) {
+        return (SystemInfo.isWindows && PathUtil.isWindowsAbsolutePath(path))
+                || (!SystemInfo.isWindows && PathUtil.isUnixAbsolutePath(path));
+    }
+
+    /**
+     * See documentation in Community's FileUtil.java, this method intentionally matches the deprecated version from the
+     * platform.
+     */
+    public static boolean isUnixAbsolutePath(@NotNull String path) {
+        return path.startsWith("/");
+
+    }
+
+    /**
+     * See documentation in Community's FileUtil.java, this method intentionally matches the deprecated version from the
+     * platform.
+     */
+    public static boolean isWindowsAbsolutePath(@NotNull String path) {
+        return path.length() <= 2 && OSAgnosticPathUtil.startsWithWindowsDrive(path)
+                || OSAgnosticPathUtil.isAbsoluteDosPath(path);
+
+    }
+}


### PR DESCRIPTION
These methods are marked as being removed in the future in the platform.
