### PR TITLE
Update `stagehand` mentions to `dart create`

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreate.java
@@ -22,20 +22,24 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-// TODO: Rename this and related classes away from "stagehand",
-//   as templates are now retrieved and bootstrapped with `dart create`.
-public class Stagehand {
+/**
+ * Handles running `dart create` to generate new Dart projects from templates.
+ */
+public class DartCreate {
 
-  public static class StagehandDescriptor {
+  /**
+   * Describes a `dart create` template.
+   */
+  public static class DartCreateTemplate {
     public final @NotNull @NonNls String myId;
     public final @NotNull @NlsSafe String myLabel;
     public final @NotNull @NlsSafe String myDescription;
     public final @Nullable @NonNls String myEntrypoint;
 
-    public StagehandDescriptor(@NotNull @NonNls String id,
-                               @NotNull @NlsSafe String label,
-                               @NotNull @NlsSafe String description,
-                               @Nullable @NonNls String entrypoint) {
+    public DartCreateTemplate(@NotNull @NonNls String id,
+                              @NotNull @NlsSafe String label,
+                              @NotNull @NlsSafe String description,
+                              @Nullable @NonNls String entrypoint) {
       myId = id;
       myLabel = label;
       myDescription = description;
@@ -48,8 +52,8 @@ public class Stagehand {
     }
   }
 
-  private static final Logger LOG = PluginLogger.INSTANCE.createLogger(Stagehand.class);
-  private static final List<StagehandDescriptor> EMPTY = new ArrayList<>();
+  private static final Logger LOG = PluginLogger.INSTANCE.createLogger(DartCreate.class);
+  private static final List<DartCreateTemplate> EMPTY = new ArrayList<>();
 
   private static ProcessOutput runDartCreate(@NotNull String sdkRoot,
                                              @Nullable String workingDirectory,
@@ -76,7 +80,7 @@ public class Stagehand {
     }
   }
 
-  public List<StagehandDescriptor> getAvailableTemplates(final @NotNull String sdkRoot) {
+  public List<DartCreateTemplate> getAvailableTemplates(final @NotNull String sdkRoot) {
     try {
       ProcessOutput output = runDartCreate(sdkRoot, null, 10, "--list-templates");
 
@@ -88,11 +92,11 @@ public class Stagehand {
 
       // [{"name":"consoleapp", "label":"Console App", "description":"A minimal command-line application."}, {"name": ..., }]
       final JsonArray templatesArray = JsonParser.parseString(output.getStdout()).getAsJsonArray();
-      final List<StagehandDescriptor> result = new ArrayList<>();
+      final List<DartCreateTemplate> result = new ArrayList<>();
       for (final JsonElement templateElement : templatesArray) {
         final JsonObject templateObject = templateElement.getAsJsonObject();
 
-        result.add(new StagehandDescriptor(
+        result.add(new DartCreateTemplate(
             templateObject.get("name").getAsString(),
             templateObject.get("label").getAsString(),
             templateObject.get("description").getAsString(),

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreateProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreateProjectTemplate.java
@@ -19,13 +19,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-class StagehandTemplate extends DartProjectTemplate {
-  private final @NotNull Stagehand myStagehand;
-  private final @NotNull Stagehand.StagehandDescriptor myTemplate;
+/**
+ * A project template backed by `dart create`.
+ */
+class DartCreateProjectTemplate extends DartProjectTemplate {
+  private final @NotNull DartCreate myDartCreate;
+  private final @NotNull DartCreate.DartCreateTemplate myTemplate;
 
-  StagehandTemplate(final @NotNull Stagehand stagehand, final @NotNull Stagehand.StagehandDescriptor template) {
+  DartCreateProjectTemplate(final @NotNull DartCreate dartCreate, final @NotNull DartCreate.DartCreateTemplate template) {
     super(template.myLabel, template.myDescription);
-    myStagehand = stagehand;
+    myDartCreate = dartCreate;
     myTemplate = template;
   }
 
@@ -34,7 +37,7 @@ class StagehandTemplate extends DartProjectTemplate {
                                                  final @NotNull Module module,
                                                  final @NotNull VirtualFile baseDir) throws IOException {
     try {
-      myStagehand.generateInto(sdkRoot, baseDir, myTemplate.myId);
+      myDartCreate.generateInto(sdkRoot, baseDir, myTemplate.myId);
     }
     catch (ExecutionException e) {
       throw new IOException(e);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
@@ -18,7 +18,7 @@ import com.jetbrains.lang.dart.ide.runner.server.webdev.DartWebdevConfigurationT
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfigurationType;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunnerParameters;
-import com.jetbrains.lang.dart.projectWizard.Stagehand.StagehandDescriptor;
+import com.jetbrains.lang.dart.projectWizard.DartCreate.DartCreateTemplate;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +30,7 @@ import java.util.List;
 
 public abstract class DartProjectTemplate {
 
-  private static final Stagehand STAGEHAND = new Stagehand();
+  private static final DartCreate DART_CREATE = new DartCreate();
   private static List<DartProjectTemplate> ourDartCreateTemplateCache;
 
   private static final Logger LOG = PluginLogger.INSTANCE.createLogger(DartProjectTemplate.class);
@@ -67,7 +67,7 @@ public abstract class DartProjectTemplate {
 
     final List<DartProjectTemplate> templates = new ArrayList<>();
     try {
-      templates.addAll(getStagehandTemplates(sdkRoot));
+      templates.addAll(getDartCreateTemplates(sdkRoot));
     }
     finally {
       if (templates.isEmpty()) {
@@ -79,16 +79,16 @@ public abstract class DartProjectTemplate {
     }
   }
 
-  private static @NotNull List<DartProjectTemplate> getStagehandTemplates(@NotNull String sdkRoot) {
+  private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull String sdkRoot) {
     if (ourDartCreateTemplateCache != null) {
       return ourDartCreateTemplateCache;
     }
 
-    final List<StagehandDescriptor> templates = STAGEHAND.getAvailableTemplates(sdkRoot);
+    final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdkRoot);
 
     ourDartCreateTemplateCache = new ArrayList<>();
-    for (StagehandDescriptor template : templates) {
-      ourDartCreateTemplateCache.add(new StagehandTemplate(STAGEHAND, template));
+    for (DartCreateTemplate template : templates) {
+      ourDartCreateTemplateCache.add(new DartCreateProjectTemplate(DART_CREATE, template));
     }
     return ourDartCreateTemplateCache;
   }


### PR DESCRIPTION
Directly updates `stagehand` references to instead reference `dart create` without otherwise modifying the code, resolving a post-migration TODO from https://github.com/flutter/dart-intellij-third-party/pull/91.