### PR TITLE
Wsl support

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -103,7 +103,40 @@ jobs:
          path: |
            **/build/reports/
            **/build/test-results/
-  # Job 4: Verify Plugin
+  # Job 4: WSL Dart SDK Tests
+  wsl-dart-tests:
+    needs: build-plugin
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Install WSL with Ubuntu
+        run: wsl --install -d Ubuntu --no-launch
+
+      - name: Install Dart SDK in WSL
+        run: |
+          wsl -d Ubuntu -- sudo apt-get update
+          wsl -d Ubuntu -- sudo apt-get install -y wget gnupg2
+          wsl -d Ubuntu -- sh -c "wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg"
+          wsl -d Ubuntu -- sh -c 'echo "deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/dart-archive/channels/stable/release/latest/linux_packages/debian stable main" | sudo tee /etc/apt/sources.list.d/dart_stable.list > /dev/null'
+          wsl -d Ubuntu -- sudo apt-get update
+          wsl -d Ubuntu -- sudo apt-get install -y dart
+
+      - name: Run WSL Tests
+        run: ./gradlew :test --tests "com.jetbrains.lang.dart.sdk.DartSdkWslTest"
+        working-directory: third_party
+        env:
+          WSL_DART_SDK: "\\\\wsl$\\Ubuntu\\usr\\lib\\dart"
+
+  # Job 5: Verify Plugin
   verify-plugin:
     needs: build-plugin
     strategy:

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -131,6 +131,20 @@ tasks {
         } else {
             logger.error("DART_HOME environment variable is not set. Dart Analysis Server tests will fail.")
         }
+
+        // WSL Dart SDK for WSL-specific tests
+        val wslDartSdkPath = System.getenv("WSL_DART_SDK")
+        if (wslDartSdkPath != null) {
+            val versionFile = file("${wslDartSdkPath}/version")
+            if (versionFile.exists() && versionFile.isFile) {
+                jvmArgs("-Dwsl.dart.sdk=${wslDartSdkPath}")
+            } else {
+                logger.error("This directory, ${dartSdkPath}, doesn't appear to be Dart SDK path, " +
+                        "no version file found at ${versionFile.absolutePath}")
+            }
+        } else {
+            logger.error("WSL_DART_SDK environment variable is not set. WSL-specific DartSdk tests will be skipped.")
+        }
     }
 }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
