### PR TITLE
[analytics] reporting API

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -52,7 +52,7 @@ import com.intellij.util.io.URLUtil;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.analytics.Analytics;
-import com.jetbrains.lang.dart.analytics.AnalyticsData;
+import com.jetbrains.lang.dart.analytics.AnalyticsConfiguration;
 import com.jetbrains.lang.dart.assists.DartQuickAssistIntention;
 import com.jetbrains.lang.dart.assists.DartQuickAssistIntentionListener;
 import com.jetbrains.lang.dart.fixes.DartQuickFix;
@@ -2286,8 +2286,8 @@ public final class DartAnalysisServerService implements Disposable {
         stopServer();
         DartProblemsView.getInstance(myProject).setInitialCurrentFileBeforeServerStart(getCurrentOpenFile());
 
-//        AnalyticsData analyticsData = Analytics.getReportingData(sdk, myProject);
-//        startServer(sdk, analyticsData.getSuppressAnalytics());
+//        AnalyticsConfiguration analyticsConfig = Analytics.getConfiguration(sdk, myProject);
+//        startServer(sdk, analyticsConfig.getSuppressAnalytics());
 
         // TODO (pq): pass in suppressAnalytics
         startServer(sdk, false);


### PR DESCRIPTION
Migrates API from the flutter plugin (and refines it).

Still TODO, the actual communication (See `UnifiedAnalyticsReporter.process(..)`).

Once implemented, instrumentation of an action (for example, `DartPubActionBase`), will look like this:

```kotlin
  override fun actionPerformed(e: AnActionEvent) {
    val (module, pubspecYamlFile) = getModuleAndPubspecYamlFile(e) ?: return

    Analytics.report(AnalyticsData.forAction(this, e))
    performPubAction(module, pubspecYamlFile, true)
  }
```



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
