### PR TITLE
Fix Internal API usage in DartTestRerunner

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunner.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRerunner.java
@@ -9,7 +9,7 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ProgramRunner;
 import com.intellij.execution.testframework.AbstractTestProxy;
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
-import com.intellij.execution.testframework.sm.runner.states.TestStateInfo.Magnitude;
+
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
@@ -49,11 +49,10 @@ public class DartTestRerunner implements RunProfileState {
     for (AbstractTestProxy test : failedTests) {
       assert test instanceof SMTestProxy : test.getClass().getName();
 
-      final Magnitude magnitude = ((SMTestProxy)test).getMagnitudeInfo();
       if (test.getParent() != null &&
           !((SMTestProxy)test).isSuite() &&
           test.isLeaf() &&
-          (magnitude == Magnitude.FAILED_INDEX || magnitude == Magnitude.ERROR_INDEX || magnitude == Magnitude.TERMINATED_INDEX)) {
+          (test.isDefect() || ((SMTestProxy)test).isInterrupted())) {
         if (!buf.isEmpty()) buf.append('|');
         buf.append(buildFullTestName(test));
       }


### PR DESCRIPTION
Replaced internal TestStateInfo.Magnitude usage with public AbstractTestProxy methods (isDefect, isInterrupted). This resolves 4 internal API usage warnings in the plugin verification report.
