### PR TITLE
Remove calls to ParsingDiagnostics.registerParse(..)

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartTokenTypesSets.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartTokenTypesSets.java
@@ -3,7 +3,6 @@ package com.jetbrains.lang.dart;
 
 import com.intellij.lang.*;
 import com.intellij.openapi.util.Pair;
-import com.intellij.psi.ParsingDiagnostics;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.TokenType;
@@ -249,11 +248,12 @@ public interface DartTokenTypesSets {
       if (isSyncOrAsync(lazyParseableBlock)) {
         builder.putUserData(DartGeneratedParserUtilBase.INSIDE_SYNC_OR_ASYNC_FUNCTION, true);
       }
-      var startTime = System.nanoTime();
+//      var startTime = System.nanoTime();
       new DartParser().parseLight(BLOCK, builder);
-      var result = builder.getTreeBuilt().getFirstChildNode();
-      ParsingDiagnostics.registerParse(builder, getLanguage(), System.nanoTime() - startTime);
-      return result;
+      return builder.getTreeBuilt().getFirstChildNode();
+      // The following is removed as it is experimental and does not provide any functionality in the IDE for Dart developers:
+      // ParsingDiagnostics.registerParse(builder, getLanguage(), System.nanoTime() - startTime);
+      // return result; (set by builder.getTreeBuilt().getFirstChildNode()
     }
 
     private static boolean isSyncOrAsync(final @NotNull ASTNode newBlock) {
@@ -271,11 +271,12 @@ public interface DartTokenTypesSets {
     @Override
     protected ASTNode doParseContents(@NotNull ASTNode chameleon, @NotNull PsiElement psi) {
       PsiBuilder builder = PsiBuilderFactory.getInstance().createBuilder(psi.getProject(), chameleon);
-      var startTime = System.nanoTime();
+//      var startTime = System.nanoTime();
       new DartParser().parseLight(DartParserDefinition.DART_FILE, builder);
-      var result = builder.getTreeBuilt().getFirstChildNode();
-      ParsingDiagnostics.registerParse(builder, getLanguage(), System.nanoTime() - startTime);
-      return result;
+      return builder.getTreeBuilt().getFirstChildNode();
+      // The following is removed as it is experimental and does not provide any functionality in the IDE for Dart developers:
+      // ParsingDiagnostics.registerParse(builder, getLanguage(), System.nanoTime() - startTime);
+      // return result; (set by builder.getTreeBuilt().getFirstChildNode()
     }
 
     @Override

--- a/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartExpressionCodeFragmentImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartExpressionCodeFragmentImpl.java
@@ -111,15 +111,16 @@ public class DartExpressionCodeFragmentImpl extends DartFile implements DartExpr
     protected ASTNode doParseContents(@NotNull ASTNode chameleon, @NotNull PsiElement psi) {
       final PsiBuilderFactory factory = PsiBuilderFactory.getInstance();
       final PsiBuilder psiBuilder = factory.createBuilder(((TreeElement)chameleon).getManager().getProject(), chameleon);
-      var startTime = System.nanoTime();
+//      var startTime = System.nanoTime();
       final PsiBuilder builder = adapt_builder_(DartTokenTypes.STATEMENTS, psiBuilder, new DartParser(), DartParser.EXTENDS_SETS_);
 
       PsiBuilder.Marker marker = enter_section_(builder, 0, _COLLAPSE_, "<code fragment>");
       boolean result = DartParser.expression(builder, 0);
       exit_section_(builder, 0, marker, DartTokenTypes.STATEMENTS, result, true, TRUE_CONDITION);
-      var treeBuilt = builder.getTreeBuilt();
-      ParsingDiagnostics.registerParse(builder, getLanguage(), System.nanoTime() - startTime);
-      return treeBuilt;
+      return builder.getTreeBuilt();
+      // The following is removed as it is experimental and does not provide any functionality in the IDE for Dart developers:
+      // ParsingDiagnostics.registerParse(builder, getLanguage(), System.nanoTime() - startTime);
+      // return treeBuilt; (set by builder.getTreeBuilt())
     }
   }
 }


### PR DESCRIPTION
These calls do not add any functionality to users, and are experimental in the IntelliJ framework APIs.

This reduces the number of experimental API usages by the verifier violations by 4.