### PR TITLE
[docs] update plugin documentation link

### DIFF
--- a/third_party/README.md
+++ b/third_party/README.md
@@ -5,7 +5,7 @@ This plugin provides support for the [Dart programming language](https://dart.de
 ## Installing and Getting Started
 
 See the
-[plugin documentation](https://www.jetbrains.com/help/idea/dart.html)
+[plugin documentation](https://dart.dev/tools/jetbrains-plugin)
 for help to get started with Dart development and the IntelliJ IDEA plugin. 
 
 ## Reporting Issues


### PR DESCRIPTION
Update the plugin docs link to point to `dart.dev`.

Related: https://github.com/flutter/dart-intellij-third-party/issues/107

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
