### PR TITLE
Fix Internal API usage of ApplicationEx

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartSortMembersAction.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartSortMembersAction.java
@@ -3,7 +3,7 @@ package com.jetbrains.lang.dart.ide.actions;
 
 import com.intellij.CommonBundle;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ex.ApplicationManagerEx;
+
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.jetbrains.lang.dart.logging.PluginLogger;
@@ -115,7 +115,7 @@ public class DartSortMembersAction extends AbstractDartFileProcessingAction {
 
     DartAnalysisServerService.getInstance(project).updateFilesContent();
 
-    final boolean ok = ApplicationManagerEx.getApplicationEx()
+    final boolean ok = ProgressManager.getInstance()
       .runProcessWithProgressSynchronously(runnable, DartBundle.message("action.Dart.DartSortMembers.progress.title"), true, project);
 
     if (ok) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartStyleAction.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartStyleAction.java
@@ -4,7 +4,7 @@ package com.jetbrains.lang.dart.ide.actions;
 import com.intellij.CommonBundle;
 import com.intellij.application.options.CodeStyle;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ex.ApplicationManagerEx;
+
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
@@ -198,7 +198,7 @@ public class DartStyleAction extends AbstractDartFileProcessingAction {
 
     DartAnalysisServerService.getInstance(project).updateFilesContent();
 
-    final boolean ok = ApplicationManagerEx.getApplicationEx()
+    final boolean ok = ProgressManager.getInstance()
       .runProcessWithProgressSynchronously(runnable, DartBundle.message("action.Dart.DartStyle.progress.title"), true, project);
 
     if (ok) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartConfigurable.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartConfigurable.java
@@ -7,7 +7,7 @@ import com.intellij.ide.actions.ShowSettingsUtilImpl;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.application.ex.ApplicationManagerEx;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.module.ModuleType;
@@ -134,9 +134,8 @@ public final class DartConfigurable implements SearchableConfigurable, NoScroll 
 
     myCheckSdkUpdateButton.addActionListener(e -> {
       final Runnable runnable = this::checkSdkUpdate;
-      ApplicationManagerEx.getApplicationEx()
-        .runProcessWithProgressSynchronously(runnable, DartBundle.message("checking.dart.sdk.update"), true, true, myProject,
-                                             myMainPanel, null);
+      ProgressManager.getInstance()
+        .runProcessWithProgressSynchronously(runnable, DartBundle.message("checking.dart.sdk.update"), true, myProject, myMainPanel);
     });
   }
 


### PR DESCRIPTION
Replaced internal ApplicationManagerEx.getApplicationEx().runProcessWithProgressSynchronously with public ProgressManager.getInstance().runProcessWithProgressSynchronously. This resolves 3 internal API usage warnings in the plugin verification report.

See https://github.com/JetBrains/intellij-community/blob/6d55b3dd5c35633312d68cc6050b66e0bb297b7e/platform/core-impl/src/com/intellij/openapi/application/ex/ApplicationEx.java#L133 to give confidence that this is the expectation from the IDEA platform.
