### PR TITLE
[fix] remove stale helpTopic references

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/formatter/settings/DartLanguageCodeStyleSettingsProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/formatter/settings/DartLanguageCodeStyleSettingsProvider.java
@@ -49,11 +49,6 @@ public final class DartLanguageCodeStyleSettingsProvider extends LanguageCodeSty
       protected @NotNull CodeStyleAbstractPanel createPanel(@NotNull CodeStyleSettings settings) {
         return new DartCodeStylePanel(getCurrentSettings(), settings);
       }
-
-      @Override
-      public String getHelpTopic() {
-        return "reference.settingsdialog.codestyle.dart";
-      }
     };
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartExceptionBreakpointType.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartExceptionBreakpointType.java
@@ -39,11 +39,6 @@ public final class DartExceptionBreakpointType
   }
 
   @Override
-  public String getBreakpointsDialogHelpTopic() {
-    return "reference.dialogs.breakpoints";
-  }
-
-  @Override
   public String getDisplayText(XBreakpoint<DartExceptionBreakpointProperties> breakpoint) {
     return DartBundle.message("break.on.exceptions");
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunConfigurationType.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunConfigurationType.java
@@ -47,9 +47,4 @@ public final class DartCommandLineRunConfigurationType extends ConfigurationType
       }
     });
   }
-
-  @Override
-  public String getHelpTopic() {
-    return "reference.dialogs.rundebug.DartCommandLineRunConfigurationType";
-  }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartRemoteDebugConfigurationType.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartRemoteDebugConfigurationType.java
@@ -42,9 +42,4 @@ public final class DartRemoteDebugConfigurationType extends ConfigurationTypeBas
       }
     });
   }
-
-  @Override
-  public String getHelpTopic() {
-    return "reference.dialogs.rundebug.DartRemoteDebugConfigurationType";
-  }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfigurationType.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfigurationType.java
@@ -44,9 +44,4 @@ public final class DartWebdevConfigurationType extends ConfigurationTypeBase imp
       }
     });
   }
-
-  @Override
-  public String getHelpTopic() {
-    return "reference.dialogs.rundebug.DartWebdevConfigurationType";
-  }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunConfigurationType.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunConfigurationType.java
@@ -22,11 +22,6 @@ public final class DartTestRunConfigurationType extends ConfigurationTypeBase im
     addFactory(new DartTestConfigurationFactory(this));
   }
 
-  @Override
-  public String getHelpTopic() {
-    return "reference.dialogs.rundebug.DartTestRunConfigurationType";
-  }
-
   public static DartTestRunConfigurationType getInstance() {
     return ConfigurationTypeUtil.findConfigurationType(DartTestRunConfigurationType.class);
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartConfigurable.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartConfigurable.java
@@ -206,11 +206,6 @@ public final class DartConfigurable implements SearchableConfigurable, NoScroll 
   }
 
   @Override
-  public @Nullable String getHelpTopic() {
-    return "settings.dart.settings";
-  }
-
-  @Override
   public @Nullable JComponent createComponent() {
     return myMainPanel;
   }


### PR DESCRIPTION
Fixes: https://github.com/flutter/dart-intellij-third-party/issues/107

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
