### PR TITLE
[tests] ignore `DartServerFindUsagesTest.testBoolUsagesWithScope`

### DIFF
--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerFindUsagesTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerFindUsagesTest.java
@@ -70,7 +70,8 @@ public class DartServerFindUsagesTest extends CodeInsightFixtureTestCase {
     assertSameElements(actualResult, expected);
   }
 
-  public void testBoolUsagesWithScope() {
+  // See: https://github.com/flutter/dart-intellij-third-party/issues/86
+  public void ignore_testBoolUsagesWithScope() {
     final PsiFile psiFile1 = myFixture.configureByText("file.dart", """
       /// [bool]
       <caret>bool foo() {


### PR DESCRIPTION
See: https://github.com/flutter/dart-intellij-third-party/issues/86

(Note that JUnit 3 has nothing like the `@Ignore` annotation so we need to appeal to a naming convention.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
