### PR TITLE
[build] reduce verifier matrix; cleanup ubuntu disk space

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -106,7 +106,7 @@ jobs:
     needs: build-plugin
     strategy:
       matrix:
-        # TODO(pq): temporarily reducing to address IO exceptions (https://github.com/flutter/dart-intellij-third-party/issues/220)
+        # TODO(pq): temporarily reduced to address IO exceptions (https://github.com/flutter/dart-intellij-third-party/issues/220)
         # os: [ ubuntu-latest, macos-latest, windows-latest ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }} # Use the OS from the matrix
@@ -114,14 +114,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4 # Use the latest stable version of actions/checkout
 
-      - name: Free up disk space (ubuntu only)
+      - name: Free up disk space (on ubuntu only)
         if: ${{ matrix.os == 'ubuntu-latest' }}
+        # Inspired by the https://github.com/marketplace/actions/free-disk-space-ubuntu action
+        # See: https://github.com/flutter/dart-intellij-third-party/issues/220
         run: |
+          echo "Freeing disk space...\n"
+          echo "Before:\n"
+          df -h
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
+          echo "After:\n"
+          df -h
 
       - name: Set up JDK
         uses: actions/setup-java@v4 # https://github.com/marketplace/actions/setup-java-jdk


### PR DESCRIPTION
In lieu of a more complete solution, some experiments to address resource exhaustion exceptions.

1. reduces os matrix
2. cleans up ubuntu disk space[^1].

It's possible that 2 will remove the need for 1 but I'd like to give this a few more runs to see.

(First run is reporting a cleanup of 783.2MB; less than I thought but hopefully enough? 🤞)

See: https://github.com/flutter/dart-intellij-third-party/issues/220

(**Caveat:** I don't love this and would like to keep the corresponding issue open for a bit but it does seem to get us somewhere and it's not an uncommon solution to what appears to be a pretty common problem.)


[^1]: It appears that ubuntu in particular accumulates a lot of disk space. It's common enough that there's an action to clean it up (https://github.com/marketplace/actions/free-disk-space-ubuntu). Unfortunately, our org disallows it so we can just use it as a source of inspiration and inline some `rm`s.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
