### PR TITLE
[cq] migrate off slated-for-removal `findId` API

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerErrorHandler.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerErrorHandler.java
@@ -104,7 +104,7 @@ public class DartAnalysisServerErrorHandler {
 
     // version info
     final ApplicationInfo platform = ApplicationInfo.getInstance();
-    final IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.findId("Dart"));
+    final IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId("Dart"));
 
     text.println("## Version information");
     text.println("");


### PR DESCRIPTION
Addresses verification error:

<img width="1434" height="213" alt="image" src="https://github.com/user-attachments/assets/831526c3-f65c-48d8-b5ce-6cb0bfa28823" />

by migrating to preferred `getId` API.

<img width="671" height="150" alt="image" src="https://github.com/user-attachments/assets/cf40d6a6-0529-4e33-98ad-34a0fc3a29d4" />



https://github.com/JetBrains/intellij-community/blob/b8fc6f85d4751817c226044f55f1a046f58b2f9b/platform/extensions/src/com/intellij/openapi/extensions/PluginId.kt#L43-L49




---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
