### PR TITLE
Update until build to 261 so plugin can be used on 2026.1

### DIFF
--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -16,7 +16,7 @@ pluginVersion = 502.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251
-pluginUntilBuild = 253.*
+pluginUntilBuild = 261.*
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.13


### PR DESCRIPTION
IntelliJ IDEA 2026.1 was just released as preview Jan 19 so I expect probably not used much yet.

Needed for https://github.com/flutter/dart-intellij-third-party/pull/246