### PR TITLE
[test] skip `DartHighlightingTest.testSpelling`

### DIFF
--- a/third_party/src/test/java/com/jetbrains/lang/dart/highlighting/DartHighlightingTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/highlighting/DartHighlightingTest.java
@@ -17,6 +17,7 @@ public class DartHighlightingTest extends DartCodeInsightFixtureTestCase {
     return "/highlighting";
   }
 
+  // See: https://github.com/flutter/dart-intellij-third-party/issues/212
   public void skipped_testSpelling() {
     // [01/14/2026]: This is failing reliably and the path forward seems to be to prefer
     //  com.intellij.grazie.spellcheck.GrazieSpellCheckingInspection


### PR DESCRIPTION
Disables the spell check test as the old inspection is no longer registered.

Stack trace of a local run:

```
Unregistered inspections requested: [com.intellij.spellchecker.inspections.SpellCheckingInspection]
java.lang.RuntimeException: Unregistered inspections requested: [com.intellij.spellchecker.inspections.SpellCheckingInspection]
    at com.intellij.testFramework.InspectionTestUtil.instantiateTools(InspectionTestUtil.java:201)
    at com.intellij.testFramework.InspectionTestUtil.instantiateTools(InspectionTestUtil.java:184)
    at com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl.enableInspections(CodeInsightTestFixtureImpl.java:563)
    at com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl.enableInspections(CodeInsightTestFixtureImpl.java:558)
    at com.jetbrains.lang.dart.highlighting.DartHighlightingTest.testSpelling(DartHighlightingTest.java:43)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at junit.framework.TestCase.runTest(TestCase.java:177)
```


If we want to add this back down the road, we can use ` com.intellij.grazie.spellcheck.GrazieSpellCheckingInspection` instead but will have to get it on the test build path.

---

Also: removes some dead code.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
