### PR TITLE
Prevent UI freezes during refactoring operations by using `awaitWithCheckCanceled`.

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ### Fixed
 
-- Fixed resolution for Dart dot shorthands (e.g. `.new`, `.named`).
+- Fixed resolution for Dart dot shorthands (e.g. `.new`, `.named`). (#89)
+- UI freeze during refactoring operations (e.g. Move File) when Analysis Server is slow (#122)
+
 
 ## 500.0.0
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoring.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoring.java
@@ -183,13 +183,7 @@ public abstract class ServerRefactoring {
     if (!success) return;
     // wait for completion
     if (indicator != null) {
-      while (true) {
-        ProgressIndicatorUtils.checkCancelledEvenWithPCEDisabled(indicator);
-        boolean done = Uninterruptibles.awaitUninterruptibly(latch, 10, TimeUnit.MILLISECONDS);
-        if (done) {
-          return;
-        }
-      }
+      ProgressIndicatorUtils.awaitWithCheckCanceled(latch);
     }
     else {
       // Wait a very short time, just in case if it can be done fast,


### PR DESCRIPTION
This should resolve https://github.com/flutter/dart-intellij-third-party/issues/122