### PR TITLE
Stop calling getButton() in ComponentWithBrowseButton

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/ui/DartCommandLineConfigurationEditorForm.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/ui/DartCommandLineConfigurationEditorForm.java
@@ -57,7 +57,7 @@ public class DartCommandLineConfigurationEditorForm extends SettingsEditor<DartC
 
   public static void initDartFileTextWithBrowse(final @NotNull Project project,
                                                 final @NotNull TextFieldWithBrowseButton textWithBrowse) {
-    textWithBrowse.getButton().addActionListener(e -> {
+    textWithBrowse.addActionListener(e -> {
       final String initialPath = FileUtil.toSystemIndependentName(textWithBrowse.getText().trim());
       final VirtualFile initialFile = initialPath.isEmpty() ? null : LocalFileSystem.getInstance().findFileByPath(initialPath);
       final PsiFile initialPsiFile = initialFile == null ? null : PsiManager.getInstance(project).findFile(initialFile);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/ui/DartWebdevConfigurationEditorForm.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/ui/DartWebdevConfigurationEditorForm.java
@@ -26,7 +26,7 @@ public class DartWebdevConfigurationEditorForm extends SettingsEditor<DartWebdev
   private PortField myWebdevPortField;
 
   public DartWebdevConfigurationEditorForm(final Project project) {
-    myHtmlFileField.getButton().addActionListener(e -> {
+    myHtmlFileField.addActionListener(e -> {
       final String initialPath = FileUtil.toSystemIndependentName(myHtmlFileField.getText().trim());
       final VirtualFile initialFile = initialPath.isEmpty() ? null : LocalFileSystem.getInstance().findFileByPath(initialPath);
       final PsiFile initialPsiFile = initialFile == null ? null : PsiManager.getInstance(project).findFile(initialFile);


### PR DESCRIPTION
This API is marked to be removed from the API in the platform, see https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/openapi/ui/ComponentWithBrowseButton.java#L270

This changes the output from the verifier from **4 usages of scheduled for removal API** to **2 usages of scheduled for removal API**