### PR TITLE
Remove the usage of the PsiElement2UsageTargetAdapter(<one arg>) constructor

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/DartRenameDialog.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/DartRenameDialog.java
@@ -189,7 +189,7 @@ final class DartRenameDialog extends ServerRefactoringDialog<ServerRenameRefacto
         final PsiElement usageElement = DartServerFindUsagesHandler.getUsagePsiElement(psiFile, range);
         if (usageElement != null) {
           if (DartComponentType.typeOf(usageElement) != null) {
-            usageTargets.add(new PsiElement2UsageTargetAdapter(usageElement));
+            usageTargets.add(new PsiElement2UsageTargetAdapter(usageElement, true));
           }
           else {
             final UsageInfo usageInfo = DartServerFindUsagesHandler.getUsageInfo(usageElement, range, potentialUsage);


### PR DESCRIPTION
See https://github.com/JetBrains/intellij-community/blob/8c7221340c9a06fff2fdc89e9ee748b49fcf06b1/platform/refactoring/src/com/intellij/find/findUsages/PsiElement2UsageTargetAdapter.java#L70
