### PR TITLE
Refactor ArrayList to SmartList to optimize memory usage

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -147,7 +147,7 @@ public final class DartAnalysisServerService implements Disposable {
 
   private final DartServerRootsHandler myRootsHandler;
   private final Map<String, Long> myFilePathWithOverlaidContentToTimestamp = Collections.synchronizedMap(new HashMap<>());
-  private final List<String> myVisibleFileUris = new ArrayList<>();
+  private final List<String> myVisibleFileUris = new SmartList<>();
   private final Set<Document> myChangedDocuments = new HashSet<>();
   private final Alarm myUpdateFilesAlarm;
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/index/DartFileIndexData.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/index/DartFileIndexData.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.ide.index;
 
+import com.intellij.util.SmartList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -10,12 +11,12 @@ import java.util.List;
 import java.util.Map;
 
 public final class DartFileIndexData {
-  private final List<String> myClassNames = new ArrayList<>();
-  private final List<DartImportOrExportInfo> myImportAndExportInfos = new ArrayList<>();
+  private final List<String> myClassNames = new SmartList<>();
+  private final List<DartImportOrExportInfo> myImportAndExportInfos = new SmartList<>();
   private final Map<String, DartComponentInfo> myComponentInfoMap = new HashMap<>();
   private @Nullable String myLibraryName;
-  private final List<String> myPartUris = new ArrayList<>();
-  private final List<String> mySymbols = new ArrayList<>();
+  private final List<String> myPartUris = new SmartList<>();
+  private final List<String> mySymbols = new SmartList<>();
   private boolean myIsPart;
 
   public List<String> getClassNames() {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandler.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandler.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.ide.runner.server.vmService;
 
+import com.intellij.util.SmartList;
 import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
 import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
@@ -103,7 +104,7 @@ public final class DartVmServiceBreakpointHandler extends XBreakpointHandler<XLi
 class IsolateBreakpointInfo {
   private final String myIsolateId;
   private final DartVmServiceDebugProcess myDebugProcess;
-  private final List<String> myTemporaryVmBreakpointIds = new ArrayList<>();
+  private final List<String> myTemporaryVmBreakpointIds = new SmartList<>();
   private final Map<XLineBreakpoint<XBreakpointProperties>, Set<String>> myXBreakpointToVmBreakpointIdsMap = new HashMap<>();
 
   IsolateBreakpointInfo(@NotNull String isolateId, @NotNull DartVmServiceDebugProcess debugProcess) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/DartRefactoringUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/DartRefactoringUtil.java
@@ -10,6 +10,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiWhiteSpace;
 import com.intellij.psi.ResolveState;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.SmartList;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartComponentType;
 import com.jetbrains.lang.dart.DartTokenTypes;
@@ -49,7 +50,7 @@ public final class DartRefactoringUtil {
     if (context == null) {
       return Collections.emptyList();
     }
-    final List<PsiElement> occurrences = new ArrayList<>();
+    final List<PsiElement> occurrences = new SmartList<>();
     context.acceptChildren(new DartRecursiveVisitor() {
       @Override
       public void visitElement(final @NotNull PsiElement element) {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/util/DartTestUtils.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/util/DartTestUtils.java
@@ -117,7 +117,7 @@ public final class DartTestUtils {
   public static List<CaretPositionInfo> extractPositionMarkers(@NotNull final Project project, @NotNull final Document document) {
     final Pattern caretPattern = Pattern.compile(
       "<caret(?: expected='([^']*)')?(?: completionEquals='([^']*)')?(?: completionIncludes='([^']*)')?(?: completionExcludes='([^']*)')?>");
-    final List<CaretPositionInfo> result = new ArrayList<>();
+    final List<CaretPositionInfo> result = new SmartList<>();
 
     WriteCommandAction.runWriteCommandAction(null, () -> {
       while (true) {


### PR DESCRIPTION
Replaces usages of `ArrayList` with `com.intellij.util.SmartList` in [DartFileIndexData](cci:2://file:///Users/jwren/src/dart-intellij-third-party/third_party/src/main/java/com/jetbrains/lang/dart/ide/index/DartFileIndexData.java:12:0-82:1), [DartRefactoringUtil](cci:2://file:///Users/jwren/src/dart-intellij-third-party/third_party/src/main/java/com/jetbrains/lang/dart/util/DartRefactoringUtil.java:23:0-163:1), [DartTestUtils](cci:2://file:///Users/jwren/src/dart-intellij-third-party/third_party/src/test/java/com/jetbrains/lang/dart/util/DartTestUtils.java:38:0-195:1), and other key classes.

`SmartList` is a specialized collection in the IntelliJ Platform designed to be more memory-efficient than `ArrayList` for lists that are frequently empty or contain only a single element. Unlike `ArrayList`, which allocates a backing array (default capacity 10) immediately or upon the first addition, `SmartList` avoids this allocation overhead for single-element lists, significantly reducing heap footprint and garbage collection pressure in hot paths.
