### PR TITLE
[fix] inline removed `ActionCenter.getToolWindow`

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsView.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsView.java
@@ -149,6 +149,12 @@ public final class DartProblemsView implements PersistentStateComponent<DartProb
     return content != null ? (DartProblemsViewPanel)content.getComponent() : null;
   }
 
+  // Inlined from `ActionCenter` (where it was removed).
+  // see: https://github.com/flutter/dart-intellij-third-party/issues/80
+  private static @Nullable ToolWindow getToolWindow(@Nullable Project project) {
+    return project == null ? null : ToolWindowManager.getInstance(project).getToolWindow("Notifications");
+  }
+
   void setTabTitle(@TabTitle @NotNull String tabTitle) {
     ToolWindow toolWindow = getDartAnalysisToolWindow();
     Content content = toolWindow != null ? toolWindow.getContentManager().getContent(0) : null;
@@ -251,9 +257,7 @@ public final class DartProblemsView implements PersistentStateComponent<DartProb
                 @Override
                 protected void hyperlinkActivated(@NotNull Notification notification, @NotNull HyperlinkEvent e) {
                   notification.expire();
-                  // 2025.1, 251 change in platform, see
-                  // https://github.com/JetBrains/intellij-plugins/commit/762b22a5626c1b47f133cefb483bbc16178caee3
-                  final ToolWindow toolWindow = ActionCenter.getToolWindow(myProject);
+                  final ToolWindow toolWindow = getToolWindow(myProject);
                   if (toolWindow != null) toolWindow.activate(null);
                   // ActionCenter.activateLog(myProject);
                 }


### PR DESCRIPTION
Fixes: https://github.com/flutter/dart-intellij-third-party/issues/80

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
