### PR TITLE
Enable SCHEDULED_FOR_REMOVAL_API_USAGES in the verifier

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -46,7 +46,7 @@ intellijPlatform {
             VerifyPluginTask.FailureLevel.COMPATIBILITY_WARNINGS,
             VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
             //            VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
-            //            VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
             //            VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
             //            VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
             VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,


### PR DESCRIPTION
This should be enforceable after the following land:
- https://github.com/flutter/dart-intellij-third-party/pull/25
- https://github.com/flutter/dart-intellij-third-party/pull/28
- https://github.com/flutter/dart-intellij-third-party/pull/26
- https://github.com/flutter/dart-intellij-third-party/pull/30