### PR TITLE
Add some class level documentation to the unit tests

### DIFF
--- a/third_party/src/test/java/com/jetbrains/lang/dart/dart_style/DartStyleLenientTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/dart_style/DartStyleLenientTest.java
@@ -4,9 +4,10 @@ package com.jetbrains.lang.dart.dart_style;
 import java.util.HashSet;
 
 /**
- * Run the dart_style test suite using the expected output as the input.
- * This quickly identifies those areas that the formatter changes
- * properly formatted code into improperly formatted code.
+ * Run the dart_style test suite in lenient mode.
+ * <p>
+ * This test class runs the dart_style test suite using the expected output as the input.
+ * It is used to quickly identify cases where the formatter changes properly formatted code into improperly formatted code.
  */
 public class DartStyleLenientTest extends DartStyleTest {
   /**

--- a/third_party/src/test/java/com/jetbrains/lang/dart/dart_style/DartStyleStrictTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/dart_style/DartStyleStrictTest.java
@@ -5,7 +5,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Run the dart_style test suite.
+ * Run the dart_style test suite in strict mode.
+ * <p>
+ * This test class runs the dart_style test suite using the original source code as input.
+ * It is used to ensure that the Dart code formatter in the IDE is consistent with the official Dart code formatter.
  */
 public class DartStyleStrictTest extends DartStyleTest {
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/dart_style/DartStyleTest.java
@@ -17,7 +17,21 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Define the dart_style test suite.
+ * The base class for the dart_style test suite.
+ * <p>
+ * This class provides the core testing infrastructure for the dart_style code formatter.
+ * It includes a list of known-to-fail tests that are not expected to pass in any mode.
+ * <p>
+ * Subclasses should override the {@code runTestInDirectory} and {@code extractSourceSelection} methods
+ * to provide the specific behavior for their test mode.
+ * <p>
+ * This test suite is based on the dart_style test suite from the Dart SDK.
+ * see: https://github.com/dart-lang/dart_style/tree/master/test
+ * <p>
+ * It is used to ensure that the Dart code formatter in the IDE is consistent with the official Dart code formatter.
+ *
+ * @see DartStyleStrictTest
+ * @see DartStyleLenientTest
  */
 public abstract class DartStyleTest extends FormatterTestCase {
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocUtilTest.java
@@ -9,6 +9,11 @@ import com.jetbrains.lang.dart.psi.DartComponent;
 
 import static com.jetbrains.lang.dart.util.DartPresentableUtil.RIGHT_ARROW;
 
+/**
+ * Test the generation of Dart documentation from source code.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.ide.documentation.DartDocUtil} class, which is responsible for generating the documentation that is displayed in the IDE.
+ */
 public class DartDocUtilTest extends DartCodeInsightFixtureTestCase {
 
   private void doTest(String expectedDoc, String fileContents) {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
@@ -18,6 +18,11 @@ import java.util.Collections;
 
 import static com.jetbrains.lang.dart.util.DartPresentableUtil.RIGHT_ARROW;
 
+/**
+ * Test the {@link com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider} class.
+ * <p>
+ * This class is responsible for providing documentation to the IDE, such as the quick navigation info and the documentation URLs.
+ */
 public class DartDocumentationProviderTest extends DartCodeInsightFixtureTestCase {
 
   private final DartDocumentationProvider myProvider = new DartDocumentationProvider();

--- a/third_party/src/test/java/com/jetbrains/lang/dart/folding/DartFoldingTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/folding/DartFoldingTest.java
@@ -8,6 +8,11 @@ import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Test the Dart code folding functionality.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.folding.DartFoldingBuilder} class, which is responsible for providing code folding regions for Dart code.
+ */
 public class DartFoldingTest extends DartCodeInsightFixtureTestCase {
 
   private void doTest() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/formatter/DartFormatterTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/formatter/DartFormatterTest.java
@@ -7,6 +7,11 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.DartLanguage;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
+/**
+ * Test the Dart code formatter.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.formatter.DartFormattingModelBuilder} class, which is responsible for formatting Dart code.
+ */
 public class DartFormatterTest extends FormatterTestCase {
 
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/generate/DartGenerateActionTestBase.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/generate/DartGenerateActionTestBase.java
@@ -4,6 +4,11 @@ import com.intellij.testFramework.LightPlatformCodeInsightTestCase;
 import com.jetbrains.lang.dart.ide.generation.*;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * The base class for the Dart code generation tests.
+ * <p>
+ * This class provides the core testing infrastructure for the Dart code generation actions.
+ */
 abstract public class DartGenerateActionTestBase extends LightPlatformCodeInsightTestCase {
   protected void doOverrideTest() {
     doTest(new DartOverrideMethodHandler());

--- a/third_party/src/test/java/com/jetbrains/lang/dart/highlighting/DartHighlightingTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/highlighting/DartHighlightingTest.java
@@ -12,6 +12,11 @@ import com.jetbrains.lang.dart.util.DartResolveUtil;
 
 import java.util.function.Consumer;
 
+/**
+ * Test the Dart code highlighting functionality.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.highlighting.DartSyntaxHighlighter} class, which is responsible for providing syntax highlighting for Dart code.
+ */
 public class DartHighlightingTest extends DartCodeInsightFixtureTestCase {
   @Override
   protected String getBasePath() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/DartLiveTemplatesTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/DartLiveTemplatesTest.java
@@ -15,6 +15,11 @@ import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
+/**
+ * Test the Dart live templates.
+ * <p>
+ * This class tests the Dart live templates, which are used to insert common code snippets into the editor.
+ */
 public class DartLiveTemplatesTest extends BasePlatformTestCase {
   @Override
   protected String getTestDataPath() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/DartSurroundWithTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/DartSurroundWithTest.java
@@ -11,6 +11,11 @@ import com.jetbrains.lang.dart.ide.surroundWith.statement.*;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Test the Dart "surround with" functionality.
+ * <p>
+ * This class tests the Dart "surround with" functionality, which is used to surround a block of code with a template, such as an if statement or a try/catch block.
+ */
 public class DartSurroundWithTest extends LightPlatformCodeInsightTestCase {
   @NotNull
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/DartTemplateMacrosTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/DartTemplateMacrosTest.java
@@ -12,6 +12,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Test the Dart template macros.
+ * <p>
+ * This class tests the Dart template macros, which are used to insert dynamic information into live templates, such as the current class name or the current method name.
+ */
 public class DartTemplateMacrosTest extends DartCodeInsightFixtureTestCase {
 
   @NotNull

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/editor/DartImplementationsViewTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/editor/DartImplementationsViewTest.java
@@ -6,6 +6,11 @@ import com.intellij.codeInsight.hint.ImplementationViewComponent;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 
+/**
+ * Test the Dart implementations view.
+ * <p>
+ * This class tests the Dart implementations view, which is used to display the implementations of a class or a method.
+ */
 public class DartImplementationsViewTest extends DartCodeInsightFixtureTestCase {
   private void doTest(String fileText, String expected) {
     myFixture.configureByText("foo.dart", fileText);

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/editor/DartWordSelectionTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/editor/DartWordSelectionTest.java
@@ -4,6 +4,11 @@ import com.intellij.testFramework.fixtures.CodeInsightTestUtil;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
+/**
+ * Test the Dart word selection functionality.
+ * <p>
+ * This class tests the Dart word selection functionality, which is used to select words and blocks of code in the editor.
+ */
 public class DartWordSelectionTest extends DartCodeInsightFixtureTestCase {
 
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartCodeMoverTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartCodeMoverTest.java
@@ -5,6 +5,11 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
+/**
+ * The base class for the Dart code mover tests.
+ * <p>
+ * This class provides the core testing infrastructure for the Dart code mover actions.
+ */
 abstract public class DartCodeMoverTest extends DartCodeInsightFixtureTestCase {
 
   // Added setUp to make sure the files that the test needs are available during tests

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartCommentIdentifierTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartCommentIdentifierTest.java
@@ -4,6 +4,11 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 
+/**
+ * Test the identification of comment ranges.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.ide.moveCode.DartComponentMover#findCommentRange(PsiElement)} method, which is responsible for identifying the range of a comment.
+ */
 public class DartCommentIdentifierTest extends DartCodeInsightFixtureTestCase {
 
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartComponentMoverTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartComponentMoverTest.java
@@ -1,5 +1,10 @@
 package com.jetbrains.lang.dart.ide.moveCode;
 
+/**
+ * Test the Dart component mover.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.ide.moveCode.DartComponentMover} class, which is responsible for moving Dart components, such as classes, methods, and variables.
+ */
 public class DartComponentMoverTest extends DartCodeMoverTest {
 
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/moveCode/DartStatementMoverTest.java
@@ -1,6 +1,11 @@
 // Copyright 2000-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.jetbrains.lang.dart.ide.moveCode;
 
+/**
+ * Test the Dart statement mover.
+ * <p>
+ * This class tests the {@link com.intellij.codeInsight.editorActions.moveUpDown.StatementUpDownMover} class for Dart, which is responsible for moving Dart statements, such as if statements, for loops, and while loops.
+ */
 public class DartStatementMoverTest extends DartCodeMoverTest {
 
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/runner/DartConsoleFilterTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/runner/DartConsoleFilterTest.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.NotNull;
 
 import static com.jetbrains.lang.dart.ide.runner.DartPositionInfo.Type;
 
+/**
+ * Test the Dart console filter.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.ide.runner.DartConsoleFilter} class, which is responsible for parsing console output and creating hyperlinks to source code.
+ */
 public class DartConsoleFilterTest extends TestCase {
 
   private static void doNegativeTest(final String text) {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/runner/util/DartTestLocationProviderTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/runner/util/DartTestLocationProviderTest.java
@@ -10,6 +10,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+/**
+ * Test the Dart test location provider.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.ide.runner.util.DartTestLocationProvider} class, which is responsible for providing the location of a test from a location hint.
+ */
 public class DartTestLocationProviderTest extends DartCodeInsightFixtureTestCase {
 
   private void doTest(@NotNull final String locationHint, @NotNull final String fileContents) {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/testIntegration/DartTestFinderTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/testIntegration/DartTestFinderTest.java
@@ -4,6 +4,11 @@ package com.jetbrains.lang.dart.ide.testIntegration;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 
+/**
+ * Test the Dart test finder.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.ide.testIntegration.DartTestFinder} class, which is responsible for finding tests and test subjects.
+ */
 public class DartTestFinderTest extends DartCodeInsightFixtureTestCase {
 
   public void testIsTest() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/injection/DartInjectionTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/injection/DartInjectionTest.java
@@ -10,6 +10,11 @@ import com.jetbrains.lang.dart.util.DartTestUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 
+/**
+ * Test the Dart language injection functionality.
+ * <p>
+ * This class tests the Dart language injection functionality, which is used to inject other languages, such as HTML, into Dart string literals.
+ */
 public class DartInjectionTest extends LightPlatformCodeInsightTestCase {
   @NotNull
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/markers/DartMethodSeparatorsTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/markers/DartMethodSeparatorsTest.java
@@ -4,6 +4,11 @@ package com.jetbrains.lang.dart.markers;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzerSettings;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 
+/**
+ * Test the Dart method separators.
+ * <p>
+ * This class tests the Dart method separators, which are the lines that are drawn between methods in the editor.
+ */
 public class DartMethodSeparatorsTest extends BasePlatformTestCase {
 
   protected void doTest(String fileText) {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/navigation/DartGoToSymbolTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/navigation/DartGoToSymbolTest.java
@@ -10,6 +10,11 @@ import com.jetbrains.lang.dart.ide.DartSymbolContributor;
 import java.util.ArrayList;
 import java.util.Collection;
 
+/**
+ * Test the Dart "go to symbol" functionality.
+ * <p>
+ * This class tests the {@link com.jetbrains.lang.dart.ide.DartSymbolContributor} class, which is responsible for providing the symbols that are displayed in the "go to symbol" list.
+ */
 public class DartGoToSymbolTest extends DartCodeInsightFixtureTestCase {
 
   private void assertNamesFound(ChooseByNameContributor contributor, String... names) {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/parser/DartParsingTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/parser/DartParsingTest.java
@@ -6,6 +6,11 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.DartParserDefinition;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
+/**
+ * Test the Dart parser.
+ * <p>
+ * This class tests the Dart parser, which is responsible for parsing Dart code and building a PSI tree.
+ */
 public class DartParsingTest extends ParsingTestCase {
   public DartParsingTest() {
     super("parsing", DartFileType.DEFAULT_EXTENSION, new DartParserDefinition());

--- a/third_party/src/test/java/com/jetbrains/lang/dart/rename/DartRenameTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/rename/DartRenameTest.java
@@ -4,6 +4,11 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 
+/**
+ * Test the Dart rename refactoring.
+ * <p>
+ * This class tests the Dart rename refactoring, which is used to rename Dart elements, such as classes, methods, and variables.
+ */
 public class DartRenameTest extends DartCodeInsightFixtureTestCase {
   @Override
   protected String getBasePath() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/resolve/DartResolveTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/resolve/DartResolveTest.java
@@ -9,6 +9,11 @@ import com.jetbrains.lang.dart.ide.runner.DartExecutionHelper;
 
 import static com.jetbrains.dart.analysisServer.DartServerResolverTest.doTest;
 
+/**
+ * Test the Dart resolve functionality.
+ * <p>
+ * This class tests the Dart resolve functionality, which is used to resolve references to Dart elements, such as classes, methods, and variables.
+ */
 public class DartResolveTest extends DartCodeInsightFixtureTestCase {
 
   public void testResolveAndUseScope() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/suppress/DartSuppressTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/suppress/DartSuppressTest.java
@@ -6,6 +6,11 @@ import com.intellij.openapi.command.CommandProcessor;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 import com.jetbrains.lang.dart.ide.annotator.DartProblemGroup;
 
+/**
+ * Test the Dart "suppress" functionality.
+ * <p>
+ * This class tests the Dart "suppress" functionality, which is used to suppress warnings and errors in the editor.
+ */
 public class DartSuppressTest extends DartCodeInsightFixtureTestCase {
 
   private boolean isSuppressActionAvailable(final boolean eolComment) {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/typing/DartSelectWordTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/typing/DartSelectWordTest.java
@@ -7,6 +7,11 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import org.jetbrains.annotations.NotNull;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
+/**
+ * Test the Dart word selection functionality.
+ * <p>
+ * This class tests the Dart word selection functionality, which is used to select words and blocks of code in the editor.
+ */
 public class DartSelectWordTest extends BasePlatformTestCase {
 
     // Added setUp to make sure the files that the test needs are available during tests

--- a/third_party/src/test/java/com/jetbrains/lang/dart/typing/DartTypingTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/typing/DartTypingTest.java
@@ -15,6 +15,11 @@ import com.jetbrains.lang.dart.DartLanguage;
 import org.jetbrains.annotations.NotNull;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
+/**
+ * Test the Dart typing functionality.
+ * <p>
+ * This class tests the Dart typing functionality, which is used to provide auto-completion and other typing assistance in the editor.
+ */
 public class DartTypingTest extends DartCodeInsightFixtureTestCase {
   @Override
   protected String getBasePath() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/util/CaretPositionInfo.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/util/CaretPositionInfo.java
@@ -4,6 +4,11 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+/**
+ * Store information about a caret position.
+ * <p>
+ * This class is used to store information about a caret position in a test file, such as the expected completion list.
+ */
 public class CaretPositionInfo {
 
   public final int caretOffset;

--- a/third_party/src/test/java/com/jetbrains/lang/dart/util/DartTestUtils.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/util/DartTestUtils.java
@@ -31,6 +31,11 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Utility methods for Dart tests.
+ * <p>
+ * This class provides utility methods for Dart tests, such as configuring the Dart SDK and extracting position markers from test files.
+ */
 public final class DartTestUtils {
 
   public static final String BASE_TEST_DATA_PATH = findTestDataPath();

--- a/third_party/src/test/java/com/jetbrains/lang/dart/workflow/DartSimpleTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/workflow/DartSimpleTest.java
@@ -9,6 +9,11 @@ import com.jetbrains.lang.dart.util.DartPsiImplUtil;
 import junit.framework.TestCase;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Test simple Dart functionality.
+ * <p>
+ * This class tests simple Dart functionality, such as unquoting strings and parsing debugger error text.
+ */
 public class DartSimpleTest extends TestCase {
   private static void doTestUnquoteDartString(@NotNull final String inputString,
                                               @NotNull final String expectedUnquoted,

--- a/third_party/src/test/java/com/jetbrains/lang/dart/workflow/DartWorkflowTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/workflow/DartWorkflowTest.java
@@ -12,6 +12,11 @@ import com.jetbrains.lang.dart.DartStartupActivityKt;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 
+/**
+ * Test the Dart workflow.
+ * <p>
+ * This class tests the Dart workflow, such as the exclusion of special folders and the Dart URL resolver.
+ */
 public class DartWorkflowTest extends DartCodeInsightFixtureTestCase {
   @Override
   protected void tearDown() throws Exception {


### PR DESCRIPTION
Use Gemini 2.5 to fill in missing class level documentation in the unit tests under `third_party/src/test/java/com/jetbrains/lang/dart/*`