@@ -138,7 +138,7 @@ public final class DartFileListener implements AsyncFileListener {
       Map<String, String> packagesMap = null;
       VirtualFile packagesFile = PackageConfigFileUtil.findPackageConfigJsonFile(pubspecFile.getParent());
       if (packagesFile != null) {
-        packagesMap = PackageConfigFileUtil.getPackagesMapFromPackageConfigJsonFile(packagesFile);
+        packagesMap = PackageConfigFileUtil.getPackagesMapFromPackageConfigJsonFile(project, packagesFile);
       }
 
       if (packagesMap != null) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
@@ -27,8 +27,8 @@ data class DartNotLocalFileInfo(private val project: Project, val fileUri: Strin
 
 
 fun getDartFileInfo(project: Project, filePathOrUri: String): DartFileInfo = when {
-  !filePathOrUri.contains("://") -> DartLocalFileInfo(FileUtil.toSystemIndependentName(filePathOrUri))
-  !filePathOrUri.startsWith("file://") -> DartNotLocalFileInfo(project, filePathOrUri)
+  !filePathOrUri.contains("://") -> DartLocalFileInfo(FileUtil.toSystemIndependentName(getIDEFileName(project, filePathOrUri)))
+  !filePathOrUri.startsWith("file://") -> DartNotLocalFileInfo(project, getIDEFileName(project, filePathOrUri))
   else -> try {
     var path = URI(filePathOrUri).path
     path = getIDEFileName(project, path)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.io.OSAgnosticPathUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.lang.dart.sdk.DartSdk
 import java.net.URI
 import java.net.URISyntaxException
 
@@ -30,9 +31,11 @@ fun getDartFileInfo(project: Project, filePathOrUri: String): DartFileInfo = whe
   !filePathOrUri.startsWith("file://") -> DartNotLocalFileInfo(project, filePathOrUri)
   else -> try {
     var path = URI(filePathOrUri).path
+    path = getIDEFileName(project, path)
     if (SystemInfo.isWindows && path.length >= 3 && path[0] == '/' && OSAgnosticPathUtil.startsWithWindowsDrive(path.substring(1))) {
       path = path.substring(1)
     }
+    path = FileUtil.toSystemIndependentName(path)
     DartLocalFileInfo(path)
   }
   catch (_: URISyntaxException) {
@@ -48,3 +51,13 @@ fun getDartFileInfo(project: Project, virtualFile: VirtualFile): DartFileInfo =
   virtualFile.getUserData(DART_NOT_LOCAL_FILE_URI_KEY)
     ?.let { DartNotLocalFileInfo(project, it) }
   ?: DartLocalFileInfo(virtualFile.path)
+
+fun getIDEFileName(project: Project, filePathOrUri: String): String {
+  val sdk = DartSdk.getDartSdk(project)
+  return sdk?.getIDEFilePath(filePathOrUri) ?: filePathOrUri
+}
+
+fun getIDEFileUri(project: Project, filePathOrUri: String): String {
+  val sdk = DartSdk.getDartSdk(project)
+  return sdk?.getLocalFileUri(filePathOrUri) ?: filePathOrUri
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
@@ -23,7 +23,6 @@ import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonConsumer
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonListener
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonRequestHandler
 import com.jetbrains.lang.dart.sdk.DartSdk
-import com.jetbrains.lang.dart.sdk.DartSdkUtil
 import de.roderick.weberknecht.WebSocket
 import de.roderick.weberknecht.WebSocketEventHandler
 import de.roderick.weberknecht.WebSocketException
@@ -124,7 +123,7 @@ class DTDProcess {
 
   fun start(sdk: DartSdk) {
     val commandLine = GeneralCommandLine().withWorkDirectory(sdk.homePath)
-    commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+    commandLine.exePath = if (sdk.isWsl) sdk.dartExePath else FileUtil.toSystemDependentName(sdk.dartExePath)
     commandLine.charset = StandardCharsets.UTF_8
     commandLine.addParameter("tooling-daemon")
     commandLine.addParameter("--machine")

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
@@ -21,12 +21,15 @@ import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.application.readAction
+import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.components.serviceAsync
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.progress.runBlockingCancellable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
@@ -137,7 +140,7 @@ abstract class DartPubActionBase : AnAction(), DumbAware {
       setupPubExePath(command, sdk)
       command.addParameters(*pubParameters)
 
-      doPerformPubAction(module, pubspecYamlFile, command, getTitle(pubspecYamlFile))
+      doPerformPubActionAsync(module, pubspecYamlFile, command, getTitle(pubspecYamlFile))
     }
   }
 
@@ -226,6 +229,17 @@ abstract class DartPubActionBase : AnAction(), DumbAware {
         return if (file != null) Pair(module, file) else null
       }
       return null
+    }
+
+    private fun doPerformPubActionAsync(
+      module: Module,
+      pubspecYamlFile: VirtualFile,
+      command: GeneralCommandLine,
+      actionTitle: @NlsContexts.NotificationTitle String,
+    ) {
+      ApplicationManager.getApplication().invokeLater {
+        doPerformPubAction(module, pubspecYamlFile, command, actionTitle)
+      };
     }
 
     private fun doPerformPubAction(

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
@@ -21,15 +21,12 @@ import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
-import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.application.readAction
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.components.serviceAsync
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.progress.runBlockingCancellable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
@@ -39,7 +36,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.NlsContexts
 import com.intellij.openapi.util.io.FileUtil
-import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowId

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.io.BaseOutputReader
 import com.jetbrains.lang.dart.logging.PluginLogger
 import com.jetbrains.lang.dart.sdk.DartSdk
-import com.jetbrains.lang.dart.sdk.DartSdkUtil
 import java.nio.charset.StandardCharsets
 
 @Service(Service.Level.PROJECT)
@@ -39,7 +38,7 @@ class DartDevToolsService(private val myProject: Project) : Disposable {
 
     val commandLine = GeneralCommandLine().withWorkDirectory(sdk.homePath)
     commandLine.charset = StandardCharsets.UTF_8
-    commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+    commandLine.exePath = if (sdk.isWsl) sdk.dartExePath else FileUtil.toSystemDependentName(sdk.dartExePath)
     commandLine.addParameter("devtools")
     commandLine.addParameter("--machine")
     dtdUri?.let { commandLine.addParameter("--dtd-uri=$it") }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -28,6 +28,7 @@ import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartAsyncMarker
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceEvaluator;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceStackFrame;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceValue;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.*;
 import org.dartlang.vm.service.element.*;
@@ -57,6 +58,8 @@ public final class VmServiceWrapper implements Disposable {
 
   private @Nullable StepOption myLatestStep;
 
+  private final DartSdk dartSdk;
+
   public VmServiceWrapper(@NotNull DartVmServiceDebugProcess debugProcess,
                           @NotNull VmService vmService,
                           @NotNull DartVmServiceListener vmServiceListener,
@@ -67,6 +70,7 @@ public final class VmServiceWrapper implements Disposable {
     myVmServiceListener = vmServiceListener;
     myIsolatesInfo = isolatesInfo;
     myBreakpointHandler = breakpointHandler;
+    dartSdk = DartSdk.getDartSdk(debugProcess.getSession().getProject());
     myRequestsScheduler = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
   }
 
@@ -452,10 +456,10 @@ public final class VmServiceWrapper implements Disposable {
     assert session != null;
     VirtualFile file = position.getFile().getCanonicalFile();
     assert file != null;
-    String url = file.getUrl();
+    String url = dartSdk.getFileUri(file);
     LOG.info("in getResolvedUri. url: " + url);
 
-    if (SystemInfo.isWindows) {
+    if (SystemInfo.isWindows && !dartSdk.isWsl()) {
       // Dart and the VM service use three /'s in file URIs: https://api.dart.dev/stable/2.16.1/dart-core/Uri-class.html.
       return url.replace("file://", "file:///");
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -28,6 +28,7 @@ import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartAsyncMarker
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceEvaluator;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceStackFrame;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceValue;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.*;
 import org.dartlang.vm.service.element.*;
@@ -55,6 +56,8 @@ public final class VmServiceWrapper implements Disposable {
 
   private @Nullable StepOption myLatestStep;
 
+  private final DartSdk dartSdk;
+
   public VmServiceWrapper(@NotNull DartVmServiceDebugProcess debugProcess,
                           @NotNull VmService vmService,
                           @NotNull DartVmServiceListener vmServiceListener,
@@ -65,6 +68,7 @@ public final class VmServiceWrapper implements Disposable {
     myVmServiceListener = vmServiceListener;
     myIsolatesInfo = isolatesInfo;
     myBreakpointHandler = breakpointHandler;
+    dartSdk = DartSdk.getDartSdk(debugProcess.getSession().getProject());
     myRequestsScheduler = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
   }
 
@@ -450,10 +454,10 @@ public final class VmServiceWrapper implements Disposable {
     assert session != null;
     VirtualFile file = position.getFile().getCanonicalFile();
     assert file != null;
-    String url = file.getUrl();
+    String url = dartSdk.getFileUri(file);
     LOG.info("in getResolvedUri. url: " + url);
 
-    if (SystemInfo.isWindows) {
+    if (SystemInfo.isWindows && !dartSdk.isWsl()) {
       // Dart and the VM service use three /'s in file URIs: https://api.dart.dev/stable/2.16.1/dart-core/Uri-class.html.
       return url.replace("file://", "file:///");
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
@@ -35,7 +35,6 @@ import com.jetbrains.lang.dart.ide.runner.base.DartRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunningState;
 import com.jetbrains.lang.dart.ide.runner.util.DartTestLocationProvider;
 import com.jetbrains.lang.dart.sdk.DartSdk;
-import com.jetbrains.lang.dart.sdk.DartSdkUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -124,7 +123,8 @@ public class DartTestRunningState extends DartCommandLineRunningState {
         builder.append(" ").append(testRunnerOptions);
       }
 
-      final String filePath = params.getFilePath();
+      String filePath = params.getFilePath();
+      filePath = sdk.getLocalFileUri(filePath);
       if (filePath != null && filePath.contains(" ")) {
         builder.append(" \"").append(filePath).append('\"');
       }
@@ -156,11 +156,15 @@ public class DartTestRunningState extends DartCommandLineRunningState {
 
   @Override
   protected void setupExePath(@NotNull GeneralCommandLine commandLine, @NotNull DartSdk sdk) {
-    commandLine.setExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk)));
+    if(sdk.isWsl()){
+      commandLine.setExePath(sdk.getDartExePath());
+    }else{
+      commandLine.setExePath(FileUtil.toSystemDependentName(sdk.getDartExePath()));
+    }
   }
 
   @Override
-  protected void appendParamsAfterVmOptionsBeforeArgs(@NotNull GeneralCommandLine commandLine) {
+  protected void appendParamsAfterVmOptionsBeforeArgs(@NotNull GeneralCommandLine commandLine, @NotNull DartSdk sdk) {
     // nothing needed
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -33,7 +33,6 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.ide.devtools.DartDevToolsService
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil
-import com.jetbrains.lang.dart.sdk.DartSdkUtil
 import de.roderick.weberknecht.WebSocket
 import de.roderick.weberknecht.WebSocketEventHandler
 import de.roderick.weberknecht.WebSocketException
@@ -84,7 +83,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
     activeLocationChangeEventSupported = DartAnalysisServerService.isDartSdkVersionSufficientForWorkspaceApplyEdits(sdk.version)
 
     val commandLine = GeneralCommandLine().withWorkDirectory(sdk.homePath)
-    commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+    commandLine.exePath = if (sdk.isWsl) sdk.dartExePath else FileUtil.toSystemDependentName(sdk.dartExePath)
     commandLine.charset = StandardCharsets.UTF_8
     commandLine.addParameter("tooling-daemon")
     commandLine.addParameter("--machine")

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/CmdLineAppTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/CmdLineAppTemplate.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,7 +21,7 @@ class CmdLineAppTemplate extends DartProjectTemplate {
   }
 
   @Override
-  public Collection<VirtualFile> generateProject(final @NotNull String sdkRoot,
+  public Collection<VirtualFile> generateProject(final @NotNull DartSdk sdk,
                                                  final @NotNull Module module,
                                                  final @NotNull VirtualFile baseDir) throws IOException {
     final VirtualFile pubspecFile = baseDir.createChildData(this, PubspecYamlUtil.PUBSPEC_YAML);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreateProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreateProjectTemplate.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -33,11 +34,11 @@ class DartCreateProjectTemplate extends DartProjectTemplate {
   }
 
   @Override
-  public Collection<VirtualFile> generateProject(final @NotNull String sdkRoot,
+  public Collection<VirtualFile> generateProject(final @NotNull DartSdk sdk,
                                                  final @NotNull Module module,
                                                  final @NotNull VirtualFile baseDir) throws IOException {
     try {
-      myDartCreate.generateInto(sdkRoot, baseDir, myTemplate.myId);
+      myDartCreate.generateInto(sdk, baseDir, myTemplate.myId);
     }
     catch (ExecutionException e) {
       throw new IOException(e);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
@@ -25,6 +25,7 @@ import com.intellij.ui.components.JBList;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.util.ui.AsyncProcessIcon;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -162,7 +163,14 @@ public class DartGeneratorPeer implements ProjectGeneratorPeer<DartProjectWizard
       final String comboSdkPath = mySdkPathComboWithBrowse.getComboBox().getEditor().getItem().toString().trim();
       final String sdkPath =
         FileUtil.toSystemIndependentName(comboSdkPath);
-      DartProjectTemplate.loadTemplatesAsync(sdkPath, templates -> {
+        final DartSdk sdk = DartSdk.forPath(sdkPath);
+        if (sdk == null) {
+            asyncProcessIcon.suspend();
+            myLoadingTemplatesPanel.remove(asyncProcessIcon);
+            Disposer.dispose(asyncProcessIcon);
+            return;
+        }
+        DartProjectTemplate.loadTemplatesAsync(sdk, templates -> {
         asyncProcessIcon.suspend();
         myLoadingTemplatesPanel.remove(asyncProcessIcon);
         Disposer.dispose(asyncProcessIcon);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
@@ -60,6 +60,17 @@ public class DartGeneratorPeer implements ProjectGeneratorPeer<DartProjectWizard
   private String myDartCreateTemplatesSdkPath; //used to expire the above cache if the sdk is changed an alternative would be to use the same cache method as com.jetbrains.lang.dart.sdk.DartSdkUtil.getSdkVersion
 
   public DartGeneratorPeer() {
+    initialiseTemplatesPanel();
+  }
+
+  // This needs to run in a background thread to avoid blocking the UI which could
+  // happen because WSL initialization can be slow, which is required for any
+  // WSL file access like confirming an exiting Dart SDK directory.
+  private void initialiseTemplatesPanel() {
+    ApplicationManager.getApplication().executeOnPooledThread(this::initialiseTemplatesPanelAsync);
+  }
+
+  private void initialiseTemplatesPanelAsync() {
     // set initial values before initDartSdkControls() because listeners should not be triggered on initialization
     mySdkPathComboWithBrowse.getComboBox().setEditable(true);
     //mySdkPathComboWithBrowse.getComboBox().getEditor().setItem(...); initial sdk path will be correctly taken from known paths history
@@ -79,8 +90,8 @@ public class DartGeneratorPeer implements ProjectGeneratorPeer<DartProjectWizard
         JLabel component = (JLabel)super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         DartProjectTemplate template = (DartProjectTemplate)value;
         String text = template.getDescription().isEmpty()
-                      ? template.getName()
-                      : template.getName() + " - " + StringUtil.decapitalize(template.getDescription());
+                ? template.getName()
+                : template.getName() + " - " + StringUtil.decapitalize(template.getDescription());
         component.setText(text);
         return component;
       }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartGeneratorPeer.java
@@ -25,6 +25,7 @@ import com.intellij.ui.components.JBList;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.util.ui.AsyncProcessIcon;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -144,7 +145,14 @@ public class DartGeneratorPeer implements ProjectGeneratorPeer<DartProjectWizard
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       final String sdkPath =
         FileUtil.toSystemIndependentName(mySdkPathComboWithBrowse.getComboBox().getEditor().getItem().toString().trim());
-      DartProjectTemplate.loadTemplatesAsync(sdkPath, templates -> {
+      final DartSdk sdk = DartSdk.forPath(sdkPath);
+      if (sdk == null) {
+        asyncProcessIcon.suspend();
+        myLoadingTemplatesPanel.remove(asyncProcessIcon);
+        Disposer.dispose(asyncProcessIcon);
+        return;
+      }
+      DartProjectTemplate.loadTemplatesAsync(sdk, templates -> {
         asyncProcessIcon.suspend();
         myLoadingTemplatesPanel.remove(asyncProcessIcon);
         Disposer.dispose(asyncProcessIcon);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
@@ -105,13 +105,17 @@ public final class DartModuleBuilder extends ModuleBuilder {
     setupSdk(modifiableRootModel, wizardData);
 
     if (wizardData.myTemplate != null) {
-      final DartSdk sdk = DartSdk.getDartSdk(modifiableRootModel.getProject());
+      DartSdk sdk = DartSdk.getDartSdk(modifiableRootModel.getProject());
+      if(sdk == null){
+        sdk = DartSdk.getDartSdkFromPath(wizardData.dartSdkPath);
+      }
       if (sdk == null) return;
 
+      DartSdk finalSdk = sdk;
       ApplicationManager.getApplication().executeOnPooledThread(() -> {
         try {
           final Collection<VirtualFile> filesToOpen =
-            wizardData.myTemplate.generateProject(sdk, modifiableRootModel.getModule(), baseDir);
+            wizardData.myTemplate.generateProject(finalSdk, modifiableRootModel.getModule(), baseDir);
           if (!filesToOpen.isEmpty()) {
             scheduleFilesOpeningAndPubGet(modifiableRootModel.getModule(), filesToOpen);
           }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
@@ -105,10 +105,13 @@ public final class DartModuleBuilder extends ModuleBuilder {
     setupSdk(modifiableRootModel, wizardData);
 
     if (wizardData.myTemplate != null) {
+      final DartSdk sdk = DartSdk.getDartSdk(modifiableRootModel.getProject());
+      if (sdk == null) return;
+
       ApplicationManager.getApplication().executeOnPooledThread(() -> {
         try {
           final Collection<VirtualFile> filesToOpen =
-            wizardData.myTemplate.generateProject(wizardData.dartSdkPath, modifiableRootModel.getModule(), baseDir);
+            wizardData.myTemplate.generateProject(sdk, modifiableRootModel.getModule(), baseDir);
           if (!filesToOpen.isEmpty()) {
             scheduleFilesOpeningAndPubGet(modifiableRootModel.getModule(), filesToOpen);
           }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
@@ -19,6 +19,7 @@ import com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfigurationType;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunnerParameters;
 import com.jetbrains.lang.dart.projectWizard.DartCreate.DartCreateTemplate;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -52,7 +53,7 @@ public abstract class DartProjectTemplate {
     return myDescription;
   }
 
-  public abstract Collection<VirtualFile> generateProject(@NotNull String sdkRoot,
+  public abstract Collection<VirtualFile> generateProject(@NotNull DartSdk sdk,
                                                           @NotNull Module module,
                                                           @NotNull VirtualFile baseDir)
     throws IOException;
@@ -61,14 +62,14 @@ public abstract class DartProjectTemplate {
   /**
    * Must be called in pooled thread without read action; {@code templatesConsumer} will be invoked in EDT
    */
-  public static void loadTemplatesAsync(@NotNull String sdkRoot, @NotNull Consumer<? super List<DartProjectTemplate>> templatesConsumer) {
+  public static void loadTemplatesAsync(@NotNull DartSdk sdk, @NotNull Consumer<? super List<DartProjectTemplate>> templatesConsumer) {
     if (ApplicationManager.getApplication().isReadAccessAllowed()) {
       LOG.error("DartProjectTemplate.loadTemplatesAsync() must be called in pooled thread without read action");
     }
 
     final List<DartProjectTemplate> templates = new ArrayList<>();
     try {
-      templates.addAll(getDartCreateTemplates(sdkRoot));
+      templates.addAll(getDartCreateTemplates(sdk));
     }
     finally {
       if (templates.isEmpty()) {
@@ -79,12 +80,14 @@ public abstract class DartProjectTemplate {
     }
   }
 
-  private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull String sdkRoot) {
+  private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull DartSdk sdk) {
+      // Todo: Check this
+      String sdkRoot = sdk.getDartExePath();
     if (ourDartCreateTemplateCache != null && sdkRoot.equals(ourDartCreateTemplateCacheSdkPath)) {
       return ourDartCreateTemplateCache;
     }
 
-    final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdkRoot);
+    final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdk);
 
     ourDartCreateTemplateCache = new ArrayList<>();
     ourDartCreateTemplateCacheSdkPath = sdkRoot;

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
@@ -33,6 +33,7 @@ public abstract class DartProjectTemplate {
 
   private static final DartCreate DART_CREATE = new DartCreate();
   private static List<DartProjectTemplate> ourDartCreateTemplateCache;
+  private static String ourDartCreateTemplateCacheSdkPath; //used to expire the above cache if the sdk is changed, an alternative would be to use the same cache method as com.jetbrains.lang.dart.sdk.DartSdkUtil.getSdkVersion
 
   private static final Logger LOG = PluginLogger.INSTANCE.createLogger(DartProjectTemplate.class);
 
@@ -80,13 +81,14 @@ public abstract class DartProjectTemplate {
   }
 
   private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull DartSdk sdk) {
-    if (ourDartCreateTemplateCache != null) {
+    if (ourDartCreateTemplateCache != null && sdk.getFullDartExePath().equals(ourDartCreateTemplateCacheSdkPath)) {
       return ourDartCreateTemplateCache;
     }
 
     final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdk);
 
     ourDartCreateTemplateCache = new ArrayList<>();
+    ourDartCreateTemplateCacheSdkPath = sdk.getFullDartExePath();
     for (DartCreateTemplate template : templates) {
       ourDartCreateTemplateCache.add(new DartCreateProjectTemplate(DART_CREATE, template));
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
@@ -19,6 +19,7 @@ import com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfigurationType;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunnerParameters;
 import com.jetbrains.lang.dart.projectWizard.DartCreate.DartCreateTemplate;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -51,7 +52,7 @@ public abstract class DartProjectTemplate {
     return myDescription;
   }
 
-  public abstract Collection<VirtualFile> generateProject(@NotNull String sdkRoot,
+  public abstract Collection<VirtualFile> generateProject(@NotNull DartSdk sdk,
                                                           @NotNull Module module,
                                                           @NotNull VirtualFile baseDir)
     throws IOException;
@@ -60,14 +61,14 @@ public abstract class DartProjectTemplate {
   /**
    * Must be called in pooled thread without read action; {@code templatesConsumer} will be invoked in EDT
    */
-  public static void loadTemplatesAsync(@NotNull String sdkRoot, @NotNull Consumer<? super List<DartProjectTemplate>> templatesConsumer) {
+  public static void loadTemplatesAsync(@NotNull DartSdk sdk, @NotNull Consumer<? super List<DartProjectTemplate>> templatesConsumer) {
     if (ApplicationManager.getApplication().isReadAccessAllowed()) {
       LOG.error("DartProjectTemplate.loadTemplatesAsync() must be called in pooled thread without read action");
     }
 
     final List<DartProjectTemplate> templates = new ArrayList<>();
     try {
-      templates.addAll(getDartCreateTemplates(sdkRoot));
+      templates.addAll(getDartCreateTemplates(sdk));
     }
     finally {
       if (templates.isEmpty()) {
@@ -78,12 +79,12 @@ public abstract class DartProjectTemplate {
     }
   }
 
-  private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull String sdkRoot) {
+  private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull DartSdk sdk) {
     if (ourDartCreateTemplateCache != null) {
       return ourDartCreateTemplateCache;
     }
 
-    final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdkRoot);
+    final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdk);
 
     ourDartCreateTemplateCache = new ArrayList<>();
     for (DartCreateTemplate template : templates) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartProjectTemplate.java
@@ -81,16 +81,14 @@ public abstract class DartProjectTemplate {
   }
 
   private static @NotNull List<DartProjectTemplate> getDartCreateTemplates(@NotNull DartSdk sdk) {
-      // Todo: Check this
-      String sdkRoot = sdk.getDartExePath();
-    if (ourDartCreateTemplateCache != null && sdkRoot.equals(ourDartCreateTemplateCacheSdkPath)) {
+    if (ourDartCreateTemplateCache != null && sdk.getFullDartExePath().equals(ourDartCreateTemplateCacheSdkPath)) {
       return ourDartCreateTemplateCache;
     }
 
     final List<DartCreateTemplate> templates = DART_CREATE.getAvailableTemplates(sdk);
 
     ourDartCreateTemplateCache = new ArrayList<>();
-    ourDartCreateTemplateCacheSdkPath = sdkRoot;
+    ourDartCreateTemplateCacheSdkPath = sdk.getFullDartExePath();
     for (DartCreateTemplate template : templates) {
       ourDartCreateTemplateCache.add(new DartCreateProjectTemplate(DART_CREATE, template));
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/pubServer/DartWebdev.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/pubServer/DartWebdev.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.NlsSafe
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.jetbrains.lang.dart.DartBundle
 import com.jetbrains.lang.dart.ide.actions.DartPubActionBase
@@ -18,6 +19,12 @@ private val LOG = logger<DartWebdev>()
 
 object DartWebdev {
   var activated: Boolean = false
+
+  fun useWebdev(sdk: DartSdk?): Boolean {
+    if (sdk == null) return false
+    val sdkVersion = sdk.version
+    return StringUtil.compareVersionNumbers(sdkVersion, "2") >= 0
+  }
 
   /**
    * @return `false` only if explicitly cancelled by user
@@ -40,7 +47,7 @@ object DartWebdev {
       DartPubActionBase.setupPubExePath(command, sdk)
       command.addParameters("global", "activate", "webdev")
       command.withEnvironment(DartPubActionBase.PUB_ENV_VAR_NAME, DartPubActionBase.pubEnvValue + ".webdev.activate")
-
+      sdk.patchCommandLineIfRequired(command)
       CapturingProcessHandler(command).runProcessWithProgressIndicator(indicator, 60 * 1000, false)
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdk.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdk.java
@@ -59,6 +59,12 @@ public final class DartSdk {
     return myHomePath;
   }
 
+  /**
+   * Extracts the WSL distribution from a Windows UNC path, if applicable.
+   *
+   * @param path the path to check for WSL UNC format
+   * @return the WSL distribution if the path is a WSL UNC path, or {@code null} otherwise
+   */
   private static @Nullable WSLDistribution getDistribution(String path) {
     WslPath wslPath = WslPath.parseWindowsUncPath(path);
     return wslPath != null ? wslPath.getDistribution() : null;
@@ -87,6 +93,13 @@ public final class DartSdk {
     });
   }
 
+  /**
+   * Creates a {@link DartSdk} instance from the given SDK path.
+   *
+   * @param sdkPath the absolute path to the Dart SDK root directory
+   * @return a new DartSdk instance, or throws if the SDK version cannot be determined
+   * @throws NullPointerException if the SDK version cannot be read from the given path
+   */
   public static @Nullable DartSdk getDartSdkFromPath(final @NotNull String sdkPath) {
     return new DartSdk(sdkPath, Objects.requireNonNull(DartSdkUtil.getSdkVersion(sdkPath)));
   }
@@ -115,10 +128,25 @@ public final class DartSdk {
   }
 
 
+  /**
+   * Checks whether this Dart SDK is located within a Windows Subsystem for Linux (WSL) distribution.
+   *
+   * @return {@code true} if the SDK path is a WSL UNC path (e.g., {@code \\wsl$\Ubuntu\...}),
+   *         {@code false} otherwise
+   */
   public boolean isWsl() {
     return distribution != null;
   }
 
+  /**
+   * Returns the path to the Dart executable.
+   * <p>
+   * For WSL SDKs, returns the Linux path (e.g., {@code /usr/lib/dart/bin/dart}).
+   * For Windows SDKs, returns the path with {@code .exe} extension.
+   * For other platforms, returns the path without extension.
+   *
+   * @return the path to the Dart executable appropriate for command execution
+   */
   public @NotNull String getDartExePath() {
     if(isWsl()){
       String path = distribution.getWslPath(Path.of(myHomePath + "/bin/dart"));
@@ -129,6 +157,15 @@ public final class DartSdk {
     return myHomePath + (SystemInfo.isWindows ? "/bin/dart.exe" : "/bin/dart");
   }
 
+  /**
+   * Returns the full path to the Dart executable using the SDK home path.
+   * <p>
+   * For WSL SDKs, returns the Windows UNC path (e.g., {@code \\wsl$\Ubuntu\usr\lib\dart\bin\dart}).
+   * For Windows SDKs, returns the path with {@code .exe} extension.
+   * For other platforms, returns the path without extension.
+   *
+   * @return the full path to the Dart executable suitable for display or file system access
+   */
   public @NotNull String getFullDartExePath() {
     if(isWsl()){
       return myHomePath + "/bin/dart";
@@ -136,6 +173,15 @@ public final class DartSdk {
     return myHomePath + (SystemInfo.isWindows ? "/bin/dart.exe" : "/bin/dart");
   }
 
+  /**
+   * Returns the path to the Pub executable.
+   * <p>
+   * For WSL SDKs, returns the Linux path (e.g., {@code /usr/lib/dart/bin/pub}).
+   * For Windows SDKs, returns the path to {@code pub.bat}.
+   * For other platforms, returns the path to the {@code pub} script.
+   *
+   * @return the path to the Pub executable appropriate for command execution
+   */
   public @NotNull String getPubPath() {
     if(isWsl()){
       String path = distribution.getWslPath(Path.of(myHomePath + "/bin/pub"));
@@ -147,6 +193,15 @@ public final class DartSdk {
     return myHomePath + (SystemInfo.isWindows ? "/bin/pub.bat" : "/bin/pub");
   }
 
+  /**
+   * Returns the full path to the Pub executable using the SDK home path.
+   * <p>
+   * For WSL SDKs, returns the Windows UNC path (e.g., {@code \\wsl$\Ubuntu\usr\lib\dart\bin\pub}).
+   * For Windows SDKs, returns the path to {@code pub.bat}.
+   * For other platforms, returns the path to the {@code pub} script.
+   *
+   * @return the full path to the Pub executable suitable for display or file system access
+   */
   public @NotNull String getFullPubPath() {
     if(isWsl()){
       return myHomePath + "/bin/pub";
@@ -154,13 +209,21 @@ public final class DartSdk {
     return myHomePath + (SystemInfo.isWindows ? "/bin/pub.bat" : "/bin/pub");
   }
 
-   // This expects a file in Linux format e.g. /tmp/local/lib and returns in windows mapped WSL format e.g.
-   // \\wsl.local\Ubuntu\tmp\local\lib
-  public String getIDEFilePath(String uri) {
-    if(isWsl() && uri != null){
-      return distribution.getWindowsPath(uri);
+  /**
+   * Converts a Linux file path to a Windows-accessible path for WSL SDKs.
+   * <p>
+   * For WSL SDKs, converts a Linux path (e.g., {@code /home/user/.pub-cache/...}) to a
+   * Windows UNC path (e.g., {@code \\wsl$\Ubuntu\home\user\.pub-cache\...}).
+   * For non-WSL SDKs, returns the path unchanged.
+   *
+   * @param path the file path in Linux format (for WSL) or any format (for non-WSL)
+   * @return the path converted to Windows UNC format for WSL, or the original path for non-WSL
+   */
+  public String getIDEFilePath(String path) {
+    if(isWsl() && path != null){
+      return distribution.getWindowsPath(path);
     }
-    return uri;
+    return path;
   }
 
   /**
@@ -196,7 +259,7 @@ public final class DartSdk {
    * Prefer {@link #getFileUri(VirtualFile)}.
    * Use this method only if the corresponding `VirtualFile` is not available at the call site,
    * and you are sure that this is a local file path.
-   *
+   * <p>
    * Examples of paths that are processed include
    *  WslUncPath: "\\wsl.localhost\Ubuntu\ usr\lib\dart\bin\snapshots\analysis_server.dart.snapshot"
    *
@@ -216,6 +279,15 @@ public final class DartSdk {
     return uri != null ? uri.toString() : url;
   }
 
+  /**
+   * Converts a file path to the appropriate format for the current platform and SDK type.
+   * <p>
+   * For WSL SDKs with a Windows UNC path input, converts it to a Linux path.
+   * For non-WSL SDKs, converts to system-dependent format.
+   *
+   * @param localFilePath the file path to convert
+   * @return the converted path appropriate for the SDK's environment
+   */
   public String getLocalFilePath(@NotNull String localFilePath){
     if(isWsl()){
       if(!WslPath.isWslUncPath(localFilePath)){
@@ -227,11 +299,26 @@ public final class DartSdk {
     return FileUtil.toSystemDependentName(localFilePath);
   }
 
+  /**
+   * Finds and returns a {@link VirtualFile} for the given local file path.
+   *
+   * @param localFilePath the local file path to find
+   * @return the VirtualFile corresponding to the path, or {@code null} if not found
+   */
   public VirtualFile getLocalFile(@NotNull String localFilePath) {
     String localUri = getLocalFileUri(localFilePath);
     return VirtualFileManager.getInstance().findFileByUrl(localUri);
   }
 
+  /**
+   * Builds a command list for executing the Dart runtime.
+   * <p>
+   * For WSL SDKs, the command list includes the necessary WSL wrapper commands.
+   * For non-WSL SDKs, returns a simple list containing the Dart executable path.
+   *
+   * @return a list of command arguments for executing Dart
+   * @throws RuntimeException if WSL command line patching fails
+   */
   public List<String> getDartCommandList() {
     if (isWsl()) {
       GeneralCommandLine commandLine = new GeneralCommandLine(getDartExePath());
@@ -246,6 +333,16 @@ public final class DartSdk {
     return List.of(getDartExePath());
   }
 
+  /**
+   * Patches the given command line for WSL execution if this SDK is a WSL SDK.
+   * <p>
+   * For WSL SDKs, configures the command line to execute within the WSL distribution,
+   * including setting the remote working directory. For non-WSL SDKs, this method
+   * does nothing.
+   *
+   * @param commandLine the command line to patch for WSL execution
+   * @throws RuntimeException if WSL command line patching fails
+   */
   public void patchCommandLineIfRequired(GeneralCommandLine commandLine) {
     if(isWsl()){
       try {
@@ -282,6 +379,14 @@ public final class DartSdk {
   }
 
 
+  /**
+   * Builds a simple command list for executing the Dart runtime.
+   * <p>
+   * For WSL SDKs, prepends the WSL executable path to the command list.
+   * This method returns a mutable list that can be modified by the caller.
+   *
+   * @return a mutable list of command arguments for executing Dart
+   */
   public List<String> getDartSimpleCommandList() {
     List<String> commandList = new ArrayList<>();
     if (isWsl()) {
@@ -291,10 +396,36 @@ public final class DartSdk {
     return commandList;
   }
 
+  /**
+   * Executes a command using this SDK's environment, with process destruction on timeout.
+   * <p>
+   * For WSL SDKs, executes the command within the WSL distribution.
+   * For non-WSL SDKs, executes directly using a {@link CapturingProcessHandler}.
+   *
+   * @param command the command line to execute
+   * @param timeout the maximum time to wait for the process in milliseconds
+   * @param processHandlerConsumer optional consumer to receive the process handler
+   * @return the output of the process execution
+   * @throws ExecutionException if the process cannot be started
+   * @see #runCommand(GeneralCommandLine, int, Consumer, boolean)
+   */
   public ProcessOutput runCommand(GeneralCommandLine command, int timeout, @Nullable Consumer<? super ProcessHandler> processHandlerConsumer) throws ExecutionException{
     return runCommand(command, timeout, processHandlerConsumer, true);
   }
 
+  /**
+   * Executes a command using this SDK's environment.
+   * <p>
+   * For WSL SDKs, executes the command within the WSL distribution.
+   * For non-WSL SDKs, executes directly using a {@link CapturingProcessHandler}.
+   *
+   * @param command the command line to execute
+   * @param timeout the maximum time to wait for the process in milliseconds
+   * @param processHandlerConsumer optional consumer to receive the process handler
+   * @param destroyOnTimeout if {@code true}, destroys the process when timeout is reached
+   * @return the output of the process execution
+   * @throws ExecutionException if the process cannot be started
+   */
   public ProcessOutput runCommand(GeneralCommandLine command, int timeout, @Nullable Consumer<? super ProcessHandler> processHandlerConsumer, boolean destroyOnTimeout) throws ExecutionException{
     if(isWsl()){
       WSLCommandLineOptions options = new WSLCommandLineOptions();
@@ -319,12 +450,27 @@ public final class DartSdk {
     //final AtomicReference<ProcessOutput> result = new AtomicReference<>();
   }
 
+  /**
+   * Creates a {@link DartSdk} instance from the given SDK root path, if valid.
+   * <p>
+   * Unlike {@link #getDartSdkFromPath(String)}, this method returns {@code null}
+   * instead of throwing if the SDK version cannot be determined.
+   *
+   * @param root the absolute path to the Dart SDK root directory
+   * @return a new DartSdk instance, or {@code null} if the SDK version cannot be determined
+   */
   public static @Nullable DartSdk forPath(String root) {
     String version = DartSdkUtil.getSdkVersion(root);
     if (version == null) return null;
     return new DartSdk(root, version);
   }
 
+  /**
+   * Converts Windows-style backslashes to forward slashes for Linux path compatibility.
+   *
+   * @param path the path to convert
+   * @return the path with all backslashes replaced by forward slashes
+   */
   private static String fixLinuxPath(String path) {
     return path.replace('\\', '/');
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdk.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdk.java
@@ -1,24 +1,45 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.sdk;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.CapturingProcessHandler;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessOutput;
+import com.intellij.execution.wsl.WSLCommandLineOptions;
+import com.intellij.execution.wsl.WSLDistribution;
+import com.intellij.execution.wsl.WslPath;
+import com.intellij.openapi.progress.impl.CoreProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.util.CachedValueProvider;
 import com.intellij.psi.util.CachedValuesManager;
 import com.intellij.util.ArrayUtil;
+import com.intellij.util.Consumer;
 import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.io.URLUtil;
+import com.jetbrains.lang.dart.analyzer.DartFileInfoKt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+
+import static com.jetbrains.lang.dart.analyzer.DartAnalysisServerService.isDartSdkVersionSufficientForFileUri;
 
 public final class DartSdk {
   public static final String DART_SDK_LIB_NAME = "Dart SDK";
@@ -26,14 +47,21 @@ public final class DartSdk {
 
   private final @NotNull String myHomePath;
   private final @NotNull String myVersion;
+  private final WSLDistribution distribution;
 
   private DartSdk(final @NotNull String homePath, final @NotNull String version) {
     myHomePath = homePath;
     myVersion = version;
+    distribution = getDistribution(homePath);
   }
 
   public @NotNull String getHomePath() {
     return myHomePath;
+  }
+
+  private static @Nullable WSLDistribution getDistribution(String path) {
+    WslPath wslPath = WslPath.parseWindowsUncPath(path);
+    return wslPath != null ? wslPath.getDistribution() : null;
   }
 
   /**
@@ -74,10 +102,209 @@ public final class DartSdk {
     final VirtualFile dartCoreRoot = DartSdkLibraryPresentationProvider.findDartCoreRoot(Arrays.asList(roots));
     if (dartCoreRoot != null) {
       final String homePath = dartCoreRoot.getParent().getParent().getPath();
+      final String firstVersion = DartSdkUtil.getSdkVersion(homePath);
       final String version = StringUtil.notNullize(DartSdkUtil.getSdkVersion(homePath), UNKNOWN_VERSION);
       return new DartSdk(homePath, version);
     }
 
     return null;
+  }
+
+
+  public boolean isWsl() {
+    return distribution != null;
+  }
+
+  public @NotNull String getDartExePath() {
+    if(isWsl()){
+      String path = distribution.getWslPath(Path.of(myHomePath + "/bin/dart"));
+      if (path != null) {
+        return path;
+      }
+    }
+    return myHomePath + (SystemInfo.isWindows ? "/bin/dart.exe" : "/bin/dart");
+  }
+
+  public @NotNull String getFullDartExePath() {
+    if(isWsl()){
+      return myHomePath + "/bin/dart";
+    }
+    return myHomePath + (SystemInfo.isWindows ? "/bin/dart.exe" : "/bin/dart");
+  }
+
+  public @NotNull String getPubPath() {
+    if(isWsl()){
+      String path = distribution.getWslPath(Path.of(myHomePath + "/bin/pub"));
+      if (path != null) {
+        return path;
+      }
+      return myHomePath + "/bin/pub";
+    }
+    return myHomePath + (SystemInfo.isWindows ? "/bin/pub.bat" : "/bin/pub");
+  }
+
+  public @NotNull String getFullPubPath() {
+    if(isWsl()){
+      return myHomePath + "/bin/pub";
+    }
+    return myHomePath + (SystemInfo.isWindows ? "/bin/pub.bat" : "/bin/pub");
+  }
+
+   // This expects a file in Linux format e.g. /tmp/local/lib and returns in windows mapped WSL format e.g.
+   // \\wsl.local\Ubuntu\tmp\local\lib
+  public String getIDEFilePath(String uri) {
+    if(isWsl()){
+      return distribution.getWindowsPath(uri);
+    }
+    return uri;
+  }
+
+  /**
+   * Returns a string, which the
+   * <a href="https://htmlpreview.github.io/?https://github.com/dart-lang/sdk/blob/main/pkg/analysis_server/doc/api.html#type_FilePath">Analysis Server API specification</a>
+   * defines as `FilePath`:
+   * <ul>
+   * <li>for SDK version 3.3 and older, it's an absolute file path with OS-dependent slashes
+   * <li>for SDK version 3.4 and newer, it's a URI, thanks to the `supportsUris` capability defined in the spec
+   * </ul>
+   */
+  public String getFileUri(@NotNull VirtualFile file) {
+    String localFilePath = file.getPath();
+    if(isWsl()){
+      if(!WslPath.isWslUncPath(localFilePath)){
+        return localFilePath;
+      }
+      localFilePath = distribution.getWslPath(Path.of(localFilePath));
+    }
+    if (!isDartSdkVersionSufficientForFileUri(myVersion)) {
+      // prior to Dart SDK 3.4, the protocol required file paths instead of URIs
+      if(isWsl()){
+        return localFilePath;
+      }
+      return FileUtil.toSystemDependentName(localFilePath);
+    }
+
+    String fileUri = file.getUserData(DartFileInfoKt.DART_NOT_LOCAL_FILE_URI_KEY);
+    return fileUri != null ? fileUri : getLocalFileUri(file.getPath());
+  }
+
+  /**
+   * Prefer {@link #getFileUri(VirtualFile)}.
+   * Use this method only if the corresponding `VirtualFile` is not available at the call site,
+   * and you are sure that this is a local file path.
+   *
+   * Examples of paths that are processed include
+   *  WslUncPath: "\\wsl.localhost\Ubuntu\ usr\lib\dart\bin\snapshots\analysis_server.dart.snapshot"
+   *
+   * @apiNote URI calculation is similar to {@link com.intellij.platform.lsp.api.LspServerDescriptor#getFileUri(VirtualFile)}
+   * @see #getFileUri(VirtualFile)
+   */
+  public String getLocalFileUri(@NotNull String localFilePath) {
+    localFilePath = getLocalFilePath(localFilePath);
+    if (!isDartSdkVersionSufficientForFileUri(myVersion)) {
+      // prior to Dart SDK 3.4, the protocol required file paths instead of URIs
+      return localFilePath;
+    }
+
+    String escapedPath = URLUtil.encodePath(FileUtil.toSystemIndependentName(localFilePath));
+    String url = VirtualFileManager.constructUrl(URLUtil.FILE_PROTOCOL, escapedPath);
+    URI uri = VfsUtil.toUri(url);
+    return uri != null ? uri.toString() : url;
+  }
+
+  public String getLocalFilePath(@NotNull String localFilePath){
+    if(isWsl()){
+      if(!WslPath.isWslUncPath(localFilePath)){
+        return localFilePath;
+      }
+      localFilePath = distribution.getWslPath(Path.of(localFilePath));
+      return localFilePath;
+    }
+    return FileUtil.toSystemDependentName(localFilePath);
+  }
+
+  public VirtualFile getLocalFile(@NotNull String localFilePath) {
+    String localUri = getLocalFileUri(localFilePath);
+    return VirtualFileManager.getInstance().findFileByUrl(localUri);
+  }
+
+  public List<String> getDartCommandList() {
+    if (isWsl()) {
+      GeneralCommandLine commandLine = new GeneralCommandLine(getDartExePath());
+      try {
+        distribution.patchCommandLine(commandLine, null, new WSLCommandLineOptions());
+      }
+      catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+      return commandLine.getCommandLineList(null);
+    }
+    return List.of(getDartExePath());
+  }
+
+  public void patchCommandLineIfRequired(GeneralCommandLine commandLine) {
+    if(isWsl()){
+      try {
+        var workPath = commandLine.getWorkDirectory().getPath();
+        var workingDir = getIDEFilePath(workPath);
+        var wslCommandLineOptions = new WSLCommandLineOptions()
+          .setExecuteCommandInShell(false);
+        if(workPath.startsWith("/")){
+          wslCommandLineOptions.setRemoteWorkingDirectory(workPath);
+        }
+        distribution.patchCommandLine(commandLine, null, wslCommandLineOptions);
+      }
+      catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+
+  public List<String> getDartSimpleCommandList() {
+    List<String> commandList = new ArrayList<>();
+    if (isWsl()) {
+      commandList.add(Objects.requireNonNull(WSLDistribution.findWslExe()).toAbsolutePath().toString());
+    }
+    commandList.add(getDartExePath());
+    return commandList;
+  }
+
+  public ProcessOutput runCommand(GeneralCommandLine command, int timeout, @Nullable Consumer<? super ProcessHandler> processHandlerConsumer) throws ExecutionException{
+    return runCommand(command, timeout, processHandlerConsumer, true);
+  }
+
+  public ProcessOutput runCommand(GeneralCommandLine command, int timeout, @Nullable Consumer<? super ProcessHandler> processHandlerConsumer, boolean destroyOnTimeout) throws ExecutionException{
+    if(isWsl()){
+      WSLCommandLineOptions options = new WSLCommandLineOptions();
+      if(command.getWorkDirectory() != null){
+        options.setRemoteWorkingDirectory(fixLinuxPath(command.getWorkDirectory().getPath()));
+      }
+      ProcessOutput output = distribution.executeOnWsl(command.getCommandLineList(fixLinuxPath(command.getExePath())), options, timeout, processHandlerConsumer);
+      return output;
+    }else{
+      final CapturingProcessHandler processHandler = new CapturingProcessHandler(command);
+      if(processHandlerConsumer != null){
+        processHandlerConsumer.consume(processHandler);
+      }
+      return processHandler.runProcess(timeout, destroyOnTimeout);
+    }
+  }
+
+  private void loadPath() {
+    CoreProgressManager.getInstance().runProcessWithProgressSynchronously(()->{
+      distribution.getShellPath();
+    }, "Get WSL Shell", false, null);
+    //final AtomicReference<ProcessOutput> result = new AtomicReference<>();
+  }
+
+  public static @Nullable DartSdk forPath(String root) {
+    String version = DartSdkUtil.getSdkVersion(root);
+    if (version == null) return null;
+    return new DartSdk(root, version);
+  }
+
+  private static String fixLinuxPath(String path) {
+    return path.replace('\\', '/');
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
@@ -51,7 +51,8 @@ public final class DartSdkUtil {
 
     final String version = FileUtil.loadFileOrNull(versionFile);
     if (version != null) {
-      return ourVersions.put(versionPair, version);
+      ourVersions.put(versionPair, version);
+      return version;
     }
 
     return null;
@@ -181,13 +182,5 @@ public final class DartSdkUtil {
     if (!isDartSdkHome(sdkRootPath)) return DartBundle.message("error.sdk.not.found.in.specified.location");
 
     return null;
-  }
-
-  public static @NotNull String getDartExePath(@NotNull DartSdk sdk) {
-    return getDartExePath(sdk.getHomePath());
-  }
-
-  public static @NotNull String getDartExePath(@NotNull String sdkRoot) {
-    return sdkRoot + (SystemInfo.isWindows ? "/bin/dart.exe" : "/bin/dart");
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
@@ -187,12 +187,4 @@ public final class DartSdkUtil {
 
     return null;
   }
-
-  public static @NotNull String getDartExePath(@NotNull DartSdk sdk) {
-    return getDartExePath(sdk.getHomePath());
-  }
-
-  public static @NotNull String getDartExePath(@NotNull String sdkRoot) {
-    return sdkRoot + (SystemInfo.isWindows ? "/bin/dart.exe" : "/bin/dart");
-  }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
@@ -82,7 +82,8 @@ public final class DartSdkUtil {
     }
 
     final String sdkHomePath = getItemFromCombo(dartSdkPathComponent.getComboBox());
-    versionLabel.setText(sdkHomePath.isEmpty() ? "" : getSdkVersion(sdkHomePath));
+    final String sdkVersion = getSdkVersion(sdkHomePath);
+    versionLabel.setText(sdkVersion == null ? "" : sdkVersion);
 
     final TextComponentAccessor<JComboBox> textComponentAccessor = new TextComponentAccessor<>() {
       @Override
@@ -113,7 +114,10 @@ public final class DartSdkUtil {
       @Override
       protected void textChanged(final @NotNull DocumentEvent e) {
         final String sdkHomePath = getItemFromCombo(dartSdkPathComponent.getComboBox());
-        versionLabel.setText(sdkHomePath.isEmpty() ? "" : getSdkVersion(sdkHomePath));
+        if(e.getType() == DocumentEvent.EventType.INSERT){
+          final String sdkVersion = getSdkVersion(sdkHomePath);
+          versionLabel.setText(sdkVersion == null ? "" : sdkVersion);
+        }
       }
     });
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.util;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
@@ -16,7 +17,9 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
 import com.intellij.util.PairConsumer;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.index.DartLibraryIndex;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryProperties;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryType;
@@ -144,6 +147,12 @@ public final class DartUrlResolverImpl extends DartUrlResolver {
 
     result = getUrlIfFileFromDartPackagesLib(file, myPackagesMapFromLib);
     if (result != null) return result;
+
+    if(myDartSdk != null && myDartSdk.isWsl()){
+      String path = file.getPath();
+      path = myDartSdk.getLocalFileUri(path);
+      return "file://" + path;
+    }
 
     // see com.google.dart.tools.debug.core.server.ServerBreakpointManager#getAbsoluteUrlForResource()
     return new File(file.getPath()).toURI().toString();

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
@@ -204,7 +204,7 @@ public final class DartUrlResolverImpl extends DartUrlResolver {
     if (myPubspecYamlFile == null || baseDir == null) return;
 
     final VirtualFile packagesFile = PackageConfigFileUtil.getPackageConfigJsonFile(myProject, myPubspecYamlFile);
-    final Map<String, String> packagesMap = packagesFile != null ? PackageConfigFileUtil.getPackagesMapFromPackageConfigJsonFile(packagesFile) : null;
+    final Map<String, String> packagesMap = packagesFile != null ? PackageConfigFileUtil.getPackagesMapFromPackageConfigJsonFile(myProject, packagesFile) : null;
 
     if (packagesMap != null) {
       for (Map.Entry<String, String> entry : packagesMap.entrySet()) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
@@ -1,7 +1,6 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.util;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
@@ -17,9 +16,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.ex.temp.TempFileSystem;
 import com.intellij.util.PairConsumer;
-import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.index.DartLibraryIndex;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryProperties;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryType;

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
@@ -176,7 +176,8 @@ public final class PackageConfigFileUtil {
     return null;
   }
 
-  private static @Nullable String getAbsolutePackageRootPath(DartSdk dartSdk, @NotNull VirtualFile baseDir, @NotNull String uri) {
+  // Package-private for testing
+  static @Nullable String getAbsolutePackageRootPath(DartSdk dartSdk, @NotNull VirtualFile baseDir, @NotNull String uri) {
     if (uri.startsWith("file:/")) {
       final String pathAfterSlashes = StringUtil.trimEnd(StringUtil.trimLeading(StringUtil.trimStart(uri, "file:/"), '/'), "/");
       if (dartSdk != null && dartSdk.isWsl()) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
@@ -85,7 +85,15 @@ public final class PackageConfigFileUtil {
     return null;
   }
 
-  public static @Nullable Map<String, String> getPackagesMapFromPackageConfigJsonFile(@NotNull Project project, final @NotNull VirtualFile packageConfigJsonFile) {
+  /**
+   * Overload without {@link Project} for compatibility with the Flutter plugin <= 89.0.0.
+   * WSL path resolution is not available through this entry point.
+   */
+  public static @Nullable Map<String, String> getPackagesMapFromPackageConfigJsonFile(final @NotNull VirtualFile packageConfigJsonFile) {
+    return getPackagesMapFromPackageConfigJsonFile(null, packageConfigJsonFile);
+  }
+
+  public static @Nullable Map<String, String> getPackagesMapFromPackageConfigJsonFile(@Nullable Project project, final @NotNull VirtualFile packageConfigJsonFile) {
     Pair<Long, Map<String, String>> data = packageConfigJsonFile.getUserData(MOD_STAMP_TO_PACKAGES_MAP);
 
     final Long currentTimestamp = packageConfigJsonFile.getModificationCount();
@@ -94,7 +102,7 @@ public final class PackageConfigFileUtil {
     if (cachedTimestamp == null || !cachedTimestamp.equals(currentTimestamp)) {
       data = null;
       packageConfigJsonFile.putUserData(MOD_STAMP_TO_PACKAGES_MAP, null);
-      final Map<String, String> packagesMap = loadPackagesMapFromJson(DartSdk.getDartSdk(project), packageConfigJsonFile);
+      final Map<String, String> packagesMap = loadPackagesMapFromJson(project != null ? DartSdk.getDartSdk(project) : null, packageConfigJsonFile);
 
       if (packagesMap != null) {
         data = Pair.create(currentTimestamp, packagesMap);

--- a/third_party/src/test/java/com/jetbrains/lang/dart/sdk/DartSdkWslTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/sdk/DartSdkWslTest.java
@@ -1,126 +1,97 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.sdk;
 
+import com.intellij.execution.wsl.WSLDistribution;
 import com.intellij.execution.wsl.WslPath;
 import com.intellij.openapi.util.SystemInfo;
-import junit.framework.TestCase;
+import com.intellij.openapi.util.io.FileUtil;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for WSL-related functionality in {@link DartSdk}.
  * <p>
- * These tests verify path conversion and WSL detection logic.
- * Some tests are only meaningful on Windows where WSL is available.
+ * WSL tests require a real Dart SDK installed inside a WSL distribution.
+ * Set the {@code WSL_DART_SDK} environment variable to the Windows UNC path
+ * of the Dart SDK (e.g., {@code \\wsl$\Ubuntu\ usr\lib\dart}) to run WSL tests.
+ * When not set, WSL tests are skipped via {@link Assume#assumeTrue}.
  */
-public class DartSdkWslTest extends TestCase {
+public class DartSdkWslTest {
 
   // Sample WSL UNC paths for testing
   private static final String WSL_UBUNTU_PATH = "\\\\wsl$\\Ubuntu\\usr\\lib\\dart";
-  private static final String WSL_DEBIAN_PATH = "\\\\wsl$\\Debian\\usr\\lib\\dart";
   private static final String WSL_LOCALHOST_PATH = "\\\\wsl.localhost\\Ubuntu\\usr\\lib\\dart";
 
   // Sample Windows paths
   private static final String WINDOWS_PATH = "C:\\dart-sdk";
-  private static final String WINDOWS_PATH_WITH_SPACES = "C:\\Program Files\\Dart\\dart-sdk";
 
   // Sample Linux paths
   private static final String LINUX_PATH = "/usr/lib/dart";
 
+  private DartSdk nonWslSdk;
+  private DartSdk wslSdk;
+  private WSLDistribution wslDistribution;
+
+  @Before
+  public void setUp() {
+    nonWslSdk = DartSdk.forPath(DartTestUtils.SDK_HOME_PATH);
+
+    // WSL SDK from environment variable (Windows UNC path, e.g. \\wsl$\Ubuntu\ usr\lib\dart)
+    String wslSdkPath = System.getProperty("wsl.dart.sdk");
+    if (wslSdkPath == null) {
+      wslSdkPath = System.getenv("WSL_DART_SDK");
+    }
+    if (wslSdkPath != null) {
+      wslSdk = DartSdk.forPath(wslSdkPath);
+      if (wslSdk != null) {
+        WslPath wslPath = WslPath.parseWindowsUncPath(wslSdkPath);
+        if (wslPath != null) {
+          wslDistribution = wslPath.getDistribution();
+        }
+      }
+    }
+  }
+
   /**
-   * Tests that WSL UNC paths are correctly identified as WSL paths.
-   * This test runs on all platforms but the actual WSL detection only works on Windows.
+   * Skips the current test if no WSL SDK is available.
+   * Tests calling this will show as "ignored" (not "failed") when WSL_DART_SDK is not set.
    */
+  private void requireWslSdk() {
+    Assume.assumeTrue(
+      "WSL_DART_SDK not set. Set to Windows UNC path of Dart SDK in WSL to run WSL tests.",
+      wslSdk != null
+    );
+  }
+
+  // ==================== WslPath Utility Tests ====================
+
+  /**
+   * Tests that WSL UNC paths are correctly identified by WslPath utility.
+   */
+  @Test
   public void testWslPathDetection() {
     if (!SystemInfo.isWindows) {
-      // On non-Windows platforms, WslPath.parseWindowsUncPath always returns null
       assertNull(WslPath.parseWindowsUncPath(WSL_UBUNTU_PATH));
       return;
     }
 
-    // On Windows, WSL UNC paths should be detected
     assertNotNull("Ubuntu WSL path should be detected", WslPath.parseWindowsUncPath(WSL_UBUNTU_PATH));
-    assertNotNull("Debian WSL path should be detected", WslPath.parseWindowsUncPath(WSL_DEBIAN_PATH));
     assertNotNull("wsl.localhost path should be detected", WslPath.parseWindowsUncPath(WSL_LOCALHOST_PATH));
-
-    // Non-WSL paths should not be detected as WSL
     assertNull("Windows path should not be detected as WSL", WslPath.parseWindowsUncPath(WINDOWS_PATH));
     assertNull("Linux path should not be detected as WSL", WslPath.parseWindowsUncPath(LINUX_PATH));
   }
 
   /**
-   * Tests the fixLinuxPath utility method converts backslashes to forward slashes.
-   */
-  public void testFixLinuxPath() {
-    assertEquals("/home/user/project", fixLinuxPath("\\home\\user\\project"));
-    assertEquals("/home/user/project", fixLinuxPath("/home/user/project"));
-    assertEquals("home/user/project", fixLinuxPath("home\\user\\project"));
-    assertEquals("", fixLinuxPath(""));
-    assertEquals("/", fixLinuxPath("\\"));
-    assertEquals("a/b/c/d", fixLinuxPath("a\\b\\c\\d"));
-  }
-
-  /**
-   * Tests path construction for various SDK locations.
-   */
-  public void testDartExePathConstruction() {
-    // Test Windows path construction
-    String windowsSdkHome = "C:\\dart-sdk";
-    String expectedWindowsExe = windowsSdkHome + "/bin/dart.exe";
-    assertEquals(expectedWindowsExe, constructDartExePath(windowsSdkHome, false, false));
-
-    // Test Linux path construction
-    String linuxSdkHome = "/usr/lib/dart";
-    String expectedLinuxExe = linuxSdkHome + "/bin/dart";
-    assertEquals(expectedLinuxExe, constructDartExePath(linuxSdkHome, false, true));
-
-    // Test WSL path construction (returns Linux path for execution)
-    String wslSdkHome = "\\\\wsl$\\Ubuntu\\usr\\lib\\dart";
-    // For WSL, getDartExePath returns the Linux path for command execution
-    // The actual path would be converted by the WSL distribution
-  }
-
-  /**
-   * Tests that package paths from package_config.json are correctly handled.
-   */
-  public void testPackagePathFormats() {
-    // Test file:// URI parsing
-    String fileUri = "file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
-    String expectedPath = "/home/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
-    assertEquals(expectedPath, extractPathFromFileUri(fileUri));
-
-    // Test Windows file:// URI
-    String windowsFileUri = "file:///C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
-    String expectedWindowsPath = "C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
-    assertEquals(expectedWindowsPath, extractPathFromFileUri(windowsFileUri));
-
-    // Test relative path handling
-    String relativeUri = "../.pub-cache/hosted/pub.dev/meta-1.9.1";
-    assertFalse(relativeUri.startsWith("file:/"));
-  }
-
-  /**
-   * Tests edge cases in path handling.
-   */
-  public void testPathEdgeCases() {
-    // Empty path
-    assertEquals("", fixLinuxPath(""));
-
-    // Path with mixed separators
-    assertEquals("a/b/c/d", fixLinuxPath("a\\b/c\\d"));
-
-    // Path with spaces
-    assertEquals("/home/user/my project/lib", fixLinuxPath("\\home\\user\\my project\\lib"));
-
-    // Path with special characters
-    assertEquals("/home/user/project-name/lib", fixLinuxPath("\\home\\user\\project-name\\lib"));
-    assertEquals("/home/user/project_name/lib", fixLinuxPath("\\home\\user\\project_name\\lib"));
-  }
-
-  /**
    * Tests that WslPath.isWslUncPath correctly identifies WSL UNC paths.
    */
+  @Test
   public void testIsWslUncPath() {
     if (!SystemInfo.isWindows) {
-      // On non-Windows, these methods may behave differently
+      assertFalse(WslPath.isWslUncPath(WSL_UBUNTU_PATH));
       return;
     }
 
@@ -130,34 +101,411 @@ public class DartSdkWslTest extends TestCase {
     assertFalse("Should not detect Linux path as WSL", WslPath.isWslUncPath(LINUX_PATH));
   }
 
-  // Helper method that mirrors DartSdk.fixLinuxPath
-  private static String fixLinuxPath(String path) {
-    return path.replace('\\', '/');
+  // ==================== Non-WSL SDK Tests ====================
+
+  /**
+   * Tests that a non-WSL SDK correctly reports isWsl() as false.
+   */
+  @Test
+  public void testNonWslSdkIsWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+    assertFalse("Non-WSL SDK should return false for isWsl()", nonWslSdk.isWsl());
   }
 
-  // Helper method to construct dart exe path based on platform
-  private static String constructDartExePath(String homePath, boolean isWsl, boolean isLinux) {
-    if (isWsl) {
-      // For WSL, would use distribution.getWslPath()
-      return homePath + "/bin/dart";
+  /**
+   * Tests that getLocalFilePath returns the correct format for non-WSL SDKs.
+   */
+  @Test
+  public void testGetLocalFilePathNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String inputPath = "/home/user/project/lib/main.dart";
+    String result = nonWslSdk.getLocalFilePath(inputPath);
+
+    if (SystemInfo.isWindows) {
+      assertEquals("Should convert to Windows path format",
+                   FileUtil.toSystemDependentName(inputPath), result);
+    } else {
+      assertEquals("Should preserve Unix path format", inputPath, result);
     }
-    if (isLinux || !SystemInfo.isWindows) {
-      return homePath + "/bin/dart";
-    }
-    return homePath + "/bin/dart.exe";
   }
 
-  // Helper method to extract path from file:// URI
-  private static String extractPathFromFileUri(String uri) {
-    if (!uri.startsWith("file:/")) {
-      return uri;
+  /**
+   * Tests that getLocalFilePath handles Windows paths correctly on non-WSL SDKs.
+   */
+  @Test
+  public void testGetLocalFilePathWindowsPath() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String windowsPath = "C:/Users/user/project/lib/main.dart";
+    String result = nonWslSdk.getLocalFilePath(windowsPath);
+
+    assertEquals("Should convert to system-dependent format",
+                 FileUtil.toSystemDependentName(windowsPath), result);
+  }
+
+  /**
+   * Tests that getIDEFilePath returns the path unchanged for non-WSL SDKs.
+   */
+  @Test
+  public void testGetIDEFilePathNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String path = "/home/user/project/lib/main.dart";
+    String result = nonWslSdk.getIDEFilePath(path);
+
+    assertEquals("Non-WSL SDK should return path unchanged", path, result);
+  }
+
+  /**
+   * Tests that getIDEFilePath handles null input gracefully.
+   */
+  @Test
+  public void testGetIDEFilePathNull() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String result = nonWslSdk.getIDEFilePath(null);
+    assertNull("Should return null for null input", result);
+  }
+
+  /**
+   * Tests that getDartExePath returns the correct executable path for non-WSL SDKs.
+   */
+  @Test
+  public void testGetDartExePathNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String dartExePath = nonWslSdk.getDartExePath();
+    assertNotNull("getDartExePath should not return null", dartExePath);
+
+    if (SystemInfo.isWindows) {
+      assertTrue("Windows dart exe should end with .exe", dartExePath.endsWith("/bin/dart.exe"));
+    } else {
+      assertTrue("Unix dart exe should end with /bin/dart", dartExePath.endsWith("/bin/dart"));
+      assertFalse("Unix dart exe should not have .exe extension", dartExePath.endsWith(".exe"));
     }
-    // Remove file:// or file:/// prefix
-    String path = uri.substring("file://".length());
-    if (path.startsWith("/") && path.length() > 2 && path.charAt(2) == ':') {
-      // Windows path like /C:/... - remove leading /
-      path = path.substring(1);
+  }
+
+  /**
+   * Tests that getFullDartExePath returns the correct path for non-WSL SDKs.
+   */
+  @Test
+  public void testGetFullDartExePathNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String fullPath = nonWslSdk.getFullDartExePath();
+    assertNotNull("getFullDartExePath should not return null", fullPath);
+
+    assertEquals("For non-WSL SDK, getDartExePath and getFullDartExePath should match",
+                 nonWslSdk.getDartExePath(), fullPath);
+  }
+
+  /**
+   * Tests that getPubPath returns the correct path for non-WSL SDKs.
+   */
+  @Test
+  public void testGetPubPathNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String pubPath = nonWslSdk.getPubPath();
+    assertNotNull("getPubPath should not return null", pubPath);
+
+    if (SystemInfo.isWindows) {
+      assertTrue("Windows pub should end with .bat", pubPath.endsWith("/bin/pub.bat"));
+    } else {
+      assertTrue("Unix pub should be in bin directory", pubPath.endsWith("/bin/pub"));
+      assertFalse("Unix pub should not have .bat extension", pubPath.endsWith(".bat"));
     }
-    return path;
+  }
+
+  /**
+   * Tests that getFullPubPath returns the correct path for non-WSL SDKs.
+   */
+  @Test
+  public void testGetFullPubPathNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String fullPubPath = nonWslSdk.getFullPubPath();
+    assertNotNull("getFullPubPath should not return null", fullPubPath);
+
+    assertEquals("For non-WSL SDK, getPubPath and getFullPubPath should match",
+                 nonWslSdk.getPubPath(), fullPubPath);
+  }
+
+  /**
+   * Tests that getHomePath returns the SDK home path.
+   */
+  @Test
+  public void testGetHomePath() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String homePath = nonWslSdk.getHomePath();
+    assertNotNull("getHomePath should not return null", homePath);
+    assertEquals("Home path should match the path used to create SDK",
+                 DartTestUtils.SDK_HOME_PATH, homePath);
+  }
+
+  /**
+   * Tests that getVersion returns a non-null version string.
+   */
+  @Test
+  public void testGetVersion() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String version = nonWslSdk.getVersion();
+    assertNotNull("getVersion should not return null", version);
+    assertFalse("Version should not be empty", version.isEmpty());
+  }
+
+  /**
+   * Tests that DartSdk.forPath returns null for an invalid path.
+   */
+  @Test
+  public void testForPathInvalidPath() {
+    DartSdk sdk = DartSdk.forPath("/non/existent/path/to/dart/sdk");
+    assertNull("forPath should return null for invalid SDK path", sdk);
+  }
+
+  /**
+   * Tests that DartSdk.forPath returns null for an empty path.
+   */
+  @Test
+  public void testForPathEmptyPath() {
+    DartSdk sdk = DartSdk.forPath("");
+    assertNull("forPath should return null for empty path", sdk);
+  }
+
+  /**
+   * Tests getLocalFileUri for non-WSL SDK.
+   */
+  @Test
+  public void testGetLocalFileUri() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    String path = "/home/user/project/lib/main.dart";
+    String result = nonWslSdk.getLocalFileUri(path);
+    assertNotNull("getLocalFileUri should not return null", result);
+
+    assertTrue("Result should contain the path components",
+               result.contains("home") && result.contains("user") && result.contains("main.dart"));
+  }
+
+  /**
+   * Tests that getDartCommandList returns a non-empty list for non-WSL SDKs.
+   */
+  @Test
+  public void testGetDartCommandListNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    var commandList = nonWslSdk.getDartCommandList();
+    assertNotNull("getDartCommandList should not return null", commandList);
+    assertFalse("Command list should not be empty", commandList.isEmpty());
+
+    assertTrue("Command list should contain dart executable",
+               commandList.get(0).contains("dart"));
+  }
+
+  /**
+   * Tests that getDartSimpleCommandList returns a non-empty list for non-WSL SDKs.
+   */
+  @Test
+  public void testGetDartSimpleCommandListNonWsl() {
+    Assume.assumeNotNull(nonWslSdk);
+
+    var commandList = nonWslSdk.getDartSimpleCommandList();
+    assertNotNull("getDartSimpleCommandList should not return null", commandList);
+    assertFalse("Command list should not be empty", commandList.isEmpty());
+
+    String firstCommand = commandList.get(0);
+    assertTrue("Command should be dart executable for non-WSL SDK",
+               firstCommand.contains("dart"));
+  }
+
+  // ==================== WSL SDK Tests ====================
+
+  /**
+   * Tests that a WSL SDK correctly reports isWsl() as true.
+   */
+  @Test
+  public void testWslSdkIsWsl() {
+    requireWslSdk();
+
+    assertTrue("WSL SDK should return true for isWsl()", wslSdk.isWsl());
+  }
+
+  /**
+   * Tests that WSL SDK returns the correct home path.
+   */
+  @Test
+  public void testWslSdkGetHomePath() {
+    requireWslSdk();
+
+    String homePath = wslSdk.getHomePath();
+    assertNotNull("WSL SDK home path should not be null", homePath);
+  }
+
+  /**
+   * Tests that WSL SDK returns a valid version.
+   */
+  @Test
+  public void testWslSdkGetVersion() {
+    requireWslSdk();
+
+    String version = wslSdk.getVersion();
+    assertNotNull("WSL SDK version should not be null", version);
+    assertFalse("WSL SDK version should not be empty", version.isEmpty());
+  }
+
+  /**
+   * Tests that getDartExePath returns a Linux path for WSL SDKs.
+   */
+  @Test
+  public void testGetDartExePathWsl() {
+    requireWslSdk();
+
+    String dartExePath = wslSdk.getDartExePath();
+    assertNotNull("getDartExePath should not return null for WSL SDK", dartExePath);
+
+    // WSL SDK should return a Linux-style path (converted by WSLDistribution)
+    assertTrue("WSL dart exe path should be a Linux path (start with /)",
+               dartExePath.startsWith("/"));
+    assertTrue("WSL dart exe path should end with /bin/dart",
+               dartExePath.endsWith("/bin/dart"));
+    assertFalse("WSL dart exe should not have .exe extension",
+                dartExePath.endsWith(".exe"));
+  }
+
+  /**
+   * Tests that getFullDartExePath returns the Windows UNC path for WSL SDKs.
+   */
+  @Test
+  public void testGetFullDartExePathWsl() {
+    requireWslSdk();
+
+    String fullPath = wslSdk.getFullDartExePath();
+    assertNotNull("getFullDartExePath should not return null for WSL SDK", fullPath);
+
+    // For WSL SDK, getFullDartExePath returns the UNC path (for display/file access)
+    assertTrue("WSL full dart exe path should end with /bin/dart",
+               fullPath.endsWith("/bin/dart"));
+  }
+
+  /**
+   * Tests that getPubPath returns a Linux path for WSL SDKs.
+   */
+  @Test
+  public void testGetPubPathWsl() {
+    requireWslSdk();
+
+    String pubPath = wslSdk.getPubPath();
+    assertNotNull("getPubPath should not return null for WSL SDK", pubPath);
+
+    // WSL SDK should return a Linux-style path
+    assertTrue("WSL pub path should be a Linux path (start with /)",
+               pubPath.startsWith("/"));
+    assertTrue("WSL pub path should end with /bin/pub",
+               pubPath.endsWith("/bin/pub"));
+    assertFalse("WSL pub should not have .bat extension",
+                pubPath.endsWith(".bat"));
+  }
+
+  /**
+   * Tests that getFullPubPath returns the Windows UNC path for WSL SDKs.
+   */
+  @Test
+  public void testGetFullPubPathWsl() {
+    requireWslSdk();
+
+    String fullPubPath = wslSdk.getFullPubPath();
+    assertNotNull("getFullPubPath should not return null for WSL SDK", fullPubPath);
+
+    assertTrue("WSL full pub path should end with /bin/pub",
+               fullPubPath.endsWith("/bin/pub"));
+  }
+
+  /**
+   * Tests that getIDEFilePath converts Linux paths to Windows UNC paths for WSL SDKs.
+   */
+  @Test
+  public void testGetIDEFilePathWsl() {
+    requireWslSdk();
+    assertNotNull("wslDistribution should not be null", wslDistribution);
+
+    String linuxPath = "/home/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
+    String result = wslSdk.getIDEFilePath(linuxPath);
+
+    assertNotNull("getIDEFilePath should not return null for WSL SDK", result);
+
+    // The result should be a Windows UNC path
+    String expected = wslDistribution.getWindowsPath(linuxPath);
+    assertEquals("getIDEFilePath should convert Linux path to Windows UNC path", expected, result);
+  }
+
+  /**
+   * Tests that getLocalFilePath converts WSL UNC paths to Linux paths for WSL SDKs.
+   */
+  @Test
+  public void testGetLocalFilePathWsl() {
+    requireWslSdk();
+    assertNotNull("wslDistribution should not be null", wslDistribution);
+
+    // Test with a WSL UNC path
+    String wslUncPath = "\\\\wsl$\\Ubuntu\\home\\user\\project\\lib\\main.dart";
+    String result = wslSdk.getLocalFilePath(wslUncPath);
+
+    assertNotNull("getLocalFilePath should not return null for WSL SDK", result);
+
+    // The result should be a Linux path
+    assertTrue("WSL getLocalFilePath should return a Linux path (start with /)",
+               result.startsWith("/"));
+  }
+
+  /**
+   * Tests that getLocalFilePath returns non-WSL paths unchanged for WSL SDKs.
+   */
+  @Test
+  public void testGetLocalFilePathWslNonWslInput() {
+    requireWslSdk();
+
+    // Test with a non-WSL path (already a Linux path)
+    String linuxPath = "/home/user/project/lib/main.dart";
+    String result = wslSdk.getLocalFilePath(linuxPath);
+
+    assertEquals("WSL getLocalFilePath should return Linux path unchanged",
+                 linuxPath, result);
+  }
+
+  /**
+   * Tests that getDartCommandList includes WSL wrapper commands for WSL SDKs.
+   */
+  @Test
+  public void testGetDartCommandListWsl() {
+    requireWslSdk();
+
+    var commandList = wslSdk.getDartCommandList();
+    assertNotNull("getDartCommandList should not return null for WSL SDK", commandList);
+    assertFalse("Command list should not be empty", commandList.isEmpty());
+
+    // WSL command list should include wsl.exe or similar wrapper
+    String commands = String.join(" ", commandList);
+    assertTrue("WSL command list should include wsl",
+               commands.toLowerCase().contains("wsl"));
+  }
+
+  /**
+   * Tests that getDartSimpleCommandList includes WSL executable for WSL SDKs.
+   */
+  @Test
+  public void testGetDartSimpleCommandListWsl() {
+    requireWslSdk();
+
+    var commandList = wslSdk.getDartSimpleCommandList();
+    assertNotNull("getDartSimpleCommandList should not return null for WSL SDK", commandList);
+    assertFalse("Command list should not be empty", commandList.isEmpty());
+
+    // First command should be wsl.exe path
+    String firstCommand = commandList.get(0).toLowerCase();
+    assertTrue("First command should be wsl executable",
+               firstCommand.contains("wsl"));
   }
 }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/sdk/DartSdkWslTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/sdk/DartSdkWslTest.java
@@ -1,0 +1,163 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.sdk;
+
+import com.intellij.execution.wsl.WslPath;
+import com.intellij.openapi.util.SystemInfo;
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for WSL-related functionality in {@link DartSdk}.
+ * <p>
+ * These tests verify path conversion and WSL detection logic.
+ * Some tests are only meaningful on Windows where WSL is available.
+ */
+public class DartSdkWslTest extends TestCase {
+
+  // Sample WSL UNC paths for testing
+  private static final String WSL_UBUNTU_PATH = "\\\\wsl$\\Ubuntu\\usr\\lib\\dart";
+  private static final String WSL_DEBIAN_PATH = "\\\\wsl$\\Debian\\usr\\lib\\dart";
+  private static final String WSL_LOCALHOST_PATH = "\\\\wsl.localhost\\Ubuntu\\usr\\lib\\dart";
+
+  // Sample Windows paths
+  private static final String WINDOWS_PATH = "C:\\dart-sdk";
+  private static final String WINDOWS_PATH_WITH_SPACES = "C:\\Program Files\\Dart\\dart-sdk";
+
+  // Sample Linux paths
+  private static final String LINUX_PATH = "/usr/lib/dart";
+
+  /**
+   * Tests that WSL UNC paths are correctly identified as WSL paths.
+   * This test runs on all platforms but the actual WSL detection only works on Windows.
+   */
+  public void testWslPathDetection() {
+    if (!SystemInfo.isWindows) {
+      // On non-Windows platforms, WslPath.parseWindowsUncPath always returns null
+      assertNull(WslPath.parseWindowsUncPath(WSL_UBUNTU_PATH));
+      return;
+    }
+
+    // On Windows, WSL UNC paths should be detected
+    assertNotNull("Ubuntu WSL path should be detected", WslPath.parseWindowsUncPath(WSL_UBUNTU_PATH));
+    assertNotNull("Debian WSL path should be detected", WslPath.parseWindowsUncPath(WSL_DEBIAN_PATH));
+    assertNotNull("wsl.localhost path should be detected", WslPath.parseWindowsUncPath(WSL_LOCALHOST_PATH));
+
+    // Non-WSL paths should not be detected as WSL
+    assertNull("Windows path should not be detected as WSL", WslPath.parseWindowsUncPath(WINDOWS_PATH));
+    assertNull("Linux path should not be detected as WSL", WslPath.parseWindowsUncPath(LINUX_PATH));
+  }
+
+  /**
+   * Tests the fixLinuxPath utility method converts backslashes to forward slashes.
+   */
+  public void testFixLinuxPath() {
+    assertEquals("/home/user/project", fixLinuxPath("\\home\\user\\project"));
+    assertEquals("/home/user/project", fixLinuxPath("/home/user/project"));
+    assertEquals("home/user/project", fixLinuxPath("home\\user\\project"));
+    assertEquals("", fixLinuxPath(""));
+    assertEquals("/", fixLinuxPath("\\"));
+    assertEquals("a/b/c/d", fixLinuxPath("a\\b\\c\\d"));
+  }
+
+  /**
+   * Tests path construction for various SDK locations.
+   */
+  public void testDartExePathConstruction() {
+    // Test Windows path construction
+    String windowsSdkHome = "C:\\dart-sdk";
+    String expectedWindowsExe = windowsSdkHome + "/bin/dart.exe";
+    assertEquals(expectedWindowsExe, constructDartExePath(windowsSdkHome, false, false));
+
+    // Test Linux path construction
+    String linuxSdkHome = "/usr/lib/dart";
+    String expectedLinuxExe = linuxSdkHome + "/bin/dart";
+    assertEquals(expectedLinuxExe, constructDartExePath(linuxSdkHome, false, true));
+
+    // Test WSL path construction (returns Linux path for execution)
+    String wslSdkHome = "\\\\wsl$\\Ubuntu\\usr\\lib\\dart";
+    // For WSL, getDartExePath returns the Linux path for command execution
+    // The actual path would be converted by the WSL distribution
+  }
+
+  /**
+   * Tests that package paths from package_config.json are correctly handled.
+   */
+  public void testPackagePathFormats() {
+    // Test file:// URI parsing
+    String fileUri = "file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
+    String expectedPath = "/home/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
+    assertEquals(expectedPath, extractPathFromFileUri(fileUri));
+
+    // Test Windows file:// URI
+    String windowsFileUri = "file:///C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
+    String expectedWindowsPath = "C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
+    assertEquals(expectedWindowsPath, extractPathFromFileUri(windowsFileUri));
+
+    // Test relative path handling
+    String relativeUri = "../.pub-cache/hosted/pub.dev/meta-1.9.1";
+    assertFalse(relativeUri.startsWith("file:/"));
+  }
+
+  /**
+   * Tests edge cases in path handling.
+   */
+  public void testPathEdgeCases() {
+    // Empty path
+    assertEquals("", fixLinuxPath(""));
+
+    // Path with mixed separators
+    assertEquals("a/b/c/d", fixLinuxPath("a\\b/c\\d"));
+
+    // Path with spaces
+    assertEquals("/home/user/my project/lib", fixLinuxPath("\\home\\user\\my project\\lib"));
+
+    // Path with special characters
+    assertEquals("/home/user/project-name/lib", fixLinuxPath("\\home\\user\\project-name\\lib"));
+    assertEquals("/home/user/project_name/lib", fixLinuxPath("\\home\\user\\project_name\\lib"));
+  }
+
+  /**
+   * Tests that WslPath.isWslUncPath correctly identifies WSL UNC paths.
+   */
+  public void testIsWslUncPath() {
+    if (!SystemInfo.isWindows) {
+      // On non-Windows, these methods may behave differently
+      return;
+    }
+
+    assertTrue("Should detect \\\\wsl$ path", WslPath.isWslUncPath(WSL_UBUNTU_PATH));
+    assertTrue("Should detect \\\\wsl.localhost path", WslPath.isWslUncPath(WSL_LOCALHOST_PATH));
+    assertFalse("Should not detect Windows path as WSL", WslPath.isWslUncPath(WINDOWS_PATH));
+    assertFalse("Should not detect Linux path as WSL", WslPath.isWslUncPath(LINUX_PATH));
+  }
+
+  // Helper method that mirrors DartSdk.fixLinuxPath
+  private static String fixLinuxPath(String path) {
+    return path.replace('\\', '/');
+  }
+
+  // Helper method to construct dart exe path based on platform
+  private static String constructDartExePath(String homePath, boolean isWsl, boolean isLinux) {
+    if (isWsl) {
+      // For WSL, would use distribution.getWslPath()
+      return homePath + "/bin/dart";
+    }
+    if (isLinux || !SystemInfo.isWindows) {
+      return homePath + "/bin/dart";
+    }
+    return homePath + "/bin/dart.exe";
+  }
+
+  // Helper method to extract path from file:// URI
+  private static String extractPathFromFileUri(String uri) {
+    if (!uri.startsWith("file:/")) {
+      return uri;
+    }
+    // Remove file:// or file:/// prefix
+    String path = uri.substring("file://".length());
+    if (path.startsWith("/") && path.length() > 2 && path.charAt(2) == ':') {
+      // Windows path like /C:/... - remove leading /
+      path = path.substring(1);
+    }
+    return path;
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/lang/dart/util/PackageConfigFileUtilTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/util/PackageConfigFileUtilTest.java
@@ -2,153 +2,206 @@
 package com.jetbrains.lang.dart.util;
 
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.io.OSAgnosticPathUtil;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.io.URLUtil;
 import junit.framework.TestCase;
 
 /**
- * Unit tests for package configuration file utilities.
+ * Unit tests for {@link PackageConfigFileUtil}.
  * <p>
  * Tests path parsing and conversion for package_config.json files,
- * including WSL path handling scenarios.
+ * including WSL path handling scenarios. These tests use the actual
+ * production utility classes from IntelliJ platform.
+ * <p>
+ * Note: Tests for {@link PackageConfigFileUtil#getAbsolutePackageRootPath}
+ * require VirtualFile instances and are better suited for integration tests.
+ * This test class focuses on the utility methods used by that code path.
  */
 public class PackageConfigFileUtilTest extends TestCase {
 
   /**
-   * Tests parsing of file:// URIs from package_config.json.
+   * Tests URLUtil.decode which is used in production code for URI decoding.
+   * This is the same decoding logic used in loadPackagesMapFromJson.
    */
-  public void testFileUriParsing() {
-    // Standard Linux file URI
-    assertEquals("/home/user/.pub-cache/hosted/pub.dev/meta-1.9.1",
-                 parseFileUri("file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1"));
-
-    // Windows file URI with drive letter
-    if (SystemInfo.isWindows) {
-      // On Windows, the path should preserve the drive letter
-      String windowsPath = parseFileUri("file:///C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1");
-      assertTrue("Windows path should contain drive letter",
-                 windowsPath.contains("C:") || windowsPath.contains("c:"));
-    }
-
-    // File URI with encoded characters
-    assertEquals("/home/user/.pub-cache/hosted/pub.dev/some+package-1.0.0",
-                 parseFileUri("file:///home/user/.pub-cache/hosted/pub.dev/some%2Bpackage-1.0.0"));
+  public void testUrlDecoding() {
+    // Test basic URL decoding (used in PackageConfigFileUtil.loadPackagesMapFromJson)
+    assertEquals("some+package-1.0.0", URLUtil.decode("some%2Bpackage-1.0.0"));
+    assertEquals("/home/user/.pub-cache", URLUtil.decode("/home/user/.pub-cache"));
+    assertEquals("path with spaces", URLUtil.decode("path%20with%20spaces"));
   }
 
   /**
-   * Tests handling of relative URIs in package_config.json.
+   * Tests the + character protection used in loadPackagesMapFromJson.
+   * The code protects + chars by encoding them before decoding.
    */
-  public void testRelativeUriHandling() {
-    // Relative path should not start with file:/
-    String relativeUri = "../.dart_tool/package_config.json";
-    assertFalse("Relative URI should not start with file:/", relativeUri.startsWith("file:/"));
+  public void testPlusCharacterProtection() {
+    // This mimics the production code in loadPackagesMapFromJson:
+    // final String encodedUriWithoutPluses = StringUtil.replace(rootUriValue + "/" + packageUriValue, "+", "%2B");
+    // final String uri = URLUtil.decode(encodedUriWithoutPluses);
 
-    // Another common relative path pattern
-    String libRelative = "../lib/";
-    assertFalse("Lib relative path should not start with file:/", libRelative.startsWith("file:/"));
+    String originalUri = "file:///home/user/.pub-cache/some+package-1.0.0/lib/";
+    String protectedUri = StringUtil.replace(originalUri, "+", "%2B");
+    String decodedUri = URLUtil.decode(protectedUri);
+
+    // The + should be preserved after protect + decode cycle
+    assertEquals("Plus should be preserved", originalUri, decodedUri);
+
+    // Without protection, + would be decoded to space
+    String directDecode = URLUtil.decode(originalUri);
+    assertTrue("Without protection, + might be mishandled",
+               directDecode.contains("+") || directDecode.contains(" "));
   }
 
   /**
-   * Tests the path trimming logic used in getAbsolutePackageRootPath.
+   * Tests StringUtil.trimStart and trimLeading used in getAbsolutePackageRootPath.
    */
-  public void testPathTrimming() {
-    // Test trimming of file:/ prefix and leading/trailing slashes
-    String uri = "file:///home/user/.pub-cache/";
-    String pathAfterSlashes = trimFilePrefix(uri);
-    assertEquals("home/user/.pub-cache", pathAfterSlashes);
+  public void testFileUriTrimming() {
+    // This mimics the production code:
+    // final String pathAfterSlashes = StringUtil.trimEnd(StringUtil.trimLeading(StringUtil.trimStart(uri, "file:/"), '/'), "/");
 
-    // Windows-style file URI
-    String windowsUri = "file:///C:/Users/user/.pub-cache/";
-    String windowsPath = trimFilePrefix(windowsUri);
-    assertEquals("C:/Users/user/.pub-cache", windowsPath);
+    String fileUri = "file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1/";
+    String afterTrimStart = StringUtil.trimStart(fileUri, "file:/");
+    String afterTrimLeading = StringUtil.trimLeading(afterTrimStart, '/');
+    String pathAfterSlashes = StringUtil.trimEnd(afterTrimLeading, "/");
+
+    assertEquals("home/user/.pub-cache/hosted/pub.dev/meta-1.9.1", pathAfterSlashes);
+
+    // Test Windows file URI
+    String windowsFileUri = "file:///C:/Users/user/.pub-cache/";
+    afterTrimStart = StringUtil.trimStart(windowsFileUri, "file:/");
+    afterTrimLeading = StringUtil.trimLeading(afterTrimStart, '/');
+    pathAfterSlashes = StringUtil.trimEnd(afterTrimLeading, "/");
+
+    assertEquals("C:/Users/user/.pub-cache", pathAfterSlashes);
   }
 
   /**
-   * Tests detection of Windows drive letters in paths.
+   * Tests OSAgnosticPathUtil.startsWithWindowsDrive used in getAbsolutePackageRootPath.
    */
   public void testWindowsDriveDetection() {
-    assertTrue("Should detect C: drive", startsWithWindowsDrive("C:/Users/user"));
-    assertTrue("Should detect D: drive", startsWithWindowsDrive("D:/dart-sdk"));
-    assertTrue("Should detect lowercase drive", startsWithWindowsDrive("c:/users/user"));
+    // Production code uses: OSAgnosticPathUtil.startsWithWindowsDrive(pathAfterSlashes)
+    assertTrue("Should detect C: drive", OSAgnosticPathUtil.startsWithWindowsDrive("C:/Users/user"));
+    assertTrue("Should detect D: drive", OSAgnosticPathUtil.startsWithWindowsDrive("D:/dart-sdk"));
+    assertTrue("Should detect lowercase drive", OSAgnosticPathUtil.startsWithWindowsDrive("c:/users/user"));
 
-    assertFalse("Should not detect Linux path", startsWithWindowsDrive("/home/user"));
-    assertFalse("Should not detect relative path", startsWithWindowsDrive("../lib"));
-    assertFalse("Should not detect short path", startsWithWindowsDrive("C"));
-    assertFalse("Should not detect UNC path", startsWithWindowsDrive("\\\\wsl$\\Ubuntu"));
+    assertFalse("Should not detect Linux path", OSAgnosticPathUtil.startsWithWindowsDrive("/home/user"));
+    assertFalse("Should not detect relative path", OSAgnosticPathUtil.startsWithWindowsDrive("../lib"));
+    assertFalse("Should not detect short path", OSAgnosticPathUtil.startsWithWindowsDrive("C"));
+    assertFalse("Should not detect single char", OSAgnosticPathUtil.startsWithWindowsDrive("a"));
   }
 
   /**
-   * Tests package URI construction.
+   * Tests the complete file URI parsing logic as used in getAbsolutePackageRootPath.
+   * This tests the production code path for non-WSL, non-Windows scenarios.
    */
-  public void testPackageUriConstruction() {
+  public void testFileUriParsingNonWindows() {
+    if (SystemInfo.isWindows) {
+      // This test is for non-Windows behavior
+      return;
+    }
+
+    String fileUri = "file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1/lib/";
+
+    // Simulate production code path
+    String pathAfterSlashes = StringUtil.trimEnd(
+        StringUtil.trimLeading(
+            StringUtil.trimStart(fileUri, "file:/"),
+            '/'),
+        "/");
+
+    // On non-Windows, the path gets a leading slash added back
+    String expectedPath = "/" + pathAfterSlashes;
+    assertEquals("/home/user/.pub-cache/hosted/pub.dev/meta-1.9.1/lib", expectedPath);
+  }
+
+  /**
+   * Tests the complete file URI parsing logic for Windows paths.
+   */
+  public void testFileUriParsingWindows() {
+    String fileUri = "file:///C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1/lib/";
+
+    // Simulate production code path
+    String pathAfterSlashes = StringUtil.trimEnd(
+        StringUtil.trimLeading(
+            StringUtil.trimStart(fileUri, "file:/"),
+            '/'),
+        "/");
+
+    // Check if it's a Windows drive path
+    assertTrue("Should detect Windows drive",
+               OSAgnosticPathUtil.startsWithWindowsDrive(pathAfterSlashes));
+
+    // On Windows with a drive letter, the path is returned as-is
+    assertEquals("C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1/lib", pathAfterSlashes);
+  }
+
+  /**
+   * Tests handling of relative URIs (no file:/ prefix).
+   */
+  public void testRelativeUriHandling() {
+    // Relative URIs don't start with file:/
+    String relativeUri = "../lib/";
+    assertFalse("Relative URI should not start with file:/", relativeUri.startsWith("file:/"));
+
+    String localPackageUri = "../";
+    assertFalse("Local package URI should not start with file:/", localPackageUri.startsWith("file:/"));
+
+    // The production code handles these by combining with baseDir.getPath()
+    // For unit testing, we just verify the detection logic
+  }
+
+  /**
+   * Tests that the constants used in production code are correct.
+   */
+  public void testPackageConfigConstants() {
+    assertEquals(".dart_tool", PackageConfigFileUtil.DART_TOOL_DIR);
+    assertEquals("package_config.json", PackageConfigFileUtil.PACKAGE_CONFIG_JSON);
+  }
+
+  /**
+   * Tests URI combining as done in loadPackagesMapFromJson.
+   */
+  public void testUriCombining() {
+    // Production code: rootUriValue + "/" + packageUriValue
     String rootUri = "file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
     String packageUri = "lib/";
     String combined = rootUri + "/" + packageUri;
 
-    assertTrue("Combined URI should point to lib directory",
-               combined.endsWith("/lib/"));
-    assertTrue("Combined URI should be a file URI",
-               combined.startsWith("file://"));
+    assertEquals("file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1/lib/", combined);
+
+    // Test with trailing slash on rootUri
+    String rootUriWithSlash = "file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1/";
+    combined = rootUriWithSlash + "/" + packageUri;
+
+    // This results in double slash, which the trim logic handles
+    assertTrue("Should contain lib directory", combined.contains("/lib/"));
   }
 
   /**
-   * Tests handling of encoded characters in URIs.
-   * The + character needs special handling as URLDecoder replaces + with space.
+   * Tests edge cases in path parsing.
    */
-  public void testEncodedCharacterHandling() {
-    // The plugin protects + chars by encoding them before decoding
-    String uriWithPlus = "file:///home/user/.pub-cache/some+package-1.0.0";
-    String protected_uri = StringUtil.replace(uriWithPlus, "+", "%2B");
-    assertTrue("Protected URI should contain %2B", protected_uri.contains("%2B"));
-    assertFalse("Protected URI should not contain +", protected_uri.contains("+"));
-  }
+  public void testPathEdgeCases() {
+    // Empty string handling
+    assertEquals("", StringUtil.trimStart("", "file:/"));
+    assertEquals("", StringUtil.trimLeading("", '/'));
+    assertEquals("", StringUtil.trimEnd("", "/"));
 
-  // Helper method that mimics the file URI parsing logic
-  private static String parseFileUri(String uri) {
-    if (!uri.startsWith("file:/")) {
-      return uri;
-    }
+    // Only file:/ prefix
+    String pathAfterSlashes = StringUtil.trimEnd(
+        StringUtil.trimLeading(
+            StringUtil.trimStart("file:/", "file:/"),
+            '/'),
+        "/");
+    assertEquals("", pathAfterSlashes);
 
-    // Trim file:/ prefix
-    String path = uri.substring("file:/".length());
-
-    // Trim leading slashes
-    while (path.startsWith("/")) {
-      path = path.substring(1);
-    }
-
-    // URL decode
-    path = java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8);
-
-    // For non-Windows absolute paths, add leading slash back
-    if (!startsWithWindowsDrive(path)) {
-      path = "/" + path;
-    }
-
-    return path;
-  }
-
-  // Helper that mimics the trimming logic in PackageConfigFileUtil
-  private static String trimFilePrefix(String uri) {
-    if (!uri.startsWith("file:/")) {
-      return uri;
-    }
-    String result = uri.substring("file:/".length());
-    // Trim leading slashes
-    while (result.startsWith("/")) {
-      result = result.substring(1);
-    }
-    // Trim trailing slash
-    if (result.endsWith("/")) {
-      result = result.substring(0, result.length() - 1);
-    }
-    return result;
-  }
-
-  // Helper that checks for Windows drive letter
-  private static boolean startsWithWindowsDrive(String path) {
-    if (path.length() < 2) return false;
-    char first = path.charAt(0);
-    char second = path.charAt(1);
-    return ((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z')) && second == ':';
+    // Path with special characters (but not +)
+    String specialPath = "file:///home/user/my-project_v1.0/lib/";
+    pathAfterSlashes = StringUtil.trimEnd(
+        StringUtil.trimLeading(
+            StringUtil.trimStart(specialPath, "file:/"),
+            '/'),
+        "/");
+    assertEquals("home/user/my-project_v1.0/lib", pathAfterSlashes);
   }
 }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/util/PackageConfigFileUtilTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/util/PackageConfigFileUtilTest.java
@@ -1,0 +1,154 @@
+// Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.util;
+
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.text.StringUtil;
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for package configuration file utilities.
+ * <p>
+ * Tests path parsing and conversion for package_config.json files,
+ * including WSL path handling scenarios.
+ */
+public class PackageConfigFileUtilTest extends TestCase {
+
+  /**
+   * Tests parsing of file:// URIs from package_config.json.
+   */
+  public void testFileUriParsing() {
+    // Standard Linux file URI
+    assertEquals("/home/user/.pub-cache/hosted/pub.dev/meta-1.9.1",
+                 parseFileUri("file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1"));
+
+    // Windows file URI with drive letter
+    if (SystemInfo.isWindows) {
+      // On Windows, the path should preserve the drive letter
+      String windowsPath = parseFileUri("file:///C:/Users/user/.pub-cache/hosted/pub.dev/meta-1.9.1");
+      assertTrue("Windows path should contain drive letter",
+                 windowsPath.contains("C:") || windowsPath.contains("c:"));
+    }
+
+    // File URI with encoded characters
+    assertEquals("/home/user/.pub-cache/hosted/pub.dev/some+package-1.0.0",
+                 parseFileUri("file:///home/user/.pub-cache/hosted/pub.dev/some%2Bpackage-1.0.0"));
+  }
+
+  /**
+   * Tests handling of relative URIs in package_config.json.
+   */
+  public void testRelativeUriHandling() {
+    // Relative path should not start with file:/
+    String relativeUri = "../.dart_tool/package_config.json";
+    assertFalse("Relative URI should not start with file:/", relativeUri.startsWith("file:/"));
+
+    // Another common relative path pattern
+    String libRelative = "../lib/";
+    assertFalse("Lib relative path should not start with file:/", libRelative.startsWith("file:/"));
+  }
+
+  /**
+   * Tests the path trimming logic used in getAbsolutePackageRootPath.
+   */
+  public void testPathTrimming() {
+    // Test trimming of file:/ prefix and leading/trailing slashes
+    String uri = "file:///home/user/.pub-cache/";
+    String pathAfterSlashes = trimFilePrefix(uri);
+    assertEquals("home/user/.pub-cache", pathAfterSlashes);
+
+    // Windows-style file URI
+    String windowsUri = "file:///C:/Users/user/.pub-cache/";
+    String windowsPath = trimFilePrefix(windowsUri);
+    assertEquals("C:/Users/user/.pub-cache", windowsPath);
+  }
+
+  /**
+   * Tests detection of Windows drive letters in paths.
+   */
+  public void testWindowsDriveDetection() {
+    assertTrue("Should detect C: drive", startsWithWindowsDrive("C:/Users/user"));
+    assertTrue("Should detect D: drive", startsWithWindowsDrive("D:/dart-sdk"));
+    assertTrue("Should detect lowercase drive", startsWithWindowsDrive("c:/users/user"));
+
+    assertFalse("Should not detect Linux path", startsWithWindowsDrive("/home/user"));
+    assertFalse("Should not detect relative path", startsWithWindowsDrive("../lib"));
+    assertFalse("Should not detect short path", startsWithWindowsDrive("C"));
+    assertFalse("Should not detect UNC path", startsWithWindowsDrive("\\\\wsl$\\Ubuntu"));
+  }
+
+  /**
+   * Tests package URI construction.
+   */
+  public void testPackageUriConstruction() {
+    String rootUri = "file:///home/user/.pub-cache/hosted/pub.dev/meta-1.9.1";
+    String packageUri = "lib/";
+    String combined = rootUri + "/" + packageUri;
+
+    assertTrue("Combined URI should point to lib directory",
+               combined.endsWith("/lib/"));
+    assertTrue("Combined URI should be a file URI",
+               combined.startsWith("file://"));
+  }
+
+  /**
+   * Tests handling of encoded characters in URIs.
+   * The + character needs special handling as URLDecoder replaces + with space.
+   */
+  public void testEncodedCharacterHandling() {
+    // The plugin protects + chars by encoding them before decoding
+    String uriWithPlus = "file:///home/user/.pub-cache/some+package-1.0.0";
+    String protected_uri = StringUtil.replace(uriWithPlus, "+", "%2B");
+    assertTrue("Protected URI should contain %2B", protected_uri.contains("%2B"));
+    assertFalse("Protected URI should not contain +", protected_uri.contains("+"));
+  }
+
+  // Helper method that mimics the file URI parsing logic
+  private static String parseFileUri(String uri) {
+    if (!uri.startsWith("file:/")) {
+      return uri;
+    }
+
+    // Trim file:/ prefix
+    String path = uri.substring("file:/".length());
+
+    // Trim leading slashes
+    while (path.startsWith("/")) {
+      path = path.substring(1);
+    }
+
+    // URL decode
+    path = java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8);
+
+    // For non-Windows absolute paths, add leading slash back
+    if (!startsWithWindowsDrive(path)) {
+      path = "/" + path;
+    }
+
+    return path;
+  }
+
+  // Helper that mimics the trimming logic in PackageConfigFileUtil
+  private static String trimFilePrefix(String uri) {
+    if (!uri.startsWith("file:/")) {
+      return uri;
+    }
+    String result = uri.substring("file:/".length());
+    // Trim leading slashes
+    while (result.startsWith("/")) {
+      result = result.substring(1);
+    }
+    // Trim trailing slash
+    if (result.endsWith("/")) {
+      result = result.substring(0, result.length() - 1);
+    }
+    return result;
+  }
+
+  // Helper that checks for Windows drive letter
+  private static boolean startsWithWindowsDrive(String path) {
+    if (path.length() < 2) return false;
+    char first = path.charAt(0);
+    char second = path.charAt(1);
+    return ((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z')) && second == ':';
+  }
+}


### PR DESCRIPTION
## Description

Adds Windows Subsystem for Linux (WSL) support to the Dart IntelliJ plugin, enabling full Dart development workflows (project creation, dependency management, code analysis, debugging, test execution) when using a Dart SDK installed inside a WSL distribution.

### Core Changes

**`DartSdk.java` — WSL-aware SDK abstraction**
- Detects WSL SDKs by parsing Windows UNC paths (`\\wsl$\Ubuntu\...` or `\\wsl.localhost\Ubuntu\...`)
- Translates paths between Windows UNC format (for IDE/file system access) and Linux format (for command execution inside WSL)
- Wraps command execution via `WSLDistribution.patchCommandLine()` and `executeOnWsl()`
- Generates proper `file://` URIs for the Dart Analysis Server protocol (SDK 3.4+ `supportsUris`)

**Command execution & threading**
- `DartPubActionBase.kt`: Moves process creation to background threads (required by `WSLDistribution.patchCommandLine()`), with EDT marshaling for save/refresh operations
- Runner files (`DartCommandLineRunningState`, `DartTestRunningState`, `VmServiceWrapper`): Patch command lines for WSL execution
- `DartCreate.java`: WSL-aware project scaffolding with Linux-style paths

**Project wizard**
- `DartModuleBuilder`, `DartGeneratorPeer`, `DartProjectTemplate`: Background initialization and template loading to support WSL file operations without blocking the UI

**Package resolution**
- `PackageConfigFileUtil.java`: Converts Linux paths from `package_config.json` to Windows UNC paths for WSL SDKs via `sdk.getIDEFilePath()`

**Analysis server integration**
- `DartAnalysisServerService.java`, `DartFileInfo.kt`: Enhanced file URI handling for non-local files and WSL paths, supporting SDK 3.4+ URI protocol

### Testing

- **`DartSdkWslTest.java`**: JUnit 4 tests covering WSL path detection, path translation, executable paths, command list generation, and file URIs. Uses `Assume.assumeTrue()` to skip gracefully when `WSL_DART_SDK` is not set.
- **`PackageConfigFileUtilTest.java`**: Tests for URL decoding, file URI parsing, Windows drive detection, and path canonicalization.
- **`build.gradle.kts`**: Reads `WSL_DART_SDK` env var and passes it as `-Dwsl.dart.sdk` JVM arg to tests.
- **`presubmit.yaml`**: New `wsl-dart-tests` CI job on `windows-latest` that installs WSL Ubuntu + Dart SDK and runs the WSL test suite.

| Environment | WSL test behavior |
|---|---|
| Unit-tests CI job (no `WSL_DART_SDK`) | Tests skipped/ignored |
| WSL CI job (`WSL_DART_SDK` set) | Tests run with real WSL SDK |
| Local dev without WSL | Tests skipped, Gradle warns |
| Local dev with WSL | Set `WSL_DART_SDK`, tests run |

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
