### PR TITLE
Remove the "Scope analysis to the current package" feature from the Dart problem view

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Vendor change from "JetBrains" to "Google"
  - Build system change from Basel to Gradle
  - Removal of the old Code Coverage support, all references to com.intellij.coverage.*
+ - Remove the "Scope analysis to the current package" feature from the Dart problem view
  - New Dart language feature: Dot Shorthands (https://youtrack.jetbrains.com/issue/IDEA-370100)
  - Support new 'Null-Aware Elements’ syntax (https://youtrack.jetbrains.com/issue/IDEA-374053)
  - Fix: IDE freezes after inserting a piece of Dart code (https://youtrack.jetbrains.com/issue/IDEA-231468)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartAnalysisServerSettingsForm.form
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartAnalysisServerSettingsForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.jetbrains.lang.dart.ide.errorTreeView.DartAnalysisServerSettingsForm">
-  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="10" bottom="10" right="5"/>
     <constraints>
       <xy x="20" y="20" width="378" height="257"/>
@@ -10,7 +10,7 @@
     <children>
       <component id="93a4" class="com.intellij.ui.HoverHyperlinkLabel" binding="myDartSettingsHyperlink" custom-create="true">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="messages/DartBundle" key="open.dart.plugin.settings"/>
@@ -18,29 +18,13 @@
       </component>
       <component id="b6360" class="com.intellij.ui.HoverHyperlinkLabel" binding="myAnalysisDiagnosticsHyperlink" custom-create="true">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="messages/DartBundle" key="analysis.server.settings.diagnostics"/>
         </properties>
       </component>
-      <component id="ea520" class="com.intellij.ui.components.JBCheckBox" binding="packageScopedAnalysisCheckbox">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text resource-bundle="messages/DartBundle" key="analysis.server.settings.package.analysis"/>
-        </properties>
-      </component>
       <component id="4a605" class="com.intellij.ui.TitledSeparator">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value=""/>
-        </properties>
-      </component>
-      <component id="d167a" class="com.intellij.ui.TitledSeparator">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -50,7 +34,7 @@
       </component>
       <vspacer id="cb7e">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
     </children>

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartAnalysisServerSettingsForm.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartAnalysisServerSettingsForm.java
@@ -4,7 +4,6 @@ package com.jetbrains.lang.dart.ide.errorTreeView;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.HoverHyperlinkLabel;
 import com.intellij.ui.HyperlinkAdapter;
-import com.intellij.ui.components.JBCheckBox;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import org.jetbrains.annotations.NotNull;
@@ -23,7 +22,6 @@ public class DartAnalysisServerSettingsForm {
   private JPanel myMainPanel;
   private HoverHyperlinkLabel myDartSettingsHyperlink;
   private HoverHyperlinkLabel myAnalysisDiagnosticsHyperlink;
-  private JBCheckBox packageScopedAnalysisCheckbox;
 
   DartAnalysisServerSettingsForm(final @NotNull Project project) {
     myProject = project;
@@ -46,22 +44,7 @@ public class DartAnalysisServerSettingsForm {
     });
   }
 
-  public void reset(final @NotNull DartProblemsPresentationHelper presentationHelper) {
-      packageScopedAnalysisCheckbox.setSelected(presentationHelper.getScopedAnalysisMode() == DartProblemsViewSettings.ScopedAnalysisMode.DartPackage);
-  }
-
-  public void addListener(final @NotNull ServerSettingsListener serverSettingsListener) {
-    packageScopedAnalysisCheckbox.addActionListener(e -> serverSettingsListener.settingsChanged());
-  }
-
   public JPanel getMainPanel() {
     return myMainPanel;
-  }
-
-  public @NotNull DartProblemsViewSettings.ScopedAnalysisMode getScopeAnalysisMode() {
-    if (packageScopedAnalysisCheckbox.isSelected()) {
-      return DartProblemsViewSettings.ScopedAnalysisMode.DartPackage;
-    }
-    return DartProblemsViewSettings.ScopedAnalysisMode.All;
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsPresentationHelper.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsPresentationHelper.java
@@ -66,15 +66,11 @@ public class DartProblemsPresentationHelper {
     mySettings.fileFilterMode = form.getFileFilterMode();
   }
 
-  void updateFromServerSettingsUI(@NotNull DartAnalysisServerSettingsForm form) {
-    mySettings.scopedAnalysisMode = form.getScopeAnalysisMode();
-  }
-
   boolean areFiltersApplied() {
     if (mySettings.showErrors != DartProblemsViewSettings.SHOW_ERRORS_DEFAULT) return true;
     if (mySettings.showWarnings != DartProblemsViewSettings.SHOW_WARNINGS_DEFAULT) return true;
     if (mySettings.showHints != DartProblemsViewSettings.SHOW_HINTS_DEFAULT) return true;
-      return mySettings.fileFilterMode != DartProblemsViewSettings.FILE_FILTER_MODE_DEFAULT;
+    return mySettings.fileFilterMode != DartProblemsViewSettings.FILE_FILTER_MODE_DEFAULT;
   }
 
   boolean setCurrentFile(@Nullable VirtualFile file) {
@@ -119,10 +115,6 @@ public class DartProblemsPresentationHelper {
 
   DartProblemsViewSettings.FileFilterMode getFileFilterMode() {
     return mySettings.fileFilterMode;
-  }
-
-  DartProblemsViewSettings.ScopedAnalysisMode getScopedAnalysisMode() {
-    return mySettings.scopedAnalysisMode;
   }
 
   @Nullable VirtualFile getCurrentFile() {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -322,13 +322,6 @@ public class DartProblemsViewPanel extends SimpleToolWindowPanel implements Copy
 
   private void showAnalysisServerSettingsPopup() {
     DartAnalysisServerSettingsForm serverSettingsForm = new DartAnalysisServerSettingsForm(myProject);
-    serverSettingsForm.reset(myPresentationHelper);
-
-    serverSettingsForm.addListener(() -> {
-      myPresentationHelper.updateFromServerSettingsUI(serverSettingsForm);
-      DartAnalysisServerService.getInstance(myProject).ensureAnalysisRootsUpToDate();
-    });
-
     createAndShowPopup(DartBundle.message("dart.problems.view.popup.title.analysis.server.settings"), serverSettingsForm.getMainPanel());
   }
 
@@ -453,8 +446,6 @@ public class DartProblemsViewPanel extends SimpleToolWindowPanel implements Copy
 
     @Override
     public void update(@NotNull AnActionEvent e) {
-      boolean asByDefault = myPresentationHelper.getScopedAnalysisMode() == DartProblemsViewSettings.SCOPED_ANALYSIS_MODE_DEFAULT;
-      Toggleable.setSelected(e.getPresentation(), !asByDefault);
     }
 
     @Override

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewSettings.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewSettings.java
@@ -7,15 +7,12 @@ public class DartProblemsViewSettings {
 
   public enum FileFilterMode {All, ContentRoot, DartPackage, Directory, File}
 
-  public enum ScopedAnalysisMode {All, DartPackage}
-
   static final boolean AUTO_SCROLL_TO_SOURCE_DEFAULT = false;
   static final boolean GROUP_BY_SEVERITY_DEFAULT = true;
   static final boolean SHOW_ERRORS_DEFAULT = true;
   static final boolean SHOW_WARNINGS_DEFAULT = true;
   static final boolean SHOW_HINTS_DEFAULT = true;
   static final FileFilterMode FILE_FILTER_MODE_DEFAULT = FileFilterMode.All;
-  static final ScopedAnalysisMode SCOPED_ANALYSIS_MODE_DEFAULT = ScopedAnalysisMode.All;
 
   @Attribute(value = "auto-scroll-to-source")
   public boolean autoScrollToSource = AUTO_SCROLL_TO_SOURCE_DEFAULT;
@@ -32,7 +29,4 @@ public class DartProblemsViewSettings {
   public boolean showWarnings = SHOW_WARNINGS_DEFAULT;
   @Attribute(value = "show-hints")
   public boolean showHints = SHOW_HINTS_DEFAULT;
-
-  @Attribute(value = "scoped-analysis-mode")
-  public ScopedAnalysisMode scopedAnalysisMode = SCOPED_ANALYSIS_MODE_DEFAULT;
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/DartBuildFileUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/DartBuildFileUtil.java
@@ -25,10 +25,7 @@ public final class DartBuildFileUtil {
     final ProjectFileIndex fileIndex = ProjectRootManager.getInstance(project).getFileIndex();
     VirtualFile parent = contextFile.isDirectory() ? contextFile : contextFile.getParent();
 
-    boolean isPackageScopedAnalysis =
-      DartProblemsView.getScopeAnalysisMode(project) == DartProblemsViewSettings.ScopedAnalysisMode.DartPackage;
-
-    while (parent != null && (isPackageScopedAnalysis || fileIndex.isInContent(parent))) {
+    while (parent != null && (fileIndex.isInContent(parent))) {
       final VirtualFile file = parent.findChild(BUILD_FILE_NAME);
       if (file != null && !file.isDirectory()) {
         final VirtualFile parent2 = parent.getParent();

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/PubspecYamlUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/PubspecYamlUtil.java
@@ -51,10 +51,7 @@ public final class PubspecYamlUtil {
     VirtualFile current = contextFile;
     VirtualFile parent = contextFile.isDirectory() ? contextFile : contextFile.getParent();
 
-    boolean isPackageScopedAnalysis =
-      DartProblemsView.getScopeAnalysisMode(project) == DartProblemsViewSettings.ScopedAnalysisMode.DartPackage;
-
-    while (parent != null && (LIB_DIR_NAME.equals(current.getName()) || isPackageScopedAnalysis || fileIndex.isInContent(parent))) {
+    while (parent != null && (LIB_DIR_NAME.equals(current.getName()) || fileIndex.isInContent(parent))) {
       current = parent;
       final VirtualFile file = parent.findChild(PUBSPEC_YAML);
       if (file != null && !file.isDirectory()) {

--- a/third_party/src/main/resources/messages/DartBundle.properties
+++ b/third_party/src/main/resources/messages/DartBundle.properties
@@ -254,7 +254,6 @@ group.by.severity=Group by Severity
 group.by.severity.description=Group by severity: errors in the top of the table, then come warnings, and hints in the end
 open.dart.plugin.settings=Open Dart plugin settings
 analysis.server.settings.diagnostics=View analyzer diagnostics
-analysis.server.settings.package.analysis=Scope analysis to the current package
 action.DartProblemsViewPanel.open.documentation.text=Open Documentation
 action.DartProblemsViewPanel.open.documentation.description=Open detailed problem description in browser
 # this text becomes a hyperlink that is added to the red code tooltip right after the error message. Example: "Dead code. (<a href='https://dart.dev/tools/diagnostic-messages#dead_code'>Documentation</a>)"


### PR DESCRIPTION
This feature is no longer recommended given progressions in the Dart Analysis Server