### PR TITLE
Update changelog with changes since 502

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Stale `helpTopic` and `helpId` references (#232, #227)
 
 ### Fixed
-- Rethrow `ProcessCanceledException` during refactorings (#264)
+- Improved cancellation handling for refactoring operations to prevent potential UI freezes (#264)
 - Keep New Project dialog details in sync with the selected Dart SDK (#215)
 - Downgrade Kotlin to be compatible with a 2.1.0 compiler (#254)
 


### PR DESCRIPTION
The text is mostly generated by gemini with some suggestions from me on how to categorize. I sanity checked that all the PRs mentioned match the generated summaries and are indeed merged since 502 was released.