### PR TITLE
[build] make DAS test runs informational and kill long runs

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   # Job 1: Build Plugin
   build-plugin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-large
     steps:
       - name: Checkout code
         uses: actions/checkout@v4 # Use the latest stable version of actions/checkout
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         # TODO(https://github.com/flutter/dart-intellij-third-party/pull/33) Fix and enable execution on Windows
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-large, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }} # Use the OS from the matrix
     steps:
       - name: Checkout code
@@ -109,15 +109,15 @@ jobs:
     strategy:
       matrix:
         # TODO(pq): temporarily reduced to address IO exceptions (https://github.com/flutter/dart-intellij-third-party/issues/220)
-        # os: [ ubuntu-latest, macos-latest, windows-latest ]
-        os: [ ubuntu-latest ]
+        # os: [ ubuntu-large, macos-latest, windows-latest ]
+        os: [ ubuntu-large ]
     runs-on: ${{ matrix.os }} # Use the OS from the matrix
     steps:
       - name: Checkout code
         uses: actions/checkout@v4 # Use the latest stable version of actions/checkout
 
       - name: Free up disk space (on ubuntu only)
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'uubuntu-large' }}
         # Inspired by the https://github.com/marketplace/actions/free-disk-space-ubuntu action
         # See: https://github.com/flutter/dart-intellij-third-party/issues/220
         run: |


### PR DESCRIPTION
An experiment in making flaky DAS test runs informational and not build breaking.

With this change, DAS tests will continue to run but never for more than 20 minutes and failures won't "break" the build.

The idea is that these runs be treated as more informational since there's such a high-level of flakiness.



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
