### PR TITLE
Update the version of the plugin to 502.0 in anticipation of releasing the Dart IJ plugin.

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -1,18 +1,21 @@
-## 501.0.0
+## 502.0.0
 
 ### Added
 
 ### Changed
 
+- Update stagehand mentions to dart create (#171)
+
 ### Removed
 
 - Dropped support for Dart SDK versions older than 2.12.
+- Unsupported Dart in HTML logic (#173)
+- Outdated web template (#172)
 
 ### Fixed
 
 - Fixed resolution for Dart dot shorthands (e.g. `.new`, `.named`). (#89)
 - UI freeze during refactoring operations (e.g. Move File) when Analysis Server is slow (#122)
-
 
 ## 500.0.0
 

--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -7,7 +7,8 @@ pluginName = Dart
 pluginId = Dart
 
 # SemVer format -> https://semver.org
-pluginVersion = 501.0.0
+# TODO(jwren) update this to grab the version from the changelog like we do in the Flutter IJ plugin
+pluginVersion = 502.0.0
 
 # TODO(https://github.com/flutter/dart-intellij-third-party/issues/23) Add a changelog
 # Not currently used in the build.gradle.kts file:


### PR DESCRIPTION
This squashes the version `501.0` (a dev release for Dot Shorthands fix ahead of the holidays), into version `502.0`.

Changelog updated with changes from @parlough (thank you for the contributions!)
