### PR TITLE
Change thread assertions from ApplicationManager.getApplication().assert* calls.

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.Alarm;
 import com.intellij.util.concurrency.Semaphore;
+import com.intellij.util.concurrency.ThreadingAssertions;
 import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
@@ -82,8 +83,8 @@ public final class VmServiceWrapper implements Disposable {
   }
 
   private void assertSyncRequestAllowed() {
-    ApplicationManager.getApplication().assertIsNonDispatchThread();
-    ApplicationManager.getApplication().assertReadAccessNotAllowed();
+      ThreadingAssertions.assertBackgroundThread();
+      ThreadingAssertions.assertNoReadAccess();
     if (myVmServiceReceiverThreadId == Thread.currentThread().getId()) {
       LOG.error("Synchronous requests must not be made in Web Socket listening thread: answer will never be received");
     }


### PR DESCRIPTION
See comments in https://github.com/JetBrains/intellij-community/blob/bf495f15fcb3611ba9f7e90aa9aec7b40cb9fad9/platform/core-api/src/com/intellij/openapi/application/Application.java#L282

This reduces the number of experimental API usages by the verifier violations by 2.