### PR TITLE
Fix a unit test in DartDocumentationProvider

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
@@ -163,7 +163,12 @@ public final class DartDocumentationProvider implements DocumentationProvider {
       final String dartUrl = urlResolver.getDartUrlForFile(libFile);
       // "dart:html" -> "dart-html"
       if (dartUrl.startsWith(DartUrlResolver.DART_PREFIX)) {
-        return "dart-" + dartUrl.substring(DartUrlResolver.DART_PREFIX.length());
+        String url = dartUrl.substring(DartUrlResolver.DART_PREFIX.length());
+        int slashIndex = url.indexOf('/');
+        if (slashIndex > 0) {
+          url = url.substring(0, slashIndex);
+        }
+        return "dart-" + url;
       }
     }
 


### PR DESCRIPTION
This is expected to resovle the flaky presubmit failures.
