### PR TITLE
fix: Update new project dialog when Dart SDK changes

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
@@ -32,6 +32,7 @@ public abstract class DartProjectTemplate {
 
   private static final DartCreate DART_CREATE = new DartCreate();
   private static List<DartProjectTemplate> ourDartCreateTemplateCache;
+  private static String ourDartCreateTemplateCacheSdkPath; //used to expire the above cache if the sdk is changed, an alternative would be to use the same cache method as com.jetbrains.lang.dart.sdk.DartSdkUtil.getSdkVersion
 
   private static final Logger LOG = PluginLogger.INSTANCE.createLogger(DartProjectTemplate.class);
 
@@ -79,13 +80,14 @@ public abstract class DartProjectTemplate {
   }
 
   private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull String sdkRoot) {
-    if (ourDartCreateTemplateCache != null) {
+    if (ourDartCreateTemplateCache != null && sdkRoot.equals(ourDartCreateTemplateCacheSdkPath)) {
       return ourDartCreateTemplateCache;
     }
 
     final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdkRoot);
 
     ourDartCreateTemplateCache = new ArrayList<>();
+    ourDartCreateTemplateCacheSdkPath = sdkRoot;
     for (DartCreateTemplate template : templates) {
       ourDartCreateTemplateCache.add(new DartCreateProjectTemplate(DART_CREATE, template));
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
@@ -51,7 +51,8 @@ public final class DartSdkUtil {
 
     final String version = FileUtil.loadFileOrNull(versionFile);
     if (version != null) {
-      return ourVersions.put(versionPair, version);
+      ourVersions.put(versionPair, version);
+      return version;
     }
 
     return null;
@@ -81,7 +82,8 @@ public final class DartSdkUtil {
     }
 
     final String sdkHomePath = getItemFromCombo(dartSdkPathComponent.getComboBox());
-    versionLabel.setText(sdkHomePath.isEmpty() ? "" : getSdkVersion(sdkHomePath));
+    final String sdkVersion = getSdkVersion(sdkHomePath);
+    versionLabel.setText(sdkVersion == null ? "" : sdkVersion);
 
     final TextComponentAccessor<JComboBox> textComponentAccessor = new TextComponentAccessor<>() {
       @Override
@@ -112,7 +114,10 @@ public final class DartSdkUtil {
       @Override
       protected void textChanged(final @NotNull DocumentEvent e) {
         final String sdkHomePath = getItemFromCombo(dartSdkPathComponent.getComboBox());
-        versionLabel.setText(sdkHomePath.isEmpty() ? "" : getSdkVersion(sdkHomePath));
+        if(e.getType() == DocumentEvent.EventType.INSERT){
+          final String sdkVersion = getSdkVersion(sdkHomePath);
+          versionLabel.setText(sdkVersion == null ? "" : sdkVersion);
+        }
       }
     });
   }


### PR DESCRIPTION
This PR provides fixes for
- #213 
- #214 

The changes predonmently change the way that the "New Project" dialog UI is updated when the Dart SDK combobox is modified.

The current issues are documented in the linked issues.

Manual Testing included
- Initially setting the SDK directory when it had never been set before
- Setting the SDK directory to a different valid directory version
- Setting the SDK directory to a different invalid directory
- Setting the SDK directory to a different valid directory from and invalid directory
- Creating a project under each of the above scenarios and ensuring the project file structure is created correctly
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
