### PR TITLE
[fix] downgrade kotlin to be compatible w/ a 2.1.0 compiler

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -17,7 +17,7 @@ allprojects {
 // Plugins - must be first
 plugins {
     id("java") // Java support
-    id("org.jetbrains.kotlin.jvm") version "2.3.0" // Kotlin support
+    id("org.jetbrains.kotlin.jvm") version "2.2.21" // Kotlin support
     id("org.jetbrains.intellij.platform") version "2.10.5" // IntelliJ Platform Gradle Plugin
     id("org.jetbrains.changelog") version "2.2.0" // Gradle Changelog Plugin
     id("org.jetbrains.kotlinx.kover") version "0.9.4" // Kover Code Coverage Plugin


### PR DESCRIPTION
The newer version of kotlin produces class files that are not compatible with Android Studio's kotlin compiler causing exceptions in the Flutter Plugin. See: https://github.com/flutter/flutter-intellij/issues/8729

(This reverts part of https://github.com/flutter/dart-intellij-third-party/commit/c2aab1b16676a1075bc2e132a2dae508bd7072e5; fyi @parlough)


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
