### PR TITLE
Add separate plugin logging for Dart

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.io.BaseOutputReader
+import com.jetbrains.lang.dart.logging.PluginLogger
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
 import java.nio.charset.StandardCharsets
@@ -101,6 +102,6 @@ class DartDevToolsService(private val myProject: Project) : Disposable {
     fun getInstance(project: Project): DartDevToolsService = project.service()
 
     private const val MIN_SDK_VERSION: String = "2.15"
-    private val logger = logger<DartDevToolsService>()
+    private val logger = PluginLogger.createLogger(DartDevToolsService::class.java)
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/logging/PluginLogger.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/logging/PluginLogger.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.logging
+
+import com.intellij.openapi.application.PathManager
+import java.io.File
+import java.io.IOException
+import java.util.logging.FileHandler
+import java.util.logging.Logger
+import java.util.logging.SimpleFormatter
+
+object PluginLogger {
+  private const val LOG_FILE_NAME = "dash.log"
+
+  private val rootLogger: Logger = Logger.getLogger("com.jetbrains.lang.dart")
+
+  // This handler specifies the logging format and location.
+  private var fileHandler: FileHandler
+
+  init {
+    val logPath = PathManager.getLogPath()
+    try {
+      fileHandler = FileHandler(logPath + File.separatorChar + LOG_FILE_NAME, 1024 * 1024, 1)
+    } catch (e: IOException) {
+      throw RuntimeException(e)
+    }
+    System.setProperty(
+      "java.util.logging.SimpleFormatter.format",
+      "%1\$tF %1\$tT %3\$s [%4$-7s] %5\$s %6\$s %n"
+    )
+    fileHandler.formatter = SimpleFormatter()
+    rootLogger.addHandler(fileHandler)
+  }
+
+  fun createLogger(logClass: Class<*>): com.intellij.openapi.diagnostic.Logger {
+    return com.intellij.openapi.diagnostic.Logger.getInstance(logClass.getName())
+  }
+}


### PR DESCRIPTION
This is follow up to the Flutter work to have a separate plugin logging file for ease of use (https://github.com/flutter/flutter-intellij/issues/8369).

Notable:
- I'm putting this into a file called `dash.log` with the intention of transitioning the Flutter plugin to use that file also, so that we end up with a `dash.log` that only contains messages from Dart and Flutter.
- Similar to the Flutter plugin, Dart plugin logs will continue to write to the main `idea.log` also.
- I've only started using the logger in the service for Devtools to test, but intend to change all other classes to use the logger too. And I will encourage everyone else to use the new logger when adding new classes.

Any additional thoughts on logging welcome.