### PR TITLE
[fix] rethrow `ProcessCanceledException`s

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -28,6 +28,7 @@ import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.fileEditor.impl.FileOffsetsManager;
 import com.intellij.openapi.fileTypes.FileTypeRegistry;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
@@ -2259,8 +2260,11 @@ public final class DartAnalysisServerService implements Disposable {
         }
       }
       catch (Exception e) {
-        LOG.warn("Failed to start Dart analysis server", e);
         stopServer();
+        // `ProcessCanceledException`s need to be rethrown and not logged
+        // https://github.com/flutter/dart-intellij-third-party/issues/263
+        if (e instanceof ProcessCanceledException) throw (ProcessCanceledException)e;
+        LOG.warn("Failed to start Dart analysis server", e);
       }
     }
   }


### PR DESCRIPTION
Rethrow (and don't log) `ProcessCanceledException`s.

Fixes: #263

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
