### PR TITLE
[analytics] enable analytics gathering

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -2286,11 +2286,8 @@ public final class DartAnalysisServerService implements Disposable {
         stopServer();
         DartProblemsView.getInstance(myProject).setInitialCurrentFileBeforeServerStart(getCurrentOpenFile());
 
-//        AnalyticsConfiguration analyticsConfig = Analytics.getConfiguration(sdk, myProject);
-//        startServer(sdk, analyticsConfig.getSuppressAnalytics());
-
-        // TODO (pq): pass in suppressAnalytics
-        startServer(sdk, false);
+        AnalyticsConfiguration analyticsConfig = Analytics.getConfiguration(sdk, myProject);
+        startServer(sdk, analyticsConfig.getSuppressAnalytics());
 
         if (myServer != null) {
           myRootsHandler.onServerStarted();


### PR DESCRIPTION
Enables analytics gathering.

(Note that analytics won't be reported until https://github.com/dart-lang/tools/pull/2282 is revved into the SDK DEPS.)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
