### PR TITLE
Fix Experimental API usage of isRename

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
@@ -69,7 +69,9 @@ public final class DartFileListener implements AsyncFileListener {
       if (event.getFileSystem() != LocalFileSystem.getInstance() && !ApplicationManager.getApplication().isUnitTestMode()) continue;
 
       if (event instanceof VFilePropertyChangeEvent) {
-        if (((VFilePropertyChangeEvent)event).isRename()) {
+        // 'isRename()' is an experimental API. Checking the property name directly is
+        // functionally equivalent.
+        if (VirtualFile.PROP_NAME.equals(((VFilePropertyChangeEvent)event).getPropertyName())) {
           if (PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getOldValue()) ||
               PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getNewValue())) {
             packagesFileEvents.add(event);


### PR DESCRIPTION
Replaced experimental VFilePropertyChangeEvent.isRename() with standard property name check. Added comment explaining that the replacement is functionally equivalent. This resolves 1 experimental API usage warning in the plugin verification report.

From the commit: "'isRename()' is an experimental API. Checking the property name directly is functionally equivalent." By calling it in this manner, the verification algorithm from IntelliJ is closer to being able to have a failing assertion on internal API usages.