### PR TITLE
Secret gist translate refactor

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -111,7 +111,6 @@ dependencies {
 
     implementation(fileTree("lib") { include("*.jar") })
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1")
-    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.23.1")
 
     testImplementation("junit:junit:4.13.2")
 }

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("org.jetbrains.intellij.platform") version "2.10.5" // IntelliJ Platform Gradle Plugin
     id("org.jetbrains.changelog") version "2.2.0" // Gradle Changelog Plugin
     id("org.jetbrains.kotlinx.kover") version "0.9.4" // Kover Code Coverage Plugin
+    id("org.jlleitschuh.gradle.ktlint") version "12.3.0" // Kotlin linter and formatter
 }
 
 // Configure project's dependencies
@@ -64,6 +65,14 @@ intellijPlatform {
         subsystemsToCheck = VerifyPluginTask.Subsystems.ALL
         ides {
             recommended()
+        }
+    }
+}
+
+ktlint {
+    filter {
+        exclude { element ->
+            !element.isDirectory && !element.file.absolutePath.contains("/dart/analyzer/lsp/")
         }
     }
 }

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
     }
 
     implementation(fileTree("lib") { include("*.jar") })
+    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1")
+    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.23.1")
 
     testImplementation("junit:junit:4.13.2")
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -4,15 +4,11 @@ package com.jetbrains.lang.dart.analyzer;
 import com.google.common.collect.EvictingQueue;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.dart.server.*;
-import com.google.dart.server.generated.AnalysisServer;
 import com.google.dart.server.internal.remote.DebugPrintStream;
-import com.google.dart.server.internal.remote.RemoteAnalysisServerImpl;
-import com.google.dart.server.internal.remote.StdioServerSocket;
 import com.google.dart.server.utilities.logging.Logging;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.CodeInsightSettings;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.application.ModalityState;
@@ -102,7 +98,6 @@ public final class DartAnalysisServerService implements Disposable {
   private static final long UPDATE_FILES_TIMEOUT = 300;
 
   private static final long CHECK_CANCELLED_PERIOD = 10;
-  private static final long SEND_REQUEST_TIMEOUT = TimeUnit.SECONDS.toMillis(1);
   private static final long EDIT_FORMAT_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
   private static final long EDIT_ORGANIZE_DIRECTIVES_TIMEOUT = TimeUnit.MILLISECONDS.toMillis(300);
   private static final long EDIT_SORT_MEMBERS_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
@@ -139,8 +134,7 @@ public final class DartAnalysisServerService implements Disposable {
 
   // Do not wait for server response under lock. Do not take read/write action under lock.
   private final Object myLock = new Object();
-  private @Nullable RemoteAnalysisServerImpl myServer;
-  private @Nullable StdioServerSocket myServerSocket;
+  private @Nullable DartClient myClient;
 
   private @NotNull String myServerVersion = "";
   private @NotNull String mySdkVersion = "";
@@ -182,10 +176,6 @@ public final class DartAnalysisServerService implements Disposable {
 
   public static String getClientId() {
     return ApplicationNamesInfo.getInstance().getFullProductName().replace(' ', '-');
-  }
-
-  private static String getClientVersion() {
-    return ApplicationInfo.getInstance().getApiVersion();
   }
 
   private final @NotNull List<AnalysisServerListener> myAdditionalServerListeners = new SmartList<>();
@@ -333,8 +323,8 @@ public final class DartAnalysisServerService implements Disposable {
       myServerVersion = version != null ? version : "";
       // completion_setSubscriptions() are handled here instead of in startServer() as the server version isn't known until this
       // serverConnected() call.
-      if (myServer != null && !shouldUseCompletion2()) {
-        myServer.completion_setSubscriptions(List.of(CompletionService.AVAILABLE_SUGGESTION_SETS));
+      if (myClient != null && !shouldUseCompletion2()) {
+        myClient.completion_setSubscriptions(List.of(CompletionService.AVAILABLE_SUGGESTION_SETS));
       }
     }
 
@@ -585,8 +575,8 @@ public final class DartAnalysisServerService implements Disposable {
   public void addAnalysisServerListener(final @NotNull AnalysisServerListener serverListener) {
     if (!myAdditionalServerListeners.contains(serverListener)) {
       myAdditionalServerListeners.add(serverListener);
-      if (myServer != null && isServerProcessActive()) {
-        myServer.addAnalysisServerListener(serverListener);
+      if (myClient != null && isServerProcessActive()) {
+        myClient.addAnalysisServerListener(serverListener);
       }
     }
   }
@@ -594,8 +584,8 @@ public final class DartAnalysisServerService implements Disposable {
   @SuppressWarnings("unused") // for Flutter plugin
   public void removeAnalysisServerListener(final @NotNull AnalysisServerListener serverListener) {
     myAdditionalServerListeners.remove(serverListener);
-    if (myServer != null) {
-      myServer.removeAnalysisServerListener(serverListener);
+    if (myClient != null) {
+      myClient.removeAnalysisServerListener(serverListener);
     }
   }
 
@@ -603,8 +593,8 @@ public final class DartAnalysisServerService implements Disposable {
   public void addRequestListener(final @NotNull RequestListener requestListener) {
     if (!myRequestListeners.contains(requestListener)) {
       myRequestListeners.add(requestListener);
-      if (myServer != null && isServerProcessActive()) {
-        myServer.addRequestListener(requestListener);
+      if (myClient != null && isServerProcessActive()) {
+        myClient.addRequestListener(requestListener);
       }
     }
   }
@@ -612,8 +602,8 @@ public final class DartAnalysisServerService implements Disposable {
   @SuppressWarnings("unused") // for Flutter plugin
   public void removeRequestListener(final @NotNull RequestListener requestListener) {
     myRequestListeners.remove(requestListener);
-    if (myServer != null) {
-      myServer.removeRequestListener(requestListener);
+    if (myClient != null) {
+      myClient.removeRequestListener(requestListener);
     }
   }
 
@@ -621,8 +611,8 @@ public final class DartAnalysisServerService implements Disposable {
   public void addResponseListener(final @NotNull ResponseListener responseListener) {
     if (!myResponseListeners.contains(responseListener)) {
       myResponseListeners.add(responseListener);
-      if (myServer != null && isServerProcessActive()) {
-        myServer.addResponseListener(responseListener);
+      if (myClient != null && isServerProcessActive()) {
+        myClient.addResponseListener(responseListener);
       }
     }
   }
@@ -630,8 +620,8 @@ public final class DartAnalysisServerService implements Disposable {
   @SuppressWarnings("unused") // for Flutter plugin
   public void removeResponseListener(final @NotNull ResponseListener responseListener) {
     myResponseListeners.remove(responseListener);
-    if (myServer != null) {
-      myServer.removeResponseListener(responseListener);
+    if (myClient != null) {
+      myClient.removeResponseListener(responseListener);
     }
   }
 
@@ -752,7 +742,7 @@ public final class DartAnalysisServerService implements Disposable {
     final DocumentListener documentListener = new DocumentListener() {
       @Override
       public void beforeDocumentChange(@NotNull DocumentEvent e) {
-        if (myServer == null) return;
+        if (myClient == null) return;
 
         myServerData.onDocumentChanged(e);
 
@@ -917,7 +907,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public void updateFilesContent() {
-    if (myServer != null) {
+    if (myClient != null) {
       ApplicationManager.getApplication().runReadAction(this::doUpdateFilesContent);
     }
   }
@@ -925,7 +915,7 @@ public final class DartAnalysisServerService implements Disposable {
   private void doUpdateFilesContent() {
     // may be use DocumentListener to collect deltas instead of sending the whole Document.getText() each time?
 
-    AnalysisServer server = myServer;
+    DartClient server = myClient;
     if (server == null) {
       return;
     }
@@ -999,7 +989,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   boolean setAnalysisRoots(@NotNull List<String> includedRootPaths, @NotNull List<String> excludedRootPaths) {
-    AnalysisServer server = myServer;
+    DartClient server = myClient;
     if (server == null) {
       return false;
     }
@@ -1072,7 +1062,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public @NotNull List<HoverInformation> analysis_getHover(final @NotNull VirtualFile file, final int _offset) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return HoverInformation.EMPTY_LIST;
     }
@@ -1107,7 +1097,7 @@ public final class DartAnalysisServerService implements Disposable {
   public @Nullable List<DartServerData.DartNavigationRegion> analysis_getNavigation(final @NotNull VirtualFile file,
                                                                                     final int _offset,
                                                                                     final int length) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1158,7 +1148,7 @@ public final class DartAnalysisServerService implements Disposable {
   public @NotNull List<SourceChange> edit_getAssists(final @NotNull VirtualFile file, final int _offset, final int _length) {
     if (!file.isInLocalFileSystem()) return Collections.emptyList();
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return Collections.emptyList();
     }
@@ -1195,7 +1185,7 @@ public final class DartAnalysisServerService implements Disposable {
   public boolean edit_isPostfixCompletionApplicable(VirtualFile file, int _offset, String key) {
     if (!file.isInLocalFileSystem()) return false;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return false;
     }
@@ -1218,7 +1208,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public PostfixTemplateDescriptor @Nullable [] edit_listPostfixCompletionTemplates() {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1253,7 +1243,7 @@ public final class DartAnalysisServerService implements Disposable {
   public @Nullable SourceChange edit_getPostfixCompletion(final @NotNull VirtualFile file, final int _offset, final String key) {
     if (!file.isInLocalFileSystem()) return null;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1287,7 +1277,7 @@ public final class DartAnalysisServerService implements Disposable {
   public @Nullable SourceChange edit_getStatementCompletion(final @NotNull VirtualFile file, final int _offset) {
     if (!file.isInLocalFileSystem()) return null;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1319,7 +1309,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public void diagnostic_getServerPort(GetServerPortConsumer consumer) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       consumer.onError(new RequestError(ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE,
                                         DartBundle.message("analysis.server.not.running"), null));
@@ -1341,7 +1331,7 @@ public final class DartAnalysisServerService implements Disposable {
       return;
     }
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       consumer.consume(Collections.emptyList());
       return;
@@ -1376,7 +1366,7 @@ public final class DartAnalysisServerService implements Disposable {
   public void search_findElementReferences(final @NotNull VirtualFile file,
                                            final int _offset,
                                            final @NotNull Consumer<? super SearchResult> consumer) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return;
     }
@@ -1439,7 +1429,7 @@ public final class DartAnalysisServerService implements Disposable {
                                                                   final int _offset,
                                                                   final boolean superOnly) {
     final List<TypeHierarchyItem> results = new ArrayList<>();
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return results;
     }
@@ -1475,7 +1465,7 @@ public final class DartAnalysisServerService implements Disposable {
                                                                               int _offset) {
     if (!file.isInLocalFileSystem()) return null;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1511,7 +1501,7 @@ public final class DartAnalysisServerService implements Disposable {
                                                                                @NotNull String libraryUri) {
     if (!file.isInLocalFileSystem()) return null;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1545,7 +1535,7 @@ public final class DartAnalysisServerService implements Disposable {
   public @Nullable String completion_getSuggestions(final @NotNull VirtualFile file, final int _offset) {
     if (!file.isInLocalFileSystem()) return null;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1592,7 +1582,7 @@ public final class DartAnalysisServerService implements Disposable {
                                                               final int invocationCount) {
     if (!file.isInLocalFileSystem()) return null;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1666,7 +1656,7 @@ public final class DartAnalysisServerService implements Disposable {
                                             final int lineLength) {
     if (!file.isInLocalFileSystem()) return null;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1709,7 +1699,7 @@ public final class DartAnalysisServerService implements Disposable {
   public @Nullable List<ImportedElements> analysis_getImportedElements(final @NotNull VirtualFile file,
                                                                        final int _selectionOffset,
                                                                        final int _selectionLength) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1748,7 +1738,7 @@ public final class DartAnalysisServerService implements Disposable {
   public @Nullable SourceFileEdit edit_importElements(final @NotNull VirtualFile file,
                                                       final @NotNull List<ImportedElements> importedElements,
                                                       final int _offset) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1792,7 +1782,7 @@ public final class DartAnalysisServerService implements Disposable {
                                      GetRefactoringConsumer consumer) {
     if (!file.isInLocalFileSystem()) return false;
 
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return false;
     }
@@ -1805,7 +1795,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public @Nullable SourceFileEdit edit_organizeDirectives(@NotNull String filePath) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1843,7 +1833,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public @Nullable SourceFileEdit edit_sortMembers(@NotNull String filePath) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -1883,7 +1873,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public void analysis_reanalyze() {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return;
     }
@@ -1895,19 +1885,19 @@ public final class DartAnalysisServerService implements Disposable {
 
   private void analysis_setPriorityFiles() {
     synchronized (myLock) {
-      if (myServer == null) return;
+      if (myClient == null) return;
 
       if (LOG.isDebugEnabled()) {
         LOG.debug("analysis_setPriorityFiles, files:\n" + StringUtil.join(myVisibleFileUris, ",\n"));
       }
 
-      myServer.analysis_setPriorityFiles(myVisibleFileUris);
+      myClient.analysis_setPriorityFiles(myVisibleFileUris);
     }
   }
 
   private void analysis_setSubscriptions() {
     synchronized (myLock) {
-      if (myServer == null) return;
+      if (myClient == null) return;
 
       final Map<String, List<String>> subscriptions = new HashMap<>();
       subscriptions.put(AnalysisService.HIGHLIGHTS, myVisibleFileUris);
@@ -1921,12 +1911,12 @@ public final class DartAnalysisServerService implements Disposable {
         LOG.debug("analysis_setSubscriptions, subscriptions:\n" + subscriptions);
       }
 
-      myServer.analysis_setSubscriptions(subscriptions);
+      myClient.analysis_setSubscriptions(subscriptions);
     }
   }
 
   public @Nullable String execution_createContext(@NotNull String filePath) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       String message = "Dart Analysis Server is not available.";
       LOG.warn(message);
@@ -1960,7 +1950,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public void execution_deleteContext(final @NotNull String contextId) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server != null) {
       server.execution_deleteContext(contextId);
     }
@@ -1972,7 +1962,7 @@ public final class DartAnalysisServerService implements Disposable {
                                                                                                                 int contextOffset,
                                                                                                                 @NotNull List<RuntimeCompletionVariable> variables,
                                                                                                                 @NotNull List<RuntimeCompletionExpression> expressions) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return new Pair<>(new SmartList<>(), new SmartList<>());
     }
@@ -2021,7 +2011,7 @@ public final class DartAnalysisServerService implements Disposable {
    */
   @Deprecated
   public @Nullable String execution_mapUri(@NotNull String _id, @Nullable String _filePathOrUri, @Nullable String _executionContextUri) {
-    final AnalysisServer server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -2075,7 +2065,7 @@ public final class DartAnalysisServerService implements Disposable {
 
   // LSP over Legacy Dart Analysis Server protocols
   public @Nullable String lspMessage_dart_textDocumentContent(@NotNull String fileUri) {
-    RemoteAnalysisServerImpl server = myServer;
+    DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -2154,35 +2144,7 @@ public final class DartAnalysisServerService implements Disposable {
           myDebugLog.add(str);
         }
       };
-
-      String vmArgsRaw;
-      try {
-        vmArgsRaw = Registry.stringValue("dart.server.vm.options");
-      }
-      catch (MissingResourceException e) {
-        vmArgsRaw = "";
-      }
-
-      String serverArgsRaw = useDartLangServerCall ? "--protocol=analyzer" : "";
-      if (suppressAnalytics) {
-        serverArgsRaw += " --suppress-analytics";
-      }
-
-      try {
-        serverArgsRaw += " " + Registry.stringValue("dart.server.additional.arguments");
-      }
-      catch (MissingResourceException e) {
-        // NOP
-      }
-
-      String firstArgument = useDartLangServerCall ? "language-server" : analysisServerPath;
-      myServerSocket =
-        new StdioServerSocket(runtimePath, StringUtil.split(vmArgsRaw, " "), firstArgument, StringUtil.split(serverArgsRaw, " "),
-                              debugStream);
-      myServerSocket.setClientId(getClientId());
-      myServerSocket.setClientVersion(getClientVersion());
-
-      final RemoteAnalysisServerImpl startedServer = new DartAnalysisServerImpl(myProject, myServerSocket);
+      final DartClient startedServer = DartClientFactory.create(myProject, sdk, debugStream, suppressAnalytics);
 
       try {
         startedServer.start();
@@ -2211,7 +2173,7 @@ public final class DartAnalysisServerService implements Disposable {
         startedServer.addStatusListener(isAlive -> {
           if (!isAlive) {
             synchronized (myLock) {
-              if (startedServer == myServer) {
+              if (startedServer == myClient) {
                 // Show a notification on the dart analysis tool window.
                 ApplicationManager.getApplication().invokeLater(
                   () -> {
@@ -2237,7 +2199,7 @@ public final class DartAnalysisServerService implements Disposable {
                                                    supportsUris,
                                                    supportsWorkspaceApplyEdits);
 
-        myServer = startedServer;
+        myClient = startedServer;
 
         // Clear any dart view notifications.
         ApplicationManager.getApplication().invokeLater(
@@ -2249,7 +2211,7 @@ public final class DartAnalysisServerService implements Disposable {
           myDisposedCondition
         );
 
-        // This must be done after myServer is set, and should be done each time the server starts.
+        // This must be done after myClient is set, and should be done each time the server starts.
         registerPostfixCompletionTemplates();
 
         myDtdUri = null;
@@ -2271,7 +2233,7 @@ public final class DartAnalysisServerService implements Disposable {
 
   public boolean isServerProcessActive() {
     synchronized (myLock) {
-      return myServer != null && myServer.isSocketOpen();
+      return myClient != null && myClient.isSocketOpen();
     }
   }
 
@@ -2284,22 +2246,22 @@ public final class DartAnalysisServerService implements Disposable {
 
     ApplicationManager.getApplication().assertReadAccessAllowed();
     synchronized (myLock) {
-      if (myServer == null ||
+      if (myClient == null ||
           !sdk.getHomePath().equals(mySdkHome) ||
           !sdk.getVersion().equals(mySdkVersion) ||
-          !myServer.isSocketOpen()) {
+          !myClient.isSocketOpen()) {
         stopServer();
         DartProblemsView.getInstance(myProject).setInitialCurrentFileBeforeServerStart(getCurrentOpenFile());
 
         AnalyticsConfiguration analyticsConfig = Analytics.getConfiguration(sdk, myProject);
         startServer(sdk, analyticsConfig.getSuppressAnalytics());
 
-        if (myServer != null) {
+        if (myClient != null) {
           myRootsHandler.onServerStarted();
         }
       }
 
-      return myServer != null;
+      return myClient != null;
     }
   }
 
@@ -2310,36 +2272,26 @@ public final class DartAnalysisServerService implements Disposable {
 
   void stopServer() {
     synchronized (myLock) {
-      if (myServer != null) {
+      if (myClient != null) {
         LOG.debug("stopping server");
-        myServer.removeAnalysisServerListener(myAnalysisServerListener);
+        myClient.removeAnalysisServerListener(myAnalysisServerListener);
         for (AnalysisServerListener listener : myAdditionalServerListeners) {
-          myServer.removeAnalysisServerListener(listener);
+          myClient.removeAnalysisServerListener(listener);
         }
         for (RequestListener listener : myRequestListeners) {
-          myServer.removeRequestListener(listener);
+          myClient.removeRequestListener(listener);
         }
         for (ResponseListener listener : myResponseListeners) {
-          myServer.removeResponseListener(listener);
+          myClient.removeResponseListener(listener);
         }
 
-        myServer.server_shutdown();
-
-        long startTime = System.currentTimeMillis();
-        while (myServerSocket != null && myServerSocket.isOpen()) {
-          if (System.currentTimeMillis() - startTime > SEND_REQUEST_TIMEOUT) {
-            myServerSocket.stop();
-            break;
-          }
-          Uninterruptibles.sleepUninterruptibly(CHECK_CANCELLED_PERIOD, TimeUnit.MILLISECONDS);
-        }
+        myClient.server_shutdown();
       }
 
       stopShowingServerProgress();
       myUpdateFilesAlarm.cancelAllRequests();
 
-      myServerSocket = null;
-      myServer = null;
+      myClient = null;
       mySdkHome = null;
       mySdkVersion = "";
       myServerVersion = "";
@@ -2356,7 +2308,7 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public void connectToDtd(@NotNull String uri) {
-    AnalysisServer server = myServer;
+    DartClient server = myClient;
     if (server == null) {
       return;
     }
@@ -2449,7 +2401,7 @@ public final class DartAnalysisServerService implements Disposable {
     LOG.info(builder.toString());
   }
 
-  private static boolean awaitForLatchCheckingCanceled(final @NotNull AnalysisServer server,
+  private static boolean awaitForLatchCheckingCanceled(final @NotNull DartClient server,
                                                        final @NotNull CountDownLatch latch,
                                                        long timeoutInMillis) {
     if (ApplicationManager.getApplication().isUnitTestMode()) {
@@ -2568,7 +2520,7 @@ public final class DartAnalysisServerService implements Disposable {
    */
   @SuppressWarnings("unused") // for Flutter plugin
   public String generateUniqueId() {
-    final RemoteAnalysisServerImpl server = myServer;
+    final DartClient server = myClient;
     if (server == null) {
       return null;
     }
@@ -2580,7 +2532,7 @@ public final class DartAnalysisServerService implements Disposable {
    */
   @SuppressWarnings("unused") // for Flutter plugin
   public void sendRequest(String id, JsonObject request) {
-    final RemoteAnalysisServerImpl server = myServer;
+    final DartClient server = myClient;
     if (server != null) {
       server.sendRequestToServer(id, request);
     }
@@ -2591,7 +2543,7 @@ public final class DartAnalysisServerService implements Disposable {
    */
   @SuppressWarnings("unused") // for Flutter plugin
   public void sendRequestToServer(String id, JsonObject request, com.google.dart.server.Consumer consumer) {
-    final RemoteAnalysisServerImpl server = myServer;
+    final DartClient server = myClient;
     if (server != null) {
       server.sendRequestToServer(id, request, consumer);
     }
@@ -2604,11 +2556,11 @@ public final class DartAnalysisServerService implements Disposable {
   public void setServerLogSubscription(boolean subscribeToLog) {
     if (mySubscribeToServerLog != subscribeToLog) {
       mySubscribeToServerLog = subscribeToLog;
-      server_setSubscriptions(myServer);
+      server_setSubscriptions(myClient);
     }
   }
 
-  private void server_setSubscriptions(@Nullable AnalysisServer server) {
+  private void server_setSubscriptions(@Nullable DartClient server) {
     if (server != null) {
       server.server_setSubscriptions(mySubscribeToServerLog ? Arrays.asList(ServerService.STATUS, ServerService.LOG)
                                                             : Collections.singletonList(ServerService.STATUS));

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -54,6 +54,8 @@ import com.jetbrains.lang.dart.assists.DartQuickAssistIntention;
 import com.jetbrains.lang.dart.assists.DartQuickAssistIntentionListener;
 import com.jetbrains.lang.dart.fixes.DartQuickFix;
 import com.jetbrains.lang.dart.fixes.DartQuickFixListener;
+import com.jetbrains.lang.dart.analyzer.lsp.LspDartAnalysisClient;
+import com.jetbrains.lang.dart.analyzer.lsp.LspRenameRefactoringResult;
 import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
 import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
@@ -1792,6 +1794,22 @@ public final class DartAnalysisServerService implements Disposable {
     final int length = getOriginalOffset(file, _offset + _length) - offset;
     server.edit_getRefactoring(kind, fileUri, offset, length, validateOnly, options, consumer);
     return true;
+  }
+
+  public @Nullable LspRenameRefactoringResult lsp_getRenameRefactoring(@NotNull VirtualFile file,
+                                                                       int _offset,
+                                                                       boolean validateOnly,
+                                                                       @Nullable String newName) {
+    if (!file.isInLocalFileSystem()) return null;
+
+    final DartClient server = myClient;
+    if (!(server instanceof LspDartAnalysisClient lspClient)) {
+      return null;
+    }
+
+    final String fileUri = getLocalFileUri(file.getPath());
+    final int offset = getOriginalOffset(file, _offset);
+    return lspClient.computeRenameRefactoring(fileUri, offset, validateOnly, newName);
   }
 
   public @Nullable SourceFileEdit edit_organizeDirectives(@NotNull String filePath) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartClient.kt
@@ -1,0 +1,172 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer
+
+import com.google.dart.server.AnalysisServerListener
+import com.google.dart.server.AnalysisServerStatusListener
+import com.google.dart.server.Consumer
+import com.google.dart.server.CreateContextConsumer
+import com.google.dart.server.DartLspTextDocumentContentConsumer
+import com.google.dart.server.FindElementReferencesConsumer
+import com.google.dart.server.FormatConsumer
+import com.google.dart.server.GetAssistsConsumer
+import com.google.dart.server.GetFixesConsumer
+import com.google.dart.server.GetHoverConsumer
+import com.google.dart.server.GetImportedElementsConsumer
+import com.google.dart.server.GetNavigationConsumer
+import com.google.dart.server.GetPostfixCompletionConsumer
+import com.google.dart.server.GetRefactoringConsumer
+import com.google.dart.server.GetRuntimeCompletionConsumer
+import com.google.dart.server.GetServerPortConsumer
+import com.google.dart.server.GetStatementCompletionConsumer
+import com.google.dart.server.GetSuggestionDetailsConsumer
+import com.google.dart.server.GetSuggestionDetailsConsumer2
+import com.google.dart.server.GetSuggestionsConsumer
+import com.google.dart.server.GetSuggestionsConsumer2
+import com.google.dart.server.GetTypeHierarchyConsumer
+import com.google.dart.server.ImportElementsConsumer
+import com.google.dart.server.IsPostfixCompletionApplicableConsumer
+import com.google.dart.server.ListPostfixCompletionTemplatesConsumer
+import com.google.dart.server.MapUriConsumer
+import com.google.dart.server.OrganizeDirectivesConsumer
+import com.google.dart.server.RequestListener
+import com.google.dart.server.ResponseListener
+import com.google.dart.server.SortMembersConsumer
+import com.google.dart.server.UpdateContentConsumer
+import com.google.gson.JsonObject
+import org.dartlang.analysis.server.protocol.AnalysisOptions
+import org.dartlang.analysis.server.protocol.ImportedElements
+import org.dartlang.analysis.server.protocol.RefactoringOptions
+import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression
+import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
+
+internal interface DartClient {
+  @Throws(Exception::class)
+  fun start()
+
+  fun isSocketOpen(): Boolean
+
+  fun addAnalysisServerListener(listener: AnalysisServerListener)
+
+  fun removeAnalysisServerListener(listener: AnalysisServerListener)
+
+  fun addRequestListener(listener: RequestListener)
+
+  fun removeRequestListener(listener: RequestListener)
+
+  fun addResponseListener(listener: ResponseListener)
+
+  fun removeResponseListener(listener: ResponseListener)
+
+  fun addStatusListener(listener: AnalysisServerStatusListener)
+
+  fun completion_setSubscriptions(subscriptions: List<String>)
+
+  fun analysis_updateContent(files: Map<String, Any>, consumer: UpdateContentConsumer)
+
+  fun analysis_setAnalysisRoots(included: List<String>, excluded: List<String>, packageRoots: Map<String, String>?)
+
+  fun analysis_getHover(file: String, offset: Int, consumer: GetHoverConsumer)
+
+  fun analysis_getNavigation(file: String, offset: Int, length: Int, consumer: GetNavigationConsumer)
+
+  fun edit_getAssists(file: String, offset: Int, length: Int, consumer: GetAssistsConsumer)
+
+  fun edit_isPostfixCompletionApplicable(file: String, key: String, offset: Int, consumer: IsPostfixCompletionApplicableConsumer)
+
+  fun edit_listPostfixCompletionTemplates(consumer: ListPostfixCompletionTemplatesConsumer)
+
+  fun edit_getPostfixCompletion(file: String, key: String, offset: Int, consumer: GetPostfixCompletionConsumer)
+
+  fun edit_getStatementCompletion(file: String, offset: Int, consumer: GetStatementCompletionConsumer)
+
+  fun diagnostic_getServerPort(consumer: GetServerPortConsumer)
+
+  fun edit_getFixes(file: String, offset: Int, consumer: GetFixesConsumer)
+
+  fun search_findElementReferences(file: String, offset: Int, includePotential: Boolean, consumer: FindElementReferencesConsumer)
+
+  fun search_getTypeHierarchy(file: String, offset: Int, superOnly: Boolean, consumer: GetTypeHierarchyConsumer)
+
+  fun completion_getSuggestionDetails(file: String, id: Int, label: String, offset: Int, consumer: GetSuggestionDetailsConsumer)
+
+  fun completion_getSuggestionDetails2(
+    file: String,
+    offset: Int,
+    completion: String,
+    libraryUri: String,
+    consumer: GetSuggestionDetailsConsumer2,
+  )
+
+  fun completion_getSuggestions(file: String, offset: Int, consumer: GetSuggestionsConsumer)
+
+  fun completion_getSuggestions2(
+    file: String,
+    offset: Int,
+    maxResults: Int,
+    completionCaseMatchingMode: String,
+    completionMode: String,
+    invocationCount: Int,
+    timeout: Int,
+    consumer: GetSuggestionsConsumer2,
+  )
+
+  fun edit_format(file: String, selectionOffset: Int, selectionLength: Int, lineLength: Int, consumer: FormatConsumer)
+
+  fun analysis_getImportedElements(file: String, offset: Int, length: Int, consumer: GetImportedElementsConsumer)
+
+  fun edit_importElements(file: String, elements: List<ImportedElements>, offset: Int, consumer: ImportElementsConsumer)
+
+  fun edit_getRefactoring(
+    kind: String,
+    file: String,
+    offset: Int,
+    length: Int,
+    validateOnly: Boolean,
+    options: RefactoringOptions?,
+    consumer: GetRefactoringConsumer,
+  )
+
+  fun edit_organizeDirectives(file: String, consumer: OrganizeDirectivesConsumer)
+
+  fun edit_sortMembers(file: String, consumer: SortMembersConsumer)
+
+  fun analysis_reanalyze()
+
+  fun analysis_setPriorityFiles(files: List<String>)
+
+  fun analysis_setSubscriptions(subscriptions: Map<String, List<String>>)
+
+  fun execution_createContext(contextRoot: String, consumer: CreateContextConsumer)
+
+  fun execution_deleteContext(contextId: String)
+
+  fun execution_getSuggestions(
+    code: String,
+    offset: Int,
+    contextFile: String,
+    contextOffset: Int,
+    variables: List<RuntimeCompletionVariable>,
+    expressions: List<RuntimeCompletionExpression>?,
+    consumer: GetRuntimeCompletionConsumer,
+  )
+
+  fun execution_mapUri(id: String, file: String?, uri: String?, consumer: MapUriConsumer)
+
+  fun server_setSubscriptions(subscriptions: List<String>)
+
+  fun analysis_updateOptions(options: AnalysisOptions)
+
+  fun server_setClientCapabilities(requests: List<String>, supportsUris: Boolean, supportsWorkspaceApplyEdits: Boolean)
+
+  fun server_shutdown()
+
+  fun generateUniqueId(): String
+
+  fun sendRequestToServer(id: String, request: JsonObject)
+
+  fun sendRequestToServer(id: String, request: JsonObject, consumer: Consumer)
+
+  fun lspMessage_dart_textDocumentContent(uri: String, consumer: DartLspTextDocumentContentConsumer)
+
+  fun lsp_connectToDtd(uri: String)
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartClientFactory.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartClientFactory.kt
@@ -1,0 +1,21 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer
+
+import com.google.dart.server.internal.remote.DebugPrintStream
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.jetbrains.lang.dart.analyzer.legacy.LegacyDartAnalysisClient
+import com.jetbrains.lang.dart.analyzer.lsp.LspDartAnalysisClient
+import com.jetbrains.lang.dart.sdk.DartSdk
+
+internal object DartClientFactory {
+  @JvmStatic
+  fun create(project: Project, sdk: DartSdk, debugStream: DebugPrintStream, suppressAnalytics: Boolean): DartClient {
+    return if (Registry.`is`("dart.use.lsp.client", false)) {
+      LspDartAnalysisClient(project, sdk, suppressAnalytics)
+    }
+    else {
+      LegacyDartAnalysisClient(project, sdk, debugStream, suppressAnalytics)
+    }
+  }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/legacy/LegacyDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/legacy/LegacyDartAnalysisClient.kt
@@ -56,331 +56,417 @@ import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
 import java.util.MissingResourceException
 
 internal class LegacyDartAnalysisClient(
-  project: Project,
-  sdk: DartSdk,
-  debugStream: DebugPrintStream,
-  suppressAnalytics: Boolean,
+    project: Project,
+    sdk: DartSdk,
+    debugStream: DebugPrintStream,
+    suppressAnalytics: Boolean,
 ) : DartClient {
-  private val serverSocket: StdioServerSocket = run {
-    val runtimePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+    private val serverSocket: StdioServerSocket =
+        run {
+            val runtimePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
 
-    val vmArguments = try {
-      StringUtil.split(Registry.stringValue("dart.server.vm.options"), " ")
-    }
-    catch (_: MissingResourceException) {
-      emptyList()
-    }
+            val vmArguments =
+                try {
+                    StringUtil.split(Registry.stringValue("dart.server.vm.options"), " ")
+                } catch (_: MissingResourceException) {
+                    emptyList()
+                }
 
-    val useDartLangServerCall = DartAnalysisServerService.isDartSdkVersionSufficientForDartLangServer(sdk)
-    val analysisServerPath = System.getProperty(
-      "dart.server.path",
-      FileUtil.toSystemDependentName(sdk.homePath + "/bin/snapshots/analysis_server.dart.snapshot"),
-    )
-    val firstArgument = if (useDartLangServerCall) "language-server" else analysisServerPath
+            val useDartLangServerCall = DartAnalysisServerService.isDartSdkVersionSufficientForDartLangServer(sdk)
+            val analysisServerPath =
+                System.getProperty(
+                    "dart.server.path",
+                    FileUtil.toSystemDependentName(sdk.homePath + "/bin/snapshots/analysis_server.dart.snapshot"),
+                )
+            val firstArgument = if (useDartLangServerCall) "language-server" else analysisServerPath
 
-    val serverArgsRaw = buildString {
-      append(if (useDartLangServerCall) "--protocol=analyzer" else "")
-      if (suppressAnalytics) {
-        if (isNotEmpty()) append(" ")
-        append("--suppress-analytics")
-      }
-      try {
-        val extra = Registry.stringValue("dart.server.additional.arguments")
-        if (extra.isNotBlank()) {
-          if (isNotEmpty()) append(" ")
-          append(extra)
+            val serverArgsRaw =
+                buildString {
+                    append(if (useDartLangServerCall) "--protocol=analyzer" else "")
+                    if (suppressAnalytics) {
+                        if (isNotEmpty()) append(" ")
+                        append("--suppress-analytics")
+                    }
+                    try {
+                        val extra = Registry.stringValue("dart.server.additional.arguments")
+                        if (extra.isNotBlank()) {
+                            if (isNotEmpty()) append(" ")
+                            append(extra)
+                        }
+                    } catch (_: MissingResourceException) {
+                    }
+                }
+            val serverArguments = StringUtil.split(serverArgsRaw, " ")
+
+            val clientId = ApplicationNamesInfo.getInstance().fullProductName.replace(' ', '-')
+            val clientVersion = ApplicationInfo.getInstance().apiVersion
+
+            StdioServerSocket(runtimePath, vmArguments, firstArgument, serverArguments, debugStream).apply {
+                setClientId(clientId)
+                setClientVersion(clientVersion)
+            }
         }
-      }
-      catch (_: MissingResourceException) {
-      }
+
+    private val remoteAnalysisClient: RemoteAnalysisServerImpl = DartAnalysisServerImpl(project, serverSocket)
+
+    private companion object {
+        private val LOG = Logger.getInstance(LegacyDartAnalysisClient::class.java)
+        private const val SHUTDOWN_TIMEOUT_MS = 1_000L
+        private const val CHECK_PERIOD_MS = 10L
     }
-    val serverArguments = StringUtil.split(serverArgsRaw, " ")
 
-    val clientId = ApplicationNamesInfo.getInstance().fullProductName.replace(' ', '-')
-    val clientVersion = ApplicationInfo.getInstance().apiVersion
-
-    StdioServerSocket(runtimePath, vmArguments, firstArgument, serverArguments, debugStream).apply {
-      setClientId(clientId)
-      setClientVersion(clientVersion)
+    override fun start() {
+        remoteAnalysisClient.start()
     }
-  }
 
-  private val remoteAnalysisClient: RemoteAnalysisServerImpl = DartAnalysisServerImpl(project, serverSocket)
+    override fun isSocketOpen(): Boolean = remoteAnalysisClient.isSocketOpen()
 
-  private companion object {
-    private val LOG = Logger.getInstance(LegacyDartAnalysisClient::class.java)
-    private const val SHUTDOWN_TIMEOUT_MS = 1_000L
-    private const val CHECK_PERIOD_MS = 10L
-  }
-
-  override fun start() {
-    remoteAnalysisClient.start()
-  }
-
-  override fun isSocketOpen(): Boolean = remoteAnalysisClient.isSocketOpen()
-
-  override fun addAnalysisServerListener(listener: AnalysisServerListener) {
-    remoteAnalysisClient.addAnalysisServerListener(listener)
-  }
-
-  override fun removeAnalysisServerListener(listener: AnalysisServerListener) {
-    remoteAnalysisClient.removeAnalysisServerListener(listener)
-  }
-
-  override fun addRequestListener(listener: RequestListener) {
-    remoteAnalysisClient.addRequestListener(listener)
-  }
-
-  override fun removeRequestListener(listener: RequestListener) {
-    remoteAnalysisClient.removeRequestListener(listener)
-  }
-
-  override fun addResponseListener(listener: ResponseListener) {
-    remoteAnalysisClient.addResponseListener(listener)
-  }
-
-  override fun removeResponseListener(listener: ResponseListener) {
-    remoteAnalysisClient.removeResponseListener(listener)
-  }
-
-  override fun addStatusListener(listener: AnalysisServerStatusListener) {
-    remoteAnalysisClient.addStatusListener(listener)
-  }
-
-  override fun completion_setSubscriptions(subscriptions: List<String>) {
-    remoteAnalysisClient.completion_setSubscriptions(subscriptions)
-  }
-
-  override fun analysis_updateContent(files: Map<String, Any>, consumer: UpdateContentConsumer) {
-    remoteAnalysisClient.analysis_updateContent(files, consumer)
-  }
-
-  override fun analysis_setAnalysisRoots(included: List<String>, excluded: List<String>, packageRoots: Map<String, String>?) {
-    remoteAnalysisClient.analysis_setAnalysisRoots(included, excluded, packageRoots)
-  }
-
-  override fun analysis_getHover(file: String, offset: Int, consumer: GetHoverConsumer) {
-    remoteAnalysisClient.analysis_getHover(file, offset, consumer)
-  }
-
-  override fun analysis_getNavigation(file: String, offset: Int, length: Int, consumer: GetNavigationConsumer) {
-    remoteAnalysisClient.analysis_getNavigation(file, offset, length, consumer)
-  }
-
-  override fun edit_getAssists(file: String, offset: Int, length: Int, consumer: GetAssistsConsumer) {
-    remoteAnalysisClient.edit_getAssists(file, offset, length, consumer)
-  }
-
-  override fun edit_isPostfixCompletionApplicable(
-    file: String,
-    key: String,
-    offset: Int,
-    consumer: IsPostfixCompletionApplicableConsumer,
-  ) {
-    remoteAnalysisClient.edit_isPostfixCompletionApplicable(file, key, offset, consumer)
-  }
-
-  override fun edit_listPostfixCompletionTemplates(consumer: ListPostfixCompletionTemplatesConsumer) {
-    remoteAnalysisClient.edit_listPostfixCompletionTemplates(consumer)
-  }
-
-  override fun edit_getPostfixCompletion(file: String, key: String, offset: Int, consumer: GetPostfixCompletionConsumer) {
-    remoteAnalysisClient.edit_getPostfixCompletion(file, key, offset, consumer)
-  }
-
-  override fun edit_getStatementCompletion(file: String, offset: Int, consumer: GetStatementCompletionConsumer) {
-    remoteAnalysisClient.edit_getStatementCompletion(file, offset, consumer)
-  }
-
-  override fun diagnostic_getServerPort(consumer: GetServerPortConsumer) {
-    remoteAnalysisClient.diagnostic_getServerPort(consumer)
-  }
-
-  override fun edit_getFixes(file: String, offset: Int, consumer: GetFixesConsumer) {
-    remoteAnalysisClient.edit_getFixes(file, offset, consumer)
-  }
-
-  override fun search_findElementReferences(
-    file: String,
-    offset: Int,
-    includePotential: Boolean,
-    consumer: FindElementReferencesConsumer,
-  ) {
-    remoteAnalysisClient.search_findElementReferences(file, offset, includePotential, consumer)
-  }
-
-  override fun search_getTypeHierarchy(file: String, offset: Int, superOnly: Boolean, consumer: GetTypeHierarchyConsumer) {
-    remoteAnalysisClient.search_getTypeHierarchy(file, offset, superOnly, consumer)
-  }
-
-  override fun completion_getSuggestionDetails(
-    file: String,
-    id: Int,
-    label: String,
-    offset: Int,
-    consumer: GetSuggestionDetailsConsumer,
-  ) {
-    remoteAnalysisClient.completion_getSuggestionDetails(file, id, label, offset, consumer)
-  }
-
-  override fun completion_getSuggestionDetails2(
-    file: String,
-    offset: Int,
-    completion: String,
-    libraryUri: String,
-    consumer: GetSuggestionDetailsConsumer2,
-  ) {
-    remoteAnalysisClient.completion_getSuggestionDetails2(file, offset, completion, libraryUri, consumer)
-  }
-
-  override fun completion_getSuggestions(file: String, offset: Int, consumer: GetSuggestionsConsumer) {
-    remoteAnalysisClient.completion_getSuggestions(file, offset, consumer)
-  }
-
-  override fun completion_getSuggestions2(
-    file: String,
-    offset: Int,
-    maxResults: Int,
-    completionCaseMatchingMode: String,
-    completionMode: String,
-    invocationCount: Int,
-    timeout: Int,
-    consumer: GetSuggestionsConsumer2,
-  ) {
-    remoteAnalysisClient.completion_getSuggestions2(
-      file,
-      offset,
-      maxResults,
-      completionCaseMatchingMode,
-      completionMode,
-      invocationCount,
-      timeout,
-      consumer,
-    )
-  }
-
-  override fun edit_format(file: String, selectionOffset: Int, selectionLength: Int, lineLength: Int, consumer: FormatConsumer) {
-    remoteAnalysisClient.edit_format(file, selectionOffset, selectionLength, lineLength, consumer)
-  }
-
-  override fun analysis_getImportedElements(file: String, offset: Int, length: Int, consumer: GetImportedElementsConsumer) {
-    remoteAnalysisClient.analysis_getImportedElements(file, offset, length, consumer)
-  }
-
-  override fun edit_importElements(file: String, elements: List<ImportedElements>, offset: Int, consumer: ImportElementsConsumer) {
-    remoteAnalysisClient.edit_importElements(file, elements, offset, consumer)
-  }
-
-  override fun edit_getRefactoring(
-    kind: String,
-    file: String,
-    offset: Int,
-    length: Int,
-    validateOnly: Boolean,
-    options: RefactoringOptions?,
-    consumer: GetRefactoringConsumer,
-  ) {
-    remoteAnalysisClient.edit_getRefactoring(kind, file, offset, length, validateOnly, options, consumer)
-  }
-
-  override fun edit_organizeDirectives(file: String, consumer: OrganizeDirectivesConsumer) {
-    remoteAnalysisClient.edit_organizeDirectives(file, consumer)
-  }
-
-  override fun edit_sortMembers(file: String, consumer: SortMembersConsumer) {
-    remoteAnalysisClient.edit_sortMembers(file, consumer)
-  }
-
-  override fun analysis_reanalyze() {
-    remoteAnalysisClient.analysis_reanalyze()
-  }
-
-  override fun analysis_setPriorityFiles(files: List<String>) {
-    remoteAnalysisClient.analysis_setPriorityFiles(files)
-  }
-
-  override fun analysis_setSubscriptions(subscriptions: Map<String, List<String>>) {
-    remoteAnalysisClient.analysis_setSubscriptions(subscriptions)
-  }
-
-  override fun execution_createContext(contextRoot: String, consumer: CreateContextConsumer) {
-    remoteAnalysisClient.execution_createContext(contextRoot, consumer)
-  }
-
-  override fun execution_deleteContext(contextId: String) {
-    remoteAnalysisClient.execution_deleteContext(contextId)
-  }
-
-  override fun execution_getSuggestions(
-    code: String,
-    offset: Int,
-    contextFile: String,
-    contextOffset: Int,
-    variables: List<RuntimeCompletionVariable>,
-    expressions: List<RuntimeCompletionExpression>?,
-    consumer: GetRuntimeCompletionConsumer,
-  ) {
-    remoteAnalysisClient.execution_getSuggestions(code, offset, contextFile, contextOffset, variables, expressions, consumer)
-  }
-
-  override fun execution_mapUri(id: String, file: String?, uri: String?, consumer: MapUriConsumer) {
-    remoteAnalysisClient.execution_mapUri(id, file, uri, consumer)
-  }
-
-  override fun server_setSubscriptions(subscriptions: List<String>) {
-    remoteAnalysisClient.server_setSubscriptions(subscriptions)
-  }
-
-  override fun analysis_updateOptions(options: AnalysisOptions) {
-    remoteAnalysisClient.analysis_updateOptions(options)
-  }
-
-  override fun server_setClientCapabilities(requests: List<String>, supportsUris: Boolean, supportsWorkspaceApplyEdits: Boolean) {
-    remoteAnalysisClient.server_setClientCapabilities(requests, supportsUris, supportsWorkspaceApplyEdits)
-  }
-
-  override fun server_shutdown() {
-    try {
-      remoteAnalysisClient.server_shutdown()
+    override fun addAnalysisServerListener(listener: AnalysisServerListener) {
+        remoteAnalysisClient.addAnalysisServerListener(listener)
     }
-    finally {
-      val startTime = System.currentTimeMillis()
-      while (serverSocket.isOpen) {
-        if (System.currentTimeMillis() - startTime > SHUTDOWN_TIMEOUT_MS) {
-          try {
-            serverSocket.stop()
-          }
-          catch (t: Throwable) {
-            LOG.warn("Failed to stop analysis server socket", t)
-          }
-          break
-        }
+
+    override fun removeAnalysisServerListener(listener: AnalysisServerListener) {
+        remoteAnalysisClient.removeAnalysisServerListener(listener)
+    }
+
+    override fun addRequestListener(listener: RequestListener) {
+        remoteAnalysisClient.addRequestListener(listener)
+    }
+
+    override fun removeRequestListener(listener: RequestListener) {
+        remoteAnalysisClient.removeRequestListener(listener)
+    }
+
+    override fun addResponseListener(listener: ResponseListener) {
+        remoteAnalysisClient.addResponseListener(listener)
+    }
+
+    override fun removeResponseListener(listener: ResponseListener) {
+        remoteAnalysisClient.removeResponseListener(listener)
+    }
+
+    override fun addStatusListener(listener: AnalysisServerStatusListener) {
+        remoteAnalysisClient.addStatusListener(listener)
+    }
+
+    override fun completion_setSubscriptions(subscriptions: List<String>) {
+        remoteAnalysisClient.completion_setSubscriptions(subscriptions)
+    }
+
+    override fun analysis_updateContent(
+        files: Map<String, Any>,
+        consumer: UpdateContentConsumer,
+    ) {
+        remoteAnalysisClient.analysis_updateContent(files, consumer)
+    }
+
+    override fun analysis_setAnalysisRoots(
+        included: List<String>,
+        excluded: List<String>,
+        packageRoots: Map<String, String>?,
+    ) {
+        remoteAnalysisClient.analysis_setAnalysisRoots(included, excluded, packageRoots)
+    }
+
+    override fun analysis_getHover(
+        file: String,
+        offset: Int,
+        consumer: GetHoverConsumer,
+    ) {
+        remoteAnalysisClient.analysis_getHover(file, offset, consumer)
+    }
+
+    override fun analysis_getNavigation(
+        file: String,
+        offset: Int,
+        length: Int,
+        consumer: GetNavigationConsumer,
+    ) {
+        remoteAnalysisClient.analysis_getNavigation(file, offset, length, consumer)
+    }
+
+    override fun edit_getAssists(
+        file: String,
+        offset: Int,
+        length: Int,
+        consumer: GetAssistsConsumer,
+    ) {
+        remoteAnalysisClient.edit_getAssists(file, offset, length, consumer)
+    }
+
+    override fun edit_isPostfixCompletionApplicable(
+        file: String,
+        key: String,
+        offset: Int,
+        consumer: IsPostfixCompletionApplicableConsumer,
+    ) {
+        remoteAnalysisClient.edit_isPostfixCompletionApplicable(file, key, offset, consumer)
+    }
+
+    override fun edit_listPostfixCompletionTemplates(consumer: ListPostfixCompletionTemplatesConsumer) {
+        remoteAnalysisClient.edit_listPostfixCompletionTemplates(consumer)
+    }
+
+    override fun edit_getPostfixCompletion(
+        file: String,
+        key: String,
+        offset: Int,
+        consumer: GetPostfixCompletionConsumer,
+    ) {
+        remoteAnalysisClient.edit_getPostfixCompletion(file, key, offset, consumer)
+    }
+
+    override fun edit_getStatementCompletion(
+        file: String,
+        offset: Int,
+        consumer: GetStatementCompletionConsumer,
+    ) {
+        remoteAnalysisClient.edit_getStatementCompletion(file, offset, consumer)
+    }
+
+    override fun diagnostic_getServerPort(consumer: GetServerPortConsumer) {
+        remoteAnalysisClient.diagnostic_getServerPort(consumer)
+    }
+
+    override fun edit_getFixes(
+        file: String,
+        offset: Int,
+        consumer: GetFixesConsumer,
+    ) {
+        remoteAnalysisClient.edit_getFixes(file, offset, consumer)
+    }
+
+    override fun search_findElementReferences(
+        file: String,
+        offset: Int,
+        includePotential: Boolean,
+        consumer: FindElementReferencesConsumer,
+    ) {
+        remoteAnalysisClient.search_findElementReferences(file, offset, includePotential, consumer)
+    }
+
+    override fun search_getTypeHierarchy(
+        file: String,
+        offset: Int,
+        superOnly: Boolean,
+        consumer: GetTypeHierarchyConsumer,
+    ) {
+        remoteAnalysisClient.search_getTypeHierarchy(file, offset, superOnly, consumer)
+    }
+
+    override fun completion_getSuggestionDetails(
+        file: String,
+        id: Int,
+        label: String,
+        offset: Int,
+        consumer: GetSuggestionDetailsConsumer,
+    ) {
+        remoteAnalysisClient.completion_getSuggestionDetails(file, id, label, offset, consumer)
+    }
+
+    override fun completion_getSuggestionDetails2(
+        file: String,
+        offset: Int,
+        completion: String,
+        libraryUri: String,
+        consumer: GetSuggestionDetailsConsumer2,
+    ) {
+        remoteAnalysisClient.completion_getSuggestionDetails2(file, offset, completion, libraryUri, consumer)
+    }
+
+    override fun completion_getSuggestions(
+        file: String,
+        offset: Int,
+        consumer: GetSuggestionsConsumer,
+    ) {
+        remoteAnalysisClient.completion_getSuggestions(file, offset, consumer)
+    }
+
+    override fun completion_getSuggestions2(
+        file: String,
+        offset: Int,
+        maxResults: Int,
+        completionCaseMatchingMode: String,
+        completionMode: String,
+        invocationCount: Int,
+        timeout: Int,
+        consumer: GetSuggestionsConsumer2,
+    ) {
+        remoteAnalysisClient.completion_getSuggestions2(
+            file,
+            offset,
+            maxResults,
+            completionCaseMatchingMode,
+            completionMode,
+            invocationCount,
+            timeout,
+            consumer,
+        )
+    }
+
+    override fun edit_format(
+        file: String,
+        selectionOffset: Int,
+        selectionLength: Int,
+        lineLength: Int,
+        consumer: FormatConsumer,
+    ) {
+        remoteAnalysisClient.edit_format(file, selectionOffset, selectionLength, lineLength, consumer)
+    }
+
+    override fun analysis_getImportedElements(
+        file: String,
+        offset: Int,
+        length: Int,
+        consumer: GetImportedElementsConsumer,
+    ) {
+        remoteAnalysisClient.analysis_getImportedElements(file, offset, length, consumer)
+    }
+
+    override fun edit_importElements(
+        file: String,
+        elements: List<ImportedElements>,
+        offset: Int,
+        consumer: ImportElementsConsumer,
+    ) {
+        remoteAnalysisClient.edit_importElements(file, elements, offset, consumer)
+    }
+
+    override fun edit_getRefactoring(
+        kind: String,
+        file: String,
+        offset: Int,
+        length: Int,
+        validateOnly: Boolean,
+        options: RefactoringOptions?,
+        consumer: GetRefactoringConsumer,
+    ) {
+        remoteAnalysisClient.edit_getRefactoring(kind, file, offset, length, validateOnly, options, consumer)
+    }
+
+    override fun edit_organizeDirectives(
+        file: String,
+        consumer: OrganizeDirectivesConsumer,
+    ) {
+        remoteAnalysisClient.edit_organizeDirectives(file, consumer)
+    }
+
+    override fun edit_sortMembers(
+        file: String,
+        consumer: SortMembersConsumer,
+    ) {
+        remoteAnalysisClient.edit_sortMembers(file, consumer)
+    }
+
+    override fun analysis_reanalyze() {
+        remoteAnalysisClient.analysis_reanalyze()
+    }
+
+    override fun analysis_setPriorityFiles(files: List<String>) {
+        remoteAnalysisClient.analysis_setPriorityFiles(files)
+    }
+
+    override fun analysis_setSubscriptions(subscriptions: Map<String, List<String>>) {
+        remoteAnalysisClient.analysis_setSubscriptions(subscriptions)
+    }
+
+    override fun execution_createContext(
+        contextRoot: String,
+        consumer: CreateContextConsumer,
+    ) {
+        remoteAnalysisClient.execution_createContext(contextRoot, consumer)
+    }
+
+    override fun execution_deleteContext(contextId: String) {
+        remoteAnalysisClient.execution_deleteContext(contextId)
+    }
+
+    override fun execution_getSuggestions(
+        code: String,
+        offset: Int,
+        contextFile: String,
+        contextOffset: Int,
+        variables: List<RuntimeCompletionVariable>,
+        expressions: List<RuntimeCompletionExpression>?,
+        consumer: GetRuntimeCompletionConsumer,
+    ) {
+        remoteAnalysisClient.execution_getSuggestions(code, offset, contextFile, contextOffset, variables, expressions, consumer)
+    }
+
+    override fun execution_mapUri(
+        id: String,
+        file: String?,
+        uri: String?,
+        consumer: MapUriConsumer,
+    ) {
+        remoteAnalysisClient.execution_mapUri(id, file, uri, consumer)
+    }
+
+    override fun server_setSubscriptions(subscriptions: List<String>) {
+        remoteAnalysisClient.server_setSubscriptions(subscriptions)
+    }
+
+    override fun analysis_updateOptions(options: AnalysisOptions) {
+        remoteAnalysisClient.analysis_updateOptions(options)
+    }
+
+    override fun server_setClientCapabilities(
+        requests: List<String>,
+        supportsUris: Boolean,
+        supportsWorkspaceApplyEdits: Boolean,
+    ) {
+        remoteAnalysisClient.server_setClientCapabilities(requests, supportsUris, supportsWorkspaceApplyEdits)
+    }
+
+    override fun server_shutdown() {
         try {
-          Thread.sleep(CHECK_PERIOD_MS)
+            remoteAnalysisClient.server_shutdown()
+        } finally {
+            val startTime = System.currentTimeMillis()
+            while (serverSocket.isOpen) {
+                if (System.currentTimeMillis() - startTime > SHUTDOWN_TIMEOUT_MS) {
+                    try {
+                        serverSocket.stop()
+                    } catch (t: Throwable) {
+                        LOG.warn("Failed to stop analysis server socket", t)
+                    }
+                    break
+                }
+                try {
+                    Thread.sleep(CHECK_PERIOD_MS)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    break
+                }
+            }
         }
-        catch (_: InterruptedException) {
-          Thread.currentThread().interrupt()
-          break
-        }
-      }
     }
-  }
 
-  override fun generateUniqueId(): String = remoteAnalysisClient.generateUniqueId()
+    override fun generateUniqueId(): String = remoteAnalysisClient.generateUniqueId()
 
-  override fun sendRequestToServer(id: String, request: JsonObject) {
-    remoteAnalysisClient.sendRequestToServer(id, request)
-  }
+    override fun sendRequestToServer(
+        id: String,
+        request: JsonObject,
+    ) {
+        remoteAnalysisClient.sendRequestToServer(id, request)
+    }
 
-  override fun sendRequestToServer(id: String, request: JsonObject, consumer: Consumer) {
-    remoteAnalysisClient.sendRequestToServer(id, request, consumer)
-  }
+    override fun sendRequestToServer(
+        id: String,
+        request: JsonObject,
+        consumer: Consumer,
+    ) {
+        remoteAnalysisClient.sendRequestToServer(id, request, consumer)
+    }
 
-  override fun lspMessage_dart_textDocumentContent(uri: String, consumer: DartLspTextDocumentContentConsumer) {
-    remoteAnalysisClient.lspMessage_dart_textDocumentContent(uri, consumer)
-  }
+    override fun lspMessage_dart_textDocumentContent(
+        uri: String,
+        consumer: DartLspTextDocumentContentConsumer,
+    ) {
+        remoteAnalysisClient.lspMessage_dart_textDocumentContent(uri, consumer)
+    }
 
-  override fun lsp_connectToDtd(uri: String) {
-    remoteAnalysisClient.lsp_connectToDtd(uri)
-  }
+    override fun lsp_connectToDtd(uri: String) {
+        remoteAnalysisClient.lsp_connectToDtd(uri)
+    }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/legacy/LegacyDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/legacy/LegacyDartAnalysisClient.kt
@@ -1,0 +1,386 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.legacy
+
+import com.google.dart.server.AnalysisServerListener
+import com.google.dart.server.AnalysisServerStatusListener
+import com.google.dart.server.Consumer
+import com.google.dart.server.CreateContextConsumer
+import com.google.dart.server.DartLspTextDocumentContentConsumer
+import com.google.dart.server.FindElementReferencesConsumer
+import com.google.dart.server.FormatConsumer
+import com.google.dart.server.GetAssistsConsumer
+import com.google.dart.server.GetFixesConsumer
+import com.google.dart.server.GetHoverConsumer
+import com.google.dart.server.GetImportedElementsConsumer
+import com.google.dart.server.GetNavigationConsumer
+import com.google.dart.server.GetPostfixCompletionConsumer
+import com.google.dart.server.GetRefactoringConsumer
+import com.google.dart.server.GetRuntimeCompletionConsumer
+import com.google.dart.server.GetServerPortConsumer
+import com.google.dart.server.GetStatementCompletionConsumer
+import com.google.dart.server.GetSuggestionDetailsConsumer
+import com.google.dart.server.GetSuggestionDetailsConsumer2
+import com.google.dart.server.GetSuggestionsConsumer
+import com.google.dart.server.GetSuggestionsConsumer2
+import com.google.dart.server.GetTypeHierarchyConsumer
+import com.google.dart.server.ImportElementsConsumer
+import com.google.dart.server.IsPostfixCompletionApplicableConsumer
+import com.google.dart.server.ListPostfixCompletionTemplatesConsumer
+import com.google.dart.server.MapUriConsumer
+import com.google.dart.server.OrganizeDirectivesConsumer
+import com.google.dart.server.RequestListener
+import com.google.dart.server.ResponseListener
+import com.google.dart.server.SortMembersConsumer
+import com.google.dart.server.UpdateContentConsumer
+import com.google.dart.server.internal.remote.DebugPrintStream
+import com.google.dart.server.internal.remote.RemoteAnalysisServerImpl
+import com.google.dart.server.internal.remote.StdioServerSocket
+import com.google.gson.JsonObject
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.application.ApplicationNamesInfo
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.text.StringUtil
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerImpl
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
+import com.jetbrains.lang.dart.analyzer.DartClient
+import com.jetbrains.lang.dart.sdk.DartSdk
+import com.jetbrains.lang.dart.sdk.DartSdkUtil
+import org.dartlang.analysis.server.protocol.AnalysisOptions
+import org.dartlang.analysis.server.protocol.ImportedElements
+import org.dartlang.analysis.server.protocol.RefactoringOptions
+import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression
+import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
+import java.util.MissingResourceException
+
+internal class LegacyDartAnalysisClient(
+  project: Project,
+  sdk: DartSdk,
+  debugStream: DebugPrintStream,
+  suppressAnalytics: Boolean,
+) : DartClient {
+  private val serverSocket: StdioServerSocket = run {
+    val runtimePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+
+    val vmArguments = try {
+      StringUtil.split(Registry.stringValue("dart.server.vm.options"), " ")
+    }
+    catch (_: MissingResourceException) {
+      emptyList()
+    }
+
+    val useDartLangServerCall = DartAnalysisServerService.isDartSdkVersionSufficientForDartLangServer(sdk)
+    val analysisServerPath = System.getProperty(
+      "dart.server.path",
+      FileUtil.toSystemDependentName(sdk.homePath + "/bin/snapshots/analysis_server.dart.snapshot"),
+    )
+    val firstArgument = if (useDartLangServerCall) "language-server" else analysisServerPath
+
+    val serverArgsRaw = buildString {
+      append(if (useDartLangServerCall) "--protocol=analyzer" else "")
+      if (suppressAnalytics) {
+        if (isNotEmpty()) append(" ")
+        append("--suppress-analytics")
+      }
+      try {
+        val extra = Registry.stringValue("dart.server.additional.arguments")
+        if (extra.isNotBlank()) {
+          if (isNotEmpty()) append(" ")
+          append(extra)
+        }
+      }
+      catch (_: MissingResourceException) {
+      }
+    }
+    val serverArguments = StringUtil.split(serverArgsRaw, " ")
+
+    val clientId = ApplicationNamesInfo.getInstance().fullProductName.replace(' ', '-')
+    val clientVersion = ApplicationInfo.getInstance().apiVersion
+
+    StdioServerSocket(runtimePath, vmArguments, firstArgument, serverArguments, debugStream).apply {
+      setClientId(clientId)
+      setClientVersion(clientVersion)
+    }
+  }
+
+  private val remoteAnalysisClient: RemoteAnalysisServerImpl = DartAnalysisServerImpl(project, serverSocket)
+
+  private companion object {
+    private val LOG = Logger.getInstance(LegacyDartAnalysisClient::class.java)
+    private const val SHUTDOWN_TIMEOUT_MS = 1_000L
+    private const val CHECK_PERIOD_MS = 10L
+  }
+
+  override fun start() {
+    remoteAnalysisClient.start()
+  }
+
+  override fun isSocketOpen(): Boolean = remoteAnalysisClient.isSocketOpen()
+
+  override fun addAnalysisServerListener(listener: AnalysisServerListener) {
+    remoteAnalysisClient.addAnalysisServerListener(listener)
+  }
+
+  override fun removeAnalysisServerListener(listener: AnalysisServerListener) {
+    remoteAnalysisClient.removeAnalysisServerListener(listener)
+  }
+
+  override fun addRequestListener(listener: RequestListener) {
+    remoteAnalysisClient.addRequestListener(listener)
+  }
+
+  override fun removeRequestListener(listener: RequestListener) {
+    remoteAnalysisClient.removeRequestListener(listener)
+  }
+
+  override fun addResponseListener(listener: ResponseListener) {
+    remoteAnalysisClient.addResponseListener(listener)
+  }
+
+  override fun removeResponseListener(listener: ResponseListener) {
+    remoteAnalysisClient.removeResponseListener(listener)
+  }
+
+  override fun addStatusListener(listener: AnalysisServerStatusListener) {
+    remoteAnalysisClient.addStatusListener(listener)
+  }
+
+  override fun completion_setSubscriptions(subscriptions: List<String>) {
+    remoteAnalysisClient.completion_setSubscriptions(subscriptions)
+  }
+
+  override fun analysis_updateContent(files: Map<String, Any>, consumer: UpdateContentConsumer) {
+    remoteAnalysisClient.analysis_updateContent(files, consumer)
+  }
+
+  override fun analysis_setAnalysisRoots(included: List<String>, excluded: List<String>, packageRoots: Map<String, String>?) {
+    remoteAnalysisClient.analysis_setAnalysisRoots(included, excluded, packageRoots)
+  }
+
+  override fun analysis_getHover(file: String, offset: Int, consumer: GetHoverConsumer) {
+    remoteAnalysisClient.analysis_getHover(file, offset, consumer)
+  }
+
+  override fun analysis_getNavigation(file: String, offset: Int, length: Int, consumer: GetNavigationConsumer) {
+    remoteAnalysisClient.analysis_getNavigation(file, offset, length, consumer)
+  }
+
+  override fun edit_getAssists(file: String, offset: Int, length: Int, consumer: GetAssistsConsumer) {
+    remoteAnalysisClient.edit_getAssists(file, offset, length, consumer)
+  }
+
+  override fun edit_isPostfixCompletionApplicable(
+    file: String,
+    key: String,
+    offset: Int,
+    consumer: IsPostfixCompletionApplicableConsumer,
+  ) {
+    remoteAnalysisClient.edit_isPostfixCompletionApplicable(file, key, offset, consumer)
+  }
+
+  override fun edit_listPostfixCompletionTemplates(consumer: ListPostfixCompletionTemplatesConsumer) {
+    remoteAnalysisClient.edit_listPostfixCompletionTemplates(consumer)
+  }
+
+  override fun edit_getPostfixCompletion(file: String, key: String, offset: Int, consumer: GetPostfixCompletionConsumer) {
+    remoteAnalysisClient.edit_getPostfixCompletion(file, key, offset, consumer)
+  }
+
+  override fun edit_getStatementCompletion(file: String, offset: Int, consumer: GetStatementCompletionConsumer) {
+    remoteAnalysisClient.edit_getStatementCompletion(file, offset, consumer)
+  }
+
+  override fun diagnostic_getServerPort(consumer: GetServerPortConsumer) {
+    remoteAnalysisClient.diagnostic_getServerPort(consumer)
+  }
+
+  override fun edit_getFixes(file: String, offset: Int, consumer: GetFixesConsumer) {
+    remoteAnalysisClient.edit_getFixes(file, offset, consumer)
+  }
+
+  override fun search_findElementReferences(
+    file: String,
+    offset: Int,
+    includePotential: Boolean,
+    consumer: FindElementReferencesConsumer,
+  ) {
+    remoteAnalysisClient.search_findElementReferences(file, offset, includePotential, consumer)
+  }
+
+  override fun search_getTypeHierarchy(file: String, offset: Int, superOnly: Boolean, consumer: GetTypeHierarchyConsumer) {
+    remoteAnalysisClient.search_getTypeHierarchy(file, offset, superOnly, consumer)
+  }
+
+  override fun completion_getSuggestionDetails(
+    file: String,
+    id: Int,
+    label: String,
+    offset: Int,
+    consumer: GetSuggestionDetailsConsumer,
+  ) {
+    remoteAnalysisClient.completion_getSuggestionDetails(file, id, label, offset, consumer)
+  }
+
+  override fun completion_getSuggestionDetails2(
+    file: String,
+    offset: Int,
+    completion: String,
+    libraryUri: String,
+    consumer: GetSuggestionDetailsConsumer2,
+  ) {
+    remoteAnalysisClient.completion_getSuggestionDetails2(file, offset, completion, libraryUri, consumer)
+  }
+
+  override fun completion_getSuggestions(file: String, offset: Int, consumer: GetSuggestionsConsumer) {
+    remoteAnalysisClient.completion_getSuggestions(file, offset, consumer)
+  }
+
+  override fun completion_getSuggestions2(
+    file: String,
+    offset: Int,
+    maxResults: Int,
+    completionCaseMatchingMode: String,
+    completionMode: String,
+    invocationCount: Int,
+    timeout: Int,
+    consumer: GetSuggestionsConsumer2,
+  ) {
+    remoteAnalysisClient.completion_getSuggestions2(
+      file,
+      offset,
+      maxResults,
+      completionCaseMatchingMode,
+      completionMode,
+      invocationCount,
+      timeout,
+      consumer,
+    )
+  }
+
+  override fun edit_format(file: String, selectionOffset: Int, selectionLength: Int, lineLength: Int, consumer: FormatConsumer) {
+    remoteAnalysisClient.edit_format(file, selectionOffset, selectionLength, lineLength, consumer)
+  }
+
+  override fun analysis_getImportedElements(file: String, offset: Int, length: Int, consumer: GetImportedElementsConsumer) {
+    remoteAnalysisClient.analysis_getImportedElements(file, offset, length, consumer)
+  }
+
+  override fun edit_importElements(file: String, elements: List<ImportedElements>, offset: Int, consumer: ImportElementsConsumer) {
+    remoteAnalysisClient.edit_importElements(file, elements, offset, consumer)
+  }
+
+  override fun edit_getRefactoring(
+    kind: String,
+    file: String,
+    offset: Int,
+    length: Int,
+    validateOnly: Boolean,
+    options: RefactoringOptions?,
+    consumer: GetRefactoringConsumer,
+  ) {
+    remoteAnalysisClient.edit_getRefactoring(kind, file, offset, length, validateOnly, options, consumer)
+  }
+
+  override fun edit_organizeDirectives(file: String, consumer: OrganizeDirectivesConsumer) {
+    remoteAnalysisClient.edit_organizeDirectives(file, consumer)
+  }
+
+  override fun edit_sortMembers(file: String, consumer: SortMembersConsumer) {
+    remoteAnalysisClient.edit_sortMembers(file, consumer)
+  }
+
+  override fun analysis_reanalyze() {
+    remoteAnalysisClient.analysis_reanalyze()
+  }
+
+  override fun analysis_setPriorityFiles(files: List<String>) {
+    remoteAnalysisClient.analysis_setPriorityFiles(files)
+  }
+
+  override fun analysis_setSubscriptions(subscriptions: Map<String, List<String>>) {
+    remoteAnalysisClient.analysis_setSubscriptions(subscriptions)
+  }
+
+  override fun execution_createContext(contextRoot: String, consumer: CreateContextConsumer) {
+    remoteAnalysisClient.execution_createContext(contextRoot, consumer)
+  }
+
+  override fun execution_deleteContext(contextId: String) {
+    remoteAnalysisClient.execution_deleteContext(contextId)
+  }
+
+  override fun execution_getSuggestions(
+    code: String,
+    offset: Int,
+    contextFile: String,
+    contextOffset: Int,
+    variables: List<RuntimeCompletionVariable>,
+    expressions: List<RuntimeCompletionExpression>?,
+    consumer: GetRuntimeCompletionConsumer,
+  ) {
+    remoteAnalysisClient.execution_getSuggestions(code, offset, contextFile, contextOffset, variables, expressions, consumer)
+  }
+
+  override fun execution_mapUri(id: String, file: String?, uri: String?, consumer: MapUriConsumer) {
+    remoteAnalysisClient.execution_mapUri(id, file, uri, consumer)
+  }
+
+  override fun server_setSubscriptions(subscriptions: List<String>) {
+    remoteAnalysisClient.server_setSubscriptions(subscriptions)
+  }
+
+  override fun analysis_updateOptions(options: AnalysisOptions) {
+    remoteAnalysisClient.analysis_updateOptions(options)
+  }
+
+  override fun server_setClientCapabilities(requests: List<String>, supportsUris: Boolean, supportsWorkspaceApplyEdits: Boolean) {
+    remoteAnalysisClient.server_setClientCapabilities(requests, supportsUris, supportsWorkspaceApplyEdits)
+  }
+
+  override fun server_shutdown() {
+    try {
+      remoteAnalysisClient.server_shutdown()
+    }
+    finally {
+      val startTime = System.currentTimeMillis()
+      while (serverSocket.isOpen) {
+        if (System.currentTimeMillis() - startTime > SHUTDOWN_TIMEOUT_MS) {
+          try {
+            serverSocket.stop()
+          }
+          catch (t: Throwable) {
+            LOG.warn("Failed to stop analysis server socket", t)
+          }
+          break
+        }
+        try {
+          Thread.sleep(CHECK_PERIOD_MS)
+        }
+        catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          break
+        }
+      }
+    }
+  }
+
+  override fun generateUniqueId(): String = remoteAnalysisClient.generateUniqueId()
+
+  override fun sendRequestToServer(id: String, request: JsonObject) {
+    remoteAnalysisClient.sendRequestToServer(id, request)
+  }
+
+  override fun sendRequestToServer(id: String, request: JsonObject, consumer: Consumer) {
+    remoteAnalysisClient.sendRequestToServer(id, request, consumer)
+  }
+
+  override fun lspMessage_dart_textDocumentContent(uri: String, consumer: DartLspTextDocumentContentConsumer) {
+    remoteAnalysisClient.lspMessage_dart_textDocumentContent(uri, consumer)
+  }
+
+  override fun lsp_connectToDtd(uri: String) {
+    remoteAnalysisClient.lsp_connectToDtd(uri)
+  }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartExtendedLanguageServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartExtendedLanguageServer.kt
@@ -1,0 +1,13 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
+import org.eclipse.lsp4j.services.LanguageServer
+import java.util.concurrent.CompletableFuture
+
+internal interface DartExtendedLanguageServer : LanguageServer {
+  @JsonRequest("dart/diagnosticServer")
+  fun diagnosticServer(): CompletableFuture<DartDiagnosticServerResult>
+}
+
+internal data class DartDiagnosticServerResult(val port: Int = 0)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartExtendedLanguageServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartExtendedLanguageServer.kt
@@ -6,8 +6,8 @@ import org.eclipse.lsp4j.services.LanguageServer
 import java.util.concurrent.CompletableFuture
 
 internal interface DartExtendedLanguageServer : LanguageServer {
-  @JsonRequest("dart/diagnosticServer")
-  fun diagnosticServer(): CompletableFuture<DartDiagnosticServerResult>
+    @JsonRequest("dart/diagnosticServer")
+    fun diagnosticServer(): CompletableFuture<DartDiagnosticServerResult>
 }
 
 internal data class DartDiagnosticServerResult(val port: Int = 0)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartLspLanguageClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartLspLanguageClient.kt
@@ -8,10 +8,14 @@ import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.services.LanguageClient
 import java.util.concurrent.CompletableFuture
 
-internal class NoOpDartLanguageClient : LanguageClient {
+internal class DartLspLanguageClient(
+    private val onPublishDiagnostics: (PublishDiagnosticsParams) -> Unit,
+) : LanguageClient {
     override fun telemetryEvent(`object`: Any?) {}
 
-    override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams) {}
+    override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams) {
+        onPublishDiagnostics(diagnostics)
+    }
 
     override fun showMessage(messageParams: MessageParams) {}
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartLspLanguageClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/DartLspLanguageClient.kt
@@ -1,6 +1,8 @@
 // Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.analyzer.lsp
 
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.PublishDiagnosticsParams
@@ -10,7 +12,12 @@ import java.util.concurrent.CompletableFuture
 
 internal class DartLspLanguageClient(
     private val onPublishDiagnostics: (PublishDiagnosticsParams) -> Unit,
+    private val onApplyEdit: (ApplyWorkspaceEditParams) -> ApplyWorkspaceEditResponse = { ApplyWorkspaceEditResponse(false) },
 ) : LanguageClient {
+    override fun applyEdit(params: ApplyWorkspaceEditParams): CompletableFuture<ApplyWorkspaceEditResponse> {
+        return CompletableFuture.completedFuture(onApplyEdit(params))
+    }
+
     override fun telemetryEvent(`object`: Any?) {}
 
     override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientCapabilities.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientCapabilities.kt
@@ -1,0 +1,53 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.CodeActionCapabilities
+import org.eclipse.lsp4j.CodeActionKind
+import org.eclipse.lsp4j.CodeActionKindCapabilities
+import org.eclipse.lsp4j.CodeActionLiteralSupportCapabilities
+import org.eclipse.lsp4j.TextDocumentClientCapabilities
+import org.eclipse.lsp4j.WorkspaceClientCapabilities
+import org.eclipse.lsp4j.WorkspaceEditCapabilities
+
+internal fun createClientCapabilities(): ClientCapabilities {
+    val workspaceCapabilities =
+        WorkspaceClientCapabilities().apply {
+            workspaceFolders = true
+            workspaceEdit =
+                WorkspaceEditCapabilities().apply {
+                    documentChanges = true
+                }
+        }
+    val textDocumentCapabilities =
+        TextDocumentClientCapabilities().apply {
+            codeAction =
+                CodeActionCapabilities().apply {
+                    codeActionLiteralSupport =
+                        CodeActionLiteralSupportCapabilities(
+                            CodeActionKindCapabilities(
+                                listOf(
+                                    CodeActionKind.QuickFix,
+                                    CodeActionKind.Refactor,
+                                    CodeActionKind.RefactorExtract,
+                                    CodeActionKind.RefactorInline,
+                                    CodeActionKind.RefactorRewrite,
+                                    CodeActionKind.Source,
+                                    CodeActionKind.SourceOrganizeImports,
+                                    CodeActionKind.SourceFixAll,
+                                ),
+                            ),
+                        )
+                    isPreferredSupport = true
+                    disabledSupport = true
+                }
+        }
+    return ClientCapabilities().apply {
+        workspace = workspaceCapabilities
+        textDocument = textDocumentCapabilities
+        experimental =
+            mapOf(
+                "snippetTextEdit" to true,
+            )
+    }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientCapabilities.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientCapabilities.kt
@@ -6,6 +6,8 @@ import org.eclipse.lsp4j.CodeActionCapabilities
 import org.eclipse.lsp4j.CodeActionKind
 import org.eclipse.lsp4j.CodeActionKindCapabilities
 import org.eclipse.lsp4j.CodeActionLiteralSupportCapabilities
+import org.eclipse.lsp4j.FileOperationsWorkspaceCapabilities
+import org.eclipse.lsp4j.RenameCapabilities
 import org.eclipse.lsp4j.TextDocumentClientCapabilities
 import org.eclipse.lsp4j.WorkspaceClientCapabilities
 import org.eclipse.lsp4j.WorkspaceEditCapabilities
@@ -13,10 +15,15 @@ import org.eclipse.lsp4j.WorkspaceEditCapabilities
 internal fun createClientCapabilities(): ClientCapabilities {
     val workspaceCapabilities =
         WorkspaceClientCapabilities().apply {
+            applyEdit = true
             workspaceFolders = true
             workspaceEdit =
                 WorkspaceEditCapabilities().apply {
                     documentChanges = true
+                }
+            fileOperations =
+                FileOperationsWorkspaceCapabilities().apply {
+                    willRename = true
                 }
         }
     val textDocumentCapabilities =
@@ -40,6 +47,10 @@ internal fun createClientCapabilities(): ClientCapabilities {
                         )
                     isPreferredSupport = true
                     disabledSupport = true
+                }
+            rename =
+                RenameCapabilities().apply {
+                    prepareSupport = true
                 }
         }
     return ClientCapabilities().apply {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
@@ -11,11 +11,9 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtilCore
-import com.intellij.remoteDev.thinClientLink.ClientToGtwMessage
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
-import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.lsp4j.Command
@@ -26,6 +24,7 @@ import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.InitializedParams
+import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.Launcher
@@ -47,6 +46,7 @@ internal class LspClientConnectionManager(
     private val project: Project,
     private val sdk: DartSdk,
     private val suppressAnalytics: Boolean,
+    onPublishDiagnostics: (PublishDiagnosticsParams) -> Unit = {},
 ) {
     private companion object {
         private val LOG = Logger.getInstance(LspClientConnectionManager::class.java)
@@ -85,7 +85,7 @@ internal class LspClientConnectionManager(
     @Volatile
     private var serverTextDocumentSyncKind = TextDocumentSyncKind.Full
 
-    private val languageClient = NoOpDartLanguageClient()
+    private val languageClient = DartLspLanguageClient(onPublishDiagnostics)
     private val workspaceFoldersManager = LspWorkspaceFoldersManager()
 
     private class StartupSession(

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
@@ -7,10 +7,10 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtilCore
-import com.intellij.util.PathUtil
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
@@ -18,12 +18,12 @@ import org.eclipse.lsp4j.ClientCapabilities
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializedParams
 import org.eclipse.lsp4j.WorkspaceFolder
-import org.eclipse.lsp4j.jsonrpc.Endpoint
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.services.LanguageServer
 import java.util.MissingResourceException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
@@ -44,6 +44,7 @@ internal class LspClientConnectionManager(
   private val lock = Any()
   private val statusListeners = CopyOnWriteArrayList<AnalysisServerStatusListener>()
   private val statusVersion = AtomicLong()
+  private val listenerStatusVersions = ConcurrentHashMap<AnalysisServerStatusListener, Long>()
 
   @Volatile
   private var process: Process? = null
@@ -56,12 +57,6 @@ internal class LspClientConnectionManager(
 
   @Volatile
   private var pendingServer: DartExtendedLanguageServer? = null
-
-  @Volatile
-  private var remoteEndpoint: Endpoint? = null
-
-  @Volatile
-  private var pendingEndpoint: Endpoint? = null
 
   @Volatile
   private var listeningFuture: Future<*>? = null
@@ -79,7 +74,6 @@ internal class LspClientConnectionManager(
   private class StartupSession(
     val process: Process,
     val server: DartExtendedLanguageServer,
-    val endpoint: Endpoint,
     val listeningFuture: Future<*>,
   )
 
@@ -152,16 +146,14 @@ internal class LspClientConnectionManager(
       .setOutput(startedProcess.outputStream)
       .create()
     val startedServer = launcher.remoteProxy
-    val startedEndpoint = launcher.remoteEndpoint
     val startedListeningFuture = launcher.startListening()
-    return StartupSession(startedProcess, startedServer, startedEndpoint, startedListeningFuture)
+    return StartupSession(startedProcess, startedServer, startedListeningFuture)
   }
 
   private fun registerPendingStartup(startupSession: StartupSession) {
     synchronized(lock) {
       pendingProcess = startupSession.process
       pendingServer = startupSession.server
-      pendingEndpoint = startupSession.endpoint
       pendingListeningFuture = startupSession.listeningFuture
     }
   }
@@ -170,18 +162,15 @@ internal class LspClientConnectionManager(
     return startupInProgress &&
            pendingProcess === startupSession.process &&
            pendingServer === startupSession.server &&
-           pendingEndpoint === startupSession.endpoint &&
            pendingListeningFuture === startupSession.listeningFuture
   }
 
   private fun activatePendingStartupLocked(startupSession: StartupSession) {
     process = startupSession.process
     remoteServer = startupSession.server
-    remoteEndpoint = startupSession.endpoint
     listeningFuture = startupSession.listeningFuture
     pendingProcess = null
     pendingServer = null
-    pendingEndpoint = null
     pendingListeningFuture = null
   }
 
@@ -190,17 +179,10 @@ internal class LspClientConnectionManager(
       if (startupSession != null) {
         if (pendingProcess === startupSession.process) pendingProcess = null
         if (pendingServer === startupSession.server) pendingServer = null
-        if (pendingEndpoint === startupSession.endpoint) pendingEndpoint = null
         if (pendingListeningFuture === startupSession.listeningFuture) pendingListeningFuture = null
       }
       startupInProgress = false
     }
-  }
-
-  fun request(method: String, params: Any?): CompletableFuture<*> {
-    val endpoint = synchronized(lock) { remoteEndpoint }
-                   ?: throw IllegalStateException("Dart LSP server is not running")
-    return endpoint.request(method, params)
   }
 
   fun requestDiagnosticServer(): CompletableFuture<DartDiagnosticServerResult> {
@@ -212,13 +194,15 @@ internal class LspClientConnectionManager(
   fun isSocketOpen(): Boolean = process?.isAlive == true
 
   fun addStatusListener(listener: AnalysisServerStatusListener) {
-    statusListeners.add(listener)
-    val statusVersionSnapshot = statusVersion.get()
-    if (isServerAlive) {
-      notifyStatusListener(listener, true)
-      if (!isServerAlive && statusVersion.get() != statusVersionSnapshot) {
-        notifyStatusListener(listener, false)
-      }
+    val statusVersionSnapshot: Long
+    val serverAlive: Boolean
+    synchronized(lock) {
+      statusListeners.add(listener)
+      statusVersionSnapshot = statusVersion.get()
+      serverAlive = isServerAlive
+    }
+    if (serverAlive) {
+      notifyStatusListener(listener, true, statusVersionSnapshot)
     }
   }
 
@@ -232,11 +216,9 @@ internal class LspClientConnectionManager(
       localListeningFuture = listeningFuture ?: pendingListeningFuture
       process = null
       remoteServer = null
-      remoteEndpoint = null
       listeningFuture = null
       pendingProcess = null
       pendingServer = null
-      pendingEndpoint = null
       pendingListeningFuture = null
       startupInProgress = false
     }
@@ -252,7 +234,7 @@ internal class LspClientConnectionManager(
       )
     }
 
-    val runtimePath = PathUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+    val runtimePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
     val vmArguments = try {
       StringUtil.split(Registry.stringValue("dart.server.vm.options"), " ")
     }
@@ -321,14 +303,12 @@ internal class LspClientConnectionManager(
           if (process === startedProcess) {
             process = null
             remoteServer = null
-            remoteEndpoint = null
             listeningFuture = null
             notifyDead = true
           }
           if (pendingProcess === startedProcess) {
             pendingProcess = null
             pendingServer = null
-            pendingEndpoint = null
             pendingListeningFuture = null
             startupInProgress = false
           }
@@ -420,19 +400,30 @@ internal class LspClientConnectionManager(
 
   private fun notifyStatusListeners(isAlive: Boolean, statusVersionSnapshot: Long) {
     statusListeners.forEach { listener ->
-      if (statusVersion.get() != statusVersionSnapshot) {
-        return
-      }
-      notifyStatusListener(listener, isAlive)
+      notifyStatusListener(listener, isAlive, statusVersionSnapshot)
     }
   }
 
-  private fun notifyStatusListener(listener: AnalysisServerStatusListener, isAlive: Boolean) {
+  private fun notifyStatusListener(listener: AnalysisServerStatusListener, isAlive: Boolean, statusVersionSnapshot: Long) {
+    if (!recordNotificationVersion(listener, statusVersionSnapshot)) return
+
     try {
       listener.isAliveServer(isAlive)
     }
     catch (t: Throwable) {
       LOG.warn("Error in LSP status listener", t)
+    }
+  }
+
+  private fun recordNotificationVersion(listener: AnalysisServerStatusListener, statusVersionSnapshot: Long): Boolean {
+    while (true) {
+        val previousVersion = listenerStatusVersions.putIfAbsent(listener, statusVersionSnapshot) ?: return true
+        if (previousVersion >= statusVersionSnapshot) {
+        return false
+      }
+      if (listenerStatusVersions.replace(listener, previousVersion, statusVersionSnapshot)) {
+        return true
+      }
     }
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
@@ -11,11 +11,16 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.remoteDev.thinClientLink.ClientToGtwMessage
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
 import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.DidChangeTextDocumentParams
+import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.InitializeParams
@@ -24,8 +29,10 @@ import org.eclipse.lsp4j.InitializedParams
 import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.Launcher
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.services.LanguageServer
 import org.eclipse.lsp4j.services.TextDocumentService
+import org.eclipse.lsp4j.services.WorkspaceService
 import java.util.MissingResourceException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
@@ -79,6 +86,7 @@ internal class LspClientConnectionManager(
     private var serverTextDocumentSyncKind = TextDocumentSyncKind.Full
 
     private val languageClient = NoOpDartLanguageClient()
+    private val workspaceFoldersManager = LspWorkspaceFoldersManager()
 
     private class StartupSession(
         val process: Process,
@@ -182,6 +190,7 @@ internal class LspClientConnectionManager(
         pendingProcess = null
         pendingServer = null
         pendingListeningFuture = null
+        resetRegisteredWorkspaceFoldersLocked()
     }
 
     private fun failStartup(startupSession: StartupSession?) {
@@ -192,6 +201,7 @@ internal class LspClientConnectionManager(
                 if (pendingListeningFuture === startupSession.listeningFuture) pendingListeningFuture = null
             }
             startupInProgress = false
+            workspaceFoldersManager.clear()
         }
     }
 
@@ -214,6 +224,28 @@ internal class LspClientConnectionManager(
 
     fun didClose(params: DidCloseTextDocumentParams) {
         textDocumentService().didClose(params)
+    }
+
+    fun codeAction(params: CodeActionParams): CompletableFuture<List<Either<Command, CodeAction>>> {
+        return textDocumentService().codeAction(params)
+    }
+
+    fun didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams) {
+        workspaceService().didChangeWorkspaceFolders(params)
+    }
+
+    fun ensureWorkspaceFolderRegistered(
+        workspaceFolderUri: String,
+        toWorkspaceFolder: (String) -> WorkspaceFolder,
+    ) {
+        workspaceFoldersManager.ensureWorkspaceFolderRegistered(workspaceFolderUri, toWorkspaceFolder, this::didChangeWorkspaceFolders)
+    }
+
+    fun synchronizeWorkspaceFolders(
+        newWorkspaceFolderUris: Set<String>,
+        toWorkspaceFolder: (String) -> WorkspaceFolder,
+    ) {
+        workspaceFoldersManager.synchronizeWorkspaceFolders(newWorkspaceFolderUris, toWorkspaceFolder, this::didChangeWorkspaceFolders)
     }
 
     fun isSocketOpen(): Boolean = process?.isAlive == true
@@ -246,6 +278,7 @@ internal class LspClientConnectionManager(
             pendingServer = null
             pendingListeningFuture = null
             startupInProgress = false
+            workspaceFoldersManager.clear()
         }
 
         closeConnection(localServer, localProcess, localListeningFuture, sendShutdownRequest = true)
@@ -327,6 +360,7 @@ internal class LspClientConnectionManager(
                         process = null
                         remoteServer = null
                         listeningFuture = null
+                        workspaceFoldersManager.clear()
                         notifyDead = true
                     }
                     if (pendingProcess === startedProcess) {
@@ -334,6 +368,7 @@ internal class LspClientConnectionManager(
                         pendingServer = null
                         pendingListeningFuture = null
                         startupInProgress = false
+                        workspaceFoldersManager.clear()
                     }
                 }
                 if (notifyDead) {
@@ -379,12 +414,12 @@ internal class LspClientConnectionManager(
     }
 
     private fun initializeServer(server: LanguageServer) {
+        val initialWorkspaceFolders = initialWorkspaceFolders()
         val initializeParams =
             InitializeParams().apply {
-                capabilities = ClientCapabilities()
-                val basePath = project.basePath
-                if (basePath != null) {
-                    workspaceFolders = listOf(WorkspaceFolder(VfsUtilCore.pathToUrl(basePath), project.name))
+                capabilities = createClientCapabilities()
+                if (initialWorkspaceFolders.isNotEmpty()) {
+                    workspaceFolders = initialWorkspaceFolders
                 } else {
                     LOG.warn("Dart LSP: project.basePath is null, workspaceFolders not set")
                 }
@@ -397,6 +432,15 @@ internal class LspClientConnectionManager(
         val initializeResult = server.initialize(initializeParams).get(INITIALIZE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         serverTextDocumentSyncKind = extractTextDocumentSyncKind(initializeResult)
         server.initialized(InitializedParams())
+    }
+
+    private fun initialWorkspaceFolders(): List<WorkspaceFolder> {
+        val basePath = project.basePath ?: return emptyList()
+        return listOf(WorkspaceFolder(VfsUtilCore.pathToUrl(basePath), project.name))
+    }
+
+    private fun resetRegisteredWorkspaceFoldersLocked() {
+        workspaceFoldersManager.resetRegisteredWorkspaceFolders(initialWorkspaceFolders().map(WorkspaceFolder::getUri))
     }
 
     private fun extractTextDocumentSyncKind(initializeResult: InitializeResult?): TextDocumentSyncKind {
@@ -414,6 +458,13 @@ internal class LspClientConnectionManager(
             synchronized(lock) { remoteServer }
                 ?: throw IllegalStateException("Dart LSP server is not running")
         return server.textDocumentService
+    }
+
+    private fun workspaceService(): WorkspaceService {
+        val server =
+            synchronized(lock) { remoteServer }
+                ?: throw IllegalStateException("Dart LSP server is not running")
+        return server.workspaceService
     }
 
     private fun notifyAliveIfCurrent(expectedProcess: Process) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
@@ -1,0 +1,438 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import com.google.dart.server.AnalysisServerStatusListener
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ApplicationNamesInfo
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.util.PathUtil
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
+import com.jetbrains.lang.dart.sdk.DartSdk
+import com.jetbrains.lang.dart.sdk.DartSdkUtil
+import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.InitializedParams
+import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.jsonrpc.Endpoint
+import org.eclipse.lsp4j.jsonrpc.Launcher
+import org.eclipse.lsp4j.services.LanguageServer
+import java.util.MissingResourceException
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+internal class LspClientConnectionManager(
+  private val project: Project,
+  private val sdk: DartSdk,
+  private val suppressAnalytics: Boolean,
+) {
+  private companion object {
+    private val LOG = Logger.getInstance(LspClientConnectionManager::class.java)
+    private const val INITIALIZE_TIMEOUT_SECONDS = 10L
+    private const val SHUTDOWN_TIMEOUT_SECONDS = 1L
+  }
+
+  private val lock = Any()
+  private val statusListeners = CopyOnWriteArrayList<AnalysisServerStatusListener>()
+  private val statusVersion = AtomicLong()
+
+  @Volatile
+  private var process: Process? = null
+
+  @Volatile
+  private var pendingProcess: Process? = null
+
+  @Volatile
+  private var remoteServer: DartExtendedLanguageServer? = null
+
+  @Volatile
+  private var pendingServer: DartExtendedLanguageServer? = null
+
+  @Volatile
+  private var remoteEndpoint: Endpoint? = null
+
+  @Volatile
+  private var pendingEndpoint: Endpoint? = null
+
+  @Volatile
+  private var listeningFuture: Future<*>? = null
+
+  @Volatile
+  private var pendingListeningFuture: Future<*>? = null
+
+  private var startupInProgress = false
+
+  @Volatile
+  private var isServerAlive = false
+
+  private val languageClient = NoOpDartLanguageClient()
+
+  private class StartupSession(
+    val process: Process,
+    val server: DartExtendedLanguageServer,
+    val endpoint: Endpoint,
+    val listeningFuture: Future<*>,
+  )
+
+  fun start() {
+    if (!beginStartupIfNeeded()) return
+
+    var startupSession: StartupSession? = null
+
+    try {
+      val createdSession = createStartupSession()
+      startupSession = createdSession
+      registerPendingStartup(createdSession)
+
+      startErrorReader(createdSession.process)
+      monitorListening(createdSession.process, createdSession.listeningFuture)
+      initializeServer(createdSession.server)
+
+      val startupPromoted = synchronized(lock) {
+        val startupStillCurrent = isPendingStartupSessionCurrentLocked(createdSession)
+        if (startupStillCurrent) {
+          activatePendingStartupLocked(createdSession)
+        }
+        startupInProgress = false
+        startupStillCurrent
+      }
+
+      if (!startupPromoted) {
+        closeConnection(
+          createdSession.server,
+          createdSession.process,
+          createdSession.listeningFuture,
+          sendShutdownRequest = false,
+        )
+        return
+      }
+
+      notifyAliveIfCurrent(createdSession.process)
+    }
+    catch (t: Throwable) {
+      failStartup(startupSession)
+      closeConnection(
+        localServer = startupSession?.server,
+        localProcess = startupSession?.process,
+        localListeningFuture = startupSession?.listeningFuture,
+        sendShutdownRequest = false,
+      )
+      LOG.warn("Failed to start Dart LSP server", t)
+      notifyDeadIfChanged()
+      throw t
+    }
+  }
+
+  private fun beginStartupIfNeeded(): Boolean {
+    synchronized(lock) {
+      if (process?.isAlive == true || startupInProgress) {
+        return false
+      }
+      startupInProgress = true
+      return true
+    }
+  }
+
+  private fun createStartupSession(): StartupSession {
+    val command = buildCommandLine()
+    val startedProcess = ProcessBuilder(command).start()
+    val launcher = Launcher.Builder<DartExtendedLanguageServer>()
+      .setLocalService(languageClient)
+      .setRemoteInterface(DartExtendedLanguageServer::class.java)
+      .setInput(startedProcess.inputStream)
+      .setOutput(startedProcess.outputStream)
+      .create()
+    val startedServer = launcher.remoteProxy
+    val startedEndpoint = launcher.remoteEndpoint
+    val startedListeningFuture = launcher.startListening()
+    return StartupSession(startedProcess, startedServer, startedEndpoint, startedListeningFuture)
+  }
+
+  private fun registerPendingStartup(startupSession: StartupSession) {
+    synchronized(lock) {
+      pendingProcess = startupSession.process
+      pendingServer = startupSession.server
+      pendingEndpoint = startupSession.endpoint
+      pendingListeningFuture = startupSession.listeningFuture
+    }
+  }
+
+  private fun isPendingStartupSessionCurrentLocked(startupSession: StartupSession): Boolean {
+    return startupInProgress &&
+           pendingProcess === startupSession.process &&
+           pendingServer === startupSession.server &&
+           pendingEndpoint === startupSession.endpoint &&
+           pendingListeningFuture === startupSession.listeningFuture
+  }
+
+  private fun activatePendingStartupLocked(startupSession: StartupSession) {
+    process = startupSession.process
+    remoteServer = startupSession.server
+    remoteEndpoint = startupSession.endpoint
+    listeningFuture = startupSession.listeningFuture
+    pendingProcess = null
+    pendingServer = null
+    pendingEndpoint = null
+    pendingListeningFuture = null
+  }
+
+  private fun failStartup(startupSession: StartupSession?) {
+    synchronized(lock) {
+      if (startupSession != null) {
+        if (pendingProcess === startupSession.process) pendingProcess = null
+        if (pendingServer === startupSession.server) pendingServer = null
+        if (pendingEndpoint === startupSession.endpoint) pendingEndpoint = null
+        if (pendingListeningFuture === startupSession.listeningFuture) pendingListeningFuture = null
+      }
+      startupInProgress = false
+    }
+  }
+
+  fun request(method: String, params: Any?): CompletableFuture<*> {
+    val endpoint = synchronized(lock) { remoteEndpoint }
+                   ?: throw IllegalStateException("Dart LSP server is not running")
+    return endpoint.request(method, params)
+  }
+
+  fun requestDiagnosticServer(): CompletableFuture<DartDiagnosticServerResult> {
+    val server = synchronized(lock) { remoteServer }
+                 ?: throw IllegalStateException("Dart LSP server is not running")
+    return server.diagnosticServer()
+  }
+
+  fun isSocketOpen(): Boolean = process?.isAlive == true
+
+  fun addStatusListener(listener: AnalysisServerStatusListener) {
+    statusListeners.add(listener)
+    val statusVersionSnapshot = statusVersion.get()
+    if (isServerAlive) {
+      notifyStatusListener(listener, true)
+      if (!isServerAlive && statusVersion.get() != statusVersionSnapshot) {
+        notifyStatusListener(listener, false)
+      }
+    }
+  }
+
+  fun shutdown() {
+    val localProcess: Process?
+    val localServer: LanguageServer?
+    val localListeningFuture: Future<*>?
+    synchronized(lock) {
+      localProcess = process ?: pendingProcess
+      localServer = remoteServer ?: pendingServer
+      localListeningFuture = listeningFuture ?: pendingListeningFuture
+      process = null
+      remoteServer = null
+      remoteEndpoint = null
+      listeningFuture = null
+      pendingProcess = null
+      pendingServer = null
+      pendingEndpoint = null
+      pendingListeningFuture = null
+      startupInProgress = false
+    }
+
+    closeConnection(localServer, localProcess, localListeningFuture, sendShutdownRequest = true)
+    notifyDeadIfChanged()
+  }
+
+  private fun buildCommandLine(): List<String> {
+    if (!DartAnalysisServerService.isDartSdkVersionSufficientForDartLangServer(sdk)) {
+      throw IllegalStateException(
+        "LSP client requires Dart SDK version ${DartAnalysisServerService.MIN_DART_LANG_SERVER_SDK_VERSION} or newer",
+      )
+    }
+
+    val runtimePath = PathUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+    val vmArguments = try {
+      StringUtil.split(Registry.stringValue("dart.server.vm.options"), " ")
+    }
+    catch (_: MissingResourceException) {
+      emptyList()
+    }
+
+    val serverArgsRaw = buildString {
+      append("--protocol=lsp")
+      if (suppressAnalytics) {
+        append(" --suppress-analytics")
+      }
+      try {
+        val extra = Registry.stringValue("dart.server.additional.arguments")
+        if (extra.isNotBlank()) {
+          append(" ").append(extra)
+        }
+      }
+      catch (_: MissingResourceException) {
+      }
+    }
+    val serverArguments = StringUtil.split(serverArgsRaw, " ")
+
+    val clientId = ApplicationNamesInfo.getInstance().fullProductName.replace(' ', '-')
+    val clientVersion = ApplicationInfo.getInstance().apiVersion
+
+    return mutableListOf<String>().apply {
+      add(runtimePath)
+      addAll(vmArguments)
+      add("language-server")
+      add("--client-id=$clientId")
+      add("--client-version=$clientVersion")
+      addAll(serverArguments)
+    }
+  }
+
+  private fun startErrorReader(startedProcess: Process) {
+    ApplicationManager.getApplication().executeOnPooledThread {
+      startedProcess.errorStream.bufferedReader().useLines { lines ->
+        lines.forEach { line ->
+          LOG.debug("[dart-lsp stderr] $line")
+        }
+      }
+    }
+  }
+
+  private fun monitorListening(startedProcess: Process, future: Future<*>?) {
+    ApplicationManager.getApplication().executeOnPooledThread {
+      try {
+        future?.get()
+      }
+      catch (_: CancellationException) {
+      }
+      catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+      }
+      catch (e: ExecutionException) {
+        LOG.warn("Dart LSP listening loop failed", e.cause ?: e)
+      }
+      catch (t: Throwable) {
+        LOG.warn("Unexpected error in Dart LSP listening loop", t)
+      }
+      finally {
+        var notifyDead = false
+        synchronized(lock) {
+          if (process === startedProcess) {
+            process = null
+            remoteServer = null
+            remoteEndpoint = null
+            listeningFuture = null
+            notifyDead = true
+          }
+          if (pendingProcess === startedProcess) {
+            pendingProcess = null
+            pendingServer = null
+            pendingEndpoint = null
+            pendingListeningFuture = null
+            startupInProgress = false
+          }
+        }
+        if (notifyDead) {
+          notifyDeadIfChanged()
+        }
+      }
+    }
+  }
+
+  private fun closeConnection(
+    localServer: LanguageServer?,
+    localProcess: Process?,
+    localListeningFuture: Future<*>?,
+    sendShutdownRequest: Boolean,
+  ) {
+    if (sendShutdownRequest) {
+      try {
+        localServer?.shutdown()?.get(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      }
+      catch (t: Throwable) {
+        LOG.debug("Error while sending shutdown to Dart LSP server", t)
+      }
+
+      try {
+        localServer?.exit()
+      }
+      catch (t: Throwable) {
+        LOG.debug("Error while sending exit to Dart LSP server", t)
+      }
+    }
+
+    if (localProcess != null && localProcess.isAlive) {
+      localProcess.destroy()
+      try {
+        if (!localProcess.waitFor(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          localProcess.destroyForcibly()
+        }
+      }
+      catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        localProcess.destroyForcibly()
+      }
+    }
+
+    localListeningFuture?.cancel(true)
+  }
+
+  private fun initializeServer(server: LanguageServer) {
+    val initializeParams = InitializeParams().apply {
+      capabilities = ClientCapabilities()
+      val basePath = project.basePath
+      if (basePath != null) {
+        workspaceFolders = listOf(WorkspaceFolder(VfsUtilCore.pathToUrl(basePath), project.name))
+      }
+      else {
+        LOG.warn("Dart LSP: project.basePath is null, workspaceFolders not set")
+      }
+      val currentPid = ProcessHandle.current().pid()
+      if (currentPid in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+        processId = currentPid.toInt()
+      }
+    }
+
+    server.initialize(initializeParams).get(INITIALIZE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    server.initialized(InitializedParams())
+  }
+
+  private fun notifyAliveIfCurrent(expectedProcess: Process) {
+    val statusVersionSnapshot = synchronized(lock) {
+      if (process !== expectedProcess) {
+        return
+      }
+      isServerAlive = true
+      statusVersion.incrementAndGet()
+    }
+    notifyStatusListeners(true, statusVersionSnapshot)
+  }
+
+  private fun notifyDeadIfChanged() {
+    val statusVersionSnapshot = synchronized(lock) {
+      if (!isServerAlive) return
+      isServerAlive = false
+      statusVersion.incrementAndGet()
+    }
+    notifyStatusListeners(false, statusVersionSnapshot)
+  }
+
+  private fun notifyStatusListeners(isAlive: Boolean, statusVersionSnapshot: Long) {
+    statusListeners.forEach { listener ->
+      if (statusVersion.get() != statusVersionSnapshot) {
+        return
+      }
+      notifyStatusListener(listener, isAlive)
+    }
+  }
+
+  private fun notifyStatusListener(listener: AnalysisServerStatusListener, isAlive: Boolean) {
+    try {
+      listener.isAliveServer(isAlive)
+    }
+    catch (t: Throwable) {
+      LOG.warn("Error in LSP status listener", t)
+    }
+  }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
@@ -37,434 +37,442 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 internal class LspClientConnectionManager(
-  private val project: Project,
-  private val sdk: DartSdk,
-  private val suppressAnalytics: Boolean,
+    private val project: Project,
+    private val sdk: DartSdk,
+    private val suppressAnalytics: Boolean,
 ) {
-  private companion object {
-    private val LOG = Logger.getInstance(LspClientConnectionManager::class.java)
-    private const val INITIALIZE_TIMEOUT_SECONDS = 10L
-    private const val SHUTDOWN_TIMEOUT_SECONDS = 1L
-  }
+    private companion object {
+        private val LOG = Logger.getInstance(LspClientConnectionManager::class.java)
+        private const val INITIALIZE_TIMEOUT_SECONDS = 10L
+        private const val SHUTDOWN_TIMEOUT_SECONDS = 1L
+    }
 
-  private val lock = Any()
-  private val statusListeners = CopyOnWriteArrayList<AnalysisServerStatusListener>()
-  private val statusVersion = AtomicLong()
-  private val listenerStatusVersions = ConcurrentHashMap<AnalysisServerStatusListener, Long>()
+    private val lock = Any()
+    private val statusListeners = CopyOnWriteArrayList<AnalysisServerStatusListener>()
+    private val statusVersion = AtomicLong()
+    private val listenerStatusVersions = ConcurrentHashMap<AnalysisServerStatusListener, Long>()
 
-  @Volatile
-  private var process: Process? = null
+    @Volatile
+    private var process: Process? = null
 
-  @Volatile
-  private var pendingProcess: Process? = null
+    @Volatile
+    private var pendingProcess: Process? = null
 
-  @Volatile
-  private var remoteServer: DartExtendedLanguageServer? = null
+    @Volatile
+    private var remoteServer: DartExtendedLanguageServer? = null
 
-  @Volatile
-  private var pendingServer: DartExtendedLanguageServer? = null
+    @Volatile
+    private var pendingServer: DartExtendedLanguageServer? = null
 
-  @Volatile
-  private var listeningFuture: Future<*>? = null
+    @Volatile
+    private var listeningFuture: Future<*>? = null
 
-  @Volatile
-  private var pendingListeningFuture: Future<*>? = null
+    @Volatile
+    private var pendingListeningFuture: Future<*>? = null
 
-  private var startupInProgress = false
+    private var startupInProgress = false
 
-  @Volatile
-  private var isServerAlive = false
+    @Volatile
+    private var isServerAlive = false
 
-  @Volatile
-  private var serverTextDocumentSyncKind = TextDocumentSyncKind.Full
+    @Volatile
+    private var serverTextDocumentSyncKind = TextDocumentSyncKind.Full
 
-  private val languageClient = NoOpDartLanguageClient()
+    private val languageClient = NoOpDartLanguageClient()
 
-  private class StartupSession(
-    val process: Process,
-    val server: DartExtendedLanguageServer,
-    val listeningFuture: Future<*>,
-  )
+    private class StartupSession(
+        val process: Process,
+        val server: DartExtendedLanguageServer,
+        val listeningFuture: Future<*>,
+    )
 
-  fun start() {
-    if (!beginStartupIfNeeded()) return
+    fun start() {
+        if (!beginStartupIfNeeded()) return
 
-    var startupSession: StartupSession? = null
+        var startupSession: StartupSession? = null
 
-    try {
-      val createdSession = createStartupSession()
-      startupSession = createdSession
-      registerPendingStartup(createdSession)
+        try {
+            val createdSession = createStartupSession()
+            startupSession = createdSession
+            registerPendingStartup(createdSession)
 
-      startErrorReader(createdSession.process)
-      monitorListening(createdSession.process, createdSession.listeningFuture)
-      initializeServer(createdSession.server)
+            startErrorReader(createdSession.process)
+            monitorListening(createdSession.process, createdSession.listeningFuture)
+            initializeServer(createdSession.server)
 
-      val startupPromoted = synchronized(lock) {
-        val startupStillCurrent = isPendingStartupSessionCurrentLocked(createdSession)
-        if (startupStillCurrent) {
-          activatePendingStartupLocked(createdSession)
+            val startupPromoted =
+                synchronized(lock) {
+                    val startupStillCurrent = isPendingStartupSessionCurrentLocked(createdSession)
+                    if (startupStillCurrent) {
+                        activatePendingStartupLocked(createdSession)
+                    }
+                    startupInProgress = false
+                    startupStillCurrent
+                }
+
+            if (!startupPromoted) {
+                closeConnection(
+                    createdSession.server,
+                    createdSession.process,
+                    createdSession.listeningFuture,
+                    sendShutdownRequest = false,
+                )
+                return
+            }
+
+            notifyAliveIfCurrent(createdSession.process)
+        } catch (t: Throwable) {
+            failStartup(startupSession)
+            closeConnection(
+                localServer = startupSession?.server,
+                localProcess = startupSession?.process,
+                localListeningFuture = startupSession?.listeningFuture,
+                sendShutdownRequest = false,
+            )
+            LOG.warn("Failed to start Dart LSP server", t)
+            notifyDeadIfChanged()
+            throw t
         }
-        startupInProgress = false
-        startupStillCurrent
-      }
-
-      if (!startupPromoted) {
-        closeConnection(
-          createdSession.server,
-          createdSession.process,
-          createdSession.listeningFuture,
-          sendShutdownRequest = false,
-        )
-        return
-      }
-
-      notifyAliveIfCurrent(createdSession.process)
-    }
-    catch (t: Throwable) {
-      failStartup(startupSession)
-      closeConnection(
-        localServer = startupSession?.server,
-        localProcess = startupSession?.process,
-        localListeningFuture = startupSession?.listeningFuture,
-        sendShutdownRequest = false,
-      )
-      LOG.warn("Failed to start Dart LSP server", t)
-      notifyDeadIfChanged()
-      throw t
-    }
-  }
-
-  private fun beginStartupIfNeeded(): Boolean {
-    synchronized(lock) {
-      if (process?.isAlive == true || startupInProgress) {
-        return false
-      }
-      startupInProgress = true
-      return true
-    }
-  }
-
-  private fun createStartupSession(): StartupSession {
-    val command = buildCommandLine()
-    val startedProcess = ProcessBuilder(command).start()
-    val launcher = Launcher.Builder<DartExtendedLanguageServer>()
-      .setLocalService(languageClient)
-      .setRemoteInterface(DartExtendedLanguageServer::class.java)
-      .setInput(startedProcess.inputStream)
-      .setOutput(startedProcess.outputStream)
-      .create()
-    val startedServer = launcher.remoteProxy
-    val startedListeningFuture = launcher.startListening()
-    return StartupSession(startedProcess, startedServer, startedListeningFuture)
-  }
-
-  private fun registerPendingStartup(startupSession: StartupSession) {
-    synchronized(lock) {
-      pendingProcess = startupSession.process
-      pendingServer = startupSession.server
-      pendingListeningFuture = startupSession.listeningFuture
-    }
-  }
-
-  private fun isPendingStartupSessionCurrentLocked(startupSession: StartupSession): Boolean {
-    return startupInProgress &&
-           pendingProcess === startupSession.process &&
-           pendingServer === startupSession.server &&
-           pendingListeningFuture === startupSession.listeningFuture
-  }
-
-  private fun activatePendingStartupLocked(startupSession: StartupSession) {
-    process = startupSession.process
-    remoteServer = startupSession.server
-    listeningFuture = startupSession.listeningFuture
-    pendingProcess = null
-    pendingServer = null
-    pendingListeningFuture = null
-  }
-
-  private fun failStartup(startupSession: StartupSession?) {
-    synchronized(lock) {
-      if (startupSession != null) {
-        if (pendingProcess === startupSession.process) pendingProcess = null
-        if (pendingServer === startupSession.server) pendingServer = null
-        if (pendingListeningFuture === startupSession.listeningFuture) pendingListeningFuture = null
-      }
-      startupInProgress = false
-    }
-  }
-
-  fun requestDiagnosticServer(): CompletableFuture<DartDiagnosticServerResult> {
-    val server = synchronized(lock) { remoteServer }
-                 ?: throw IllegalStateException("Dart LSP server is not running")
-    return server.diagnosticServer()
-  }
-
-  fun textDocumentSyncKind(): TextDocumentSyncKind = serverTextDocumentSyncKind
-
-  fun didOpen(params: DidOpenTextDocumentParams) {
-    textDocumentService().didOpen(params)
-  }
-
-  fun didChange(params: DidChangeTextDocumentParams) {
-    textDocumentService().didChange(params)
-  }
-
-  fun didClose(params: DidCloseTextDocumentParams) {
-    textDocumentService().didClose(params)
-  }
-
-  fun isSocketOpen(): Boolean = process?.isAlive == true
-
-  fun addStatusListener(listener: AnalysisServerStatusListener) {
-    val statusVersionSnapshot: Long
-    val serverAlive: Boolean
-    synchronized(lock) {
-      statusListeners.add(listener)
-      statusVersionSnapshot = statusVersion.get()
-      serverAlive = isServerAlive
-    }
-    if (serverAlive) {
-      notifyStatusListener(listener, true, statusVersionSnapshot)
-    }
-  }
-
-  fun shutdown() {
-    val localProcess: Process?
-    val localServer: LanguageServer?
-    val localListeningFuture: Future<*>?
-    synchronized(lock) {
-      localProcess = process ?: pendingProcess
-      localServer = remoteServer ?: pendingServer
-      localListeningFuture = listeningFuture ?: pendingListeningFuture
-      process = null
-      remoteServer = null
-      listeningFuture = null
-      pendingProcess = null
-      pendingServer = null
-      pendingListeningFuture = null
-      startupInProgress = false
     }
 
-    closeConnection(localServer, localProcess, localListeningFuture, sendShutdownRequest = true)
-    notifyDeadIfChanged()
-  }
-
-  private fun buildCommandLine(): List<String> {
-    if (!DartAnalysisServerService.isDartSdkVersionSufficientForDartLangServer(sdk)) {
-      throw IllegalStateException(
-        "LSP client requires Dart SDK version ${DartAnalysisServerService.MIN_DART_LANG_SERVER_SDK_VERSION} or newer",
-      )
-    }
-
-    val runtimePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
-    val vmArguments = try {
-      StringUtil.split(Registry.stringValue("dart.server.vm.options"), " ")
-    }
-    catch (_: MissingResourceException) {
-      emptyList()
-    }
-
-    val serverArgsRaw = buildString {
-      append("--protocol=lsp")
-      if (suppressAnalytics) {
-        append(" --suppress-analytics")
-      }
-      try {
-        val extra = Registry.stringValue("dart.server.additional.arguments")
-        if (extra.isNotBlank()) {
-          append(" ").append(extra)
-        }
-      }
-      catch (_: MissingResourceException) {
-      }
-    }
-    val serverArguments = StringUtil.split(serverArgsRaw, " ")
-
-    val clientId = ApplicationNamesInfo.getInstance().fullProductName.replace(' ', '-')
-    val clientVersion = ApplicationInfo.getInstance().apiVersion
-
-    return mutableListOf<String>().apply {
-      add(runtimePath)
-      addAll(vmArguments)
-      add("language-server")
-      add("--client-id=$clientId")
-      add("--client-version=$clientVersion")
-      addAll(serverArguments)
-    }
-  }
-
-  private fun startErrorReader(startedProcess: Process) {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      startedProcess.errorStream.bufferedReader().useLines { lines ->
-        lines.forEach { line ->
-          LOG.debug("[dart-lsp stderr] $line")
-        }
-      }
-    }
-  }
-
-  private fun monitorListening(startedProcess: Process, future: Future<*>?) {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      try {
-        future?.get()
-      }
-      catch (_: CancellationException) {
-      }
-      catch (_: InterruptedException) {
-        Thread.currentThread().interrupt()
-      }
-      catch (e: ExecutionException) {
-        LOG.warn("Dart LSP listening loop failed", e.cause ?: e)
-      }
-      catch (t: Throwable) {
-        LOG.warn("Unexpected error in Dart LSP listening loop", t)
-      }
-      finally {
-        var notifyDead = false
+    private fun beginStartupIfNeeded(): Boolean {
         synchronized(lock) {
-          if (process === startedProcess) {
+            if (process?.isAlive == true || startupInProgress) {
+                return false
+            }
+            startupInProgress = true
+            return true
+        }
+    }
+
+    private fun createStartupSession(): StartupSession {
+        val command = buildCommandLine()
+        val startedProcess = ProcessBuilder(command).start()
+        val launcher =
+            Launcher.Builder<DartExtendedLanguageServer>()
+                .setLocalService(languageClient)
+                .setRemoteInterface(DartExtendedLanguageServer::class.java)
+                .setInput(startedProcess.inputStream)
+                .setOutput(startedProcess.outputStream)
+                .create()
+        val startedServer = launcher.remoteProxy
+        val startedListeningFuture = launcher.startListening()
+        return StartupSession(startedProcess, startedServer, startedListeningFuture)
+    }
+
+    private fun registerPendingStartup(startupSession: StartupSession) {
+        synchronized(lock) {
+            pendingProcess = startupSession.process
+            pendingServer = startupSession.server
+            pendingListeningFuture = startupSession.listeningFuture
+        }
+    }
+
+    private fun isPendingStartupSessionCurrentLocked(startupSession: StartupSession): Boolean {
+        return startupInProgress &&
+            pendingProcess === startupSession.process &&
+            pendingServer === startupSession.server &&
+            pendingListeningFuture === startupSession.listeningFuture
+    }
+
+    private fun activatePendingStartupLocked(startupSession: StartupSession) {
+        process = startupSession.process
+        remoteServer = startupSession.server
+        listeningFuture = startupSession.listeningFuture
+        pendingProcess = null
+        pendingServer = null
+        pendingListeningFuture = null
+    }
+
+    private fun failStartup(startupSession: StartupSession?) {
+        synchronized(lock) {
+            if (startupSession != null) {
+                if (pendingProcess === startupSession.process) pendingProcess = null
+                if (pendingServer === startupSession.server) pendingServer = null
+                if (pendingListeningFuture === startupSession.listeningFuture) pendingListeningFuture = null
+            }
+            startupInProgress = false
+        }
+    }
+
+    fun requestDiagnosticServer(): CompletableFuture<DartDiagnosticServerResult> {
+        val server =
+            synchronized(lock) { remoteServer }
+                ?: throw IllegalStateException("Dart LSP server is not running")
+        return server.diagnosticServer()
+    }
+
+    fun textDocumentSyncKind(): TextDocumentSyncKind = serverTextDocumentSyncKind
+
+    fun didOpen(params: DidOpenTextDocumentParams) {
+        textDocumentService().didOpen(params)
+    }
+
+    fun didChange(params: DidChangeTextDocumentParams) {
+        textDocumentService().didChange(params)
+    }
+
+    fun didClose(params: DidCloseTextDocumentParams) {
+        textDocumentService().didClose(params)
+    }
+
+    fun isSocketOpen(): Boolean = process?.isAlive == true
+
+    fun addStatusListener(listener: AnalysisServerStatusListener) {
+        val statusVersionSnapshot: Long
+        val serverAlive: Boolean
+        synchronized(lock) {
+            statusListeners.add(listener)
+            statusVersionSnapshot = statusVersion.get()
+            serverAlive = isServerAlive
+        }
+        if (serverAlive) {
+            notifyStatusListener(listener, true, statusVersionSnapshot)
+        }
+    }
+
+    fun shutdown() {
+        val localProcess: Process?
+        val localServer: LanguageServer?
+        val localListeningFuture: Future<*>?
+        synchronized(lock) {
+            localProcess = process ?: pendingProcess
+            localServer = remoteServer ?: pendingServer
+            localListeningFuture = listeningFuture ?: pendingListeningFuture
             process = null
             remoteServer = null
             listeningFuture = null
-            notifyDead = true
-          }
-          if (pendingProcess === startedProcess) {
             pendingProcess = null
             pendingServer = null
             pendingListeningFuture = null
             startupInProgress = false
-          }
         }
-        if (notifyDead) {
-          notifyDeadIfChanged()
+
+        closeConnection(localServer, localProcess, localListeningFuture, sendShutdownRequest = true)
+        notifyDeadIfChanged()
+    }
+
+    private fun buildCommandLine(): List<String> {
+        if (!DartAnalysisServerService.isDartSdkVersionSufficientForDartLangServer(sdk)) {
+            throw IllegalStateException(
+                "LSP client requires Dart SDK version ${DartAnalysisServerService.MIN_DART_LANG_SERVER_SDK_VERSION} or newer",
+            )
         }
-      }
-    }
-  }
 
-  private fun closeConnection(
-    localServer: LanguageServer?,
-    localProcess: Process?,
-    localListeningFuture: Future<*>?,
-    sendShutdownRequest: Boolean,
-  ) {
-    if (sendShutdownRequest) {
-      try {
-        localServer?.shutdown()?.get(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-      }
-      catch (t: Throwable) {
-        LOG.debug("Error while sending shutdown to Dart LSP server", t)
-      }
+        val runtimePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+        val vmArguments =
+            try {
+                StringUtil.split(Registry.stringValue("dart.server.vm.options"), " ")
+            } catch (_: MissingResourceException) {
+                emptyList()
+            }
 
-      try {
-        localServer?.exit()
-      }
-      catch (t: Throwable) {
-        LOG.debug("Error while sending exit to Dart LSP server", t)
-      }
-    }
+        val serverArgsRaw =
+            buildString {
+                append("--protocol=lsp")
+                if (suppressAnalytics) {
+                    append(" --suppress-analytics")
+                }
+                try {
+                    val extra = Registry.stringValue("dart.server.additional.arguments")
+                    if (extra.isNotBlank()) {
+                        append(" ").append(extra)
+                    }
+                } catch (_: MissingResourceException) {
+                }
+            }
+        val serverArguments = StringUtil.split(serverArgsRaw, " ")
 
-    if (localProcess != null && localProcess.isAlive) {
-      localProcess.destroy()
-      try {
-        if (!localProcess.waitFor(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-          localProcess.destroyForcibly()
+        val clientId = ApplicationNamesInfo.getInstance().fullProductName.replace(' ', '-')
+        val clientVersion = ApplicationInfo.getInstance().apiVersion
+
+        return mutableListOf<String>().apply {
+            add(runtimePath)
+            addAll(vmArguments)
+            add("language-server")
+            add("--client-id=$clientId")
+            add("--client-version=$clientVersion")
+            addAll(serverArguments)
         }
-      }
-      catch (_: InterruptedException) {
-        Thread.currentThread().interrupt()
-        localProcess.destroyForcibly()
-      }
     }
 
-    localListeningFuture?.cancel(true)
-  }
-
-  private fun initializeServer(server: LanguageServer) {
-    val initializeParams = InitializeParams().apply {
-      capabilities = ClientCapabilities()
-      val basePath = project.basePath
-      if (basePath != null) {
-        workspaceFolders = listOf(WorkspaceFolder(VfsUtilCore.pathToUrl(basePath), project.name))
-      }
-      else {
-        LOG.warn("Dart LSP: project.basePath is null, workspaceFolders not set")
-      }
-      val currentPid = ProcessHandle.current().pid()
-      if (currentPid in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
-        processId = currentPid.toInt()
-      }
+    private fun startErrorReader(startedProcess: Process) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            startedProcess.errorStream.bufferedReader().useLines { lines ->
+                lines.forEach { line ->
+                    LOG.debug("[dart-lsp stderr] $line")
+                }
+            }
+        }
     }
 
-    val initializeResult = server.initialize(initializeParams).get(INITIALIZE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-    serverTextDocumentSyncKind = extractTextDocumentSyncKind(initializeResult)
-    server.initialized(InitializedParams())
-  }
-
-  private fun extractTextDocumentSyncKind(initializeResult: InitializeResult?): TextDocumentSyncKind {
-    val capabilities = initializeResult?.capabilities ?: return TextDocumentSyncKind.Full
-    val textDocumentSync = capabilities.textDocumentSync ?: return TextDocumentSyncKind.Full
-    return if (textDocumentSync.isLeft) {
-      textDocumentSync.left ?: TextDocumentSyncKind.Full
+    private fun monitorListening(
+        startedProcess: Process,
+        future: Future<*>?,
+    ) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                future?.get()
+            } catch (_: CancellationException) {
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+            } catch (e: ExecutionException) {
+                LOG.warn("Dart LSP listening loop failed", e.cause ?: e)
+            } catch (t: Throwable) {
+                LOG.warn("Unexpected error in Dart LSP listening loop", t)
+            } finally {
+                var notifyDead = false
+                synchronized(lock) {
+                    if (process === startedProcess) {
+                        process = null
+                        remoteServer = null
+                        listeningFuture = null
+                        notifyDead = true
+                    }
+                    if (pendingProcess === startedProcess) {
+                        pendingProcess = null
+                        pendingServer = null
+                        pendingListeningFuture = null
+                        startupInProgress = false
+                    }
+                }
+                if (notifyDead) {
+                    notifyDeadIfChanged()
+                }
+            }
+        }
     }
-    else {
-      textDocumentSync.right?.change ?: TextDocumentSyncKind.Full
-    }
-  }
 
-  private fun textDocumentService(): TextDocumentService {
-    val server = synchronized(lock) { remoteServer }
-                 ?: throw IllegalStateException("Dart LSP server is not running")
-    return server.textDocumentService
-  }
+    private fun closeConnection(
+        localServer: LanguageServer?,
+        localProcess: Process?,
+        localListeningFuture: Future<*>?,
+        sendShutdownRequest: Boolean,
+    ) {
+        if (sendShutdownRequest) {
+            try {
+                localServer?.shutdown()?.get(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            } catch (t: Throwable) {
+                LOG.debug("Error while sending shutdown to Dart LSP server", t)
+            }
 
-  private fun notifyAliveIfCurrent(expectedProcess: Process) {
-    val statusVersionSnapshot = synchronized(lock) {
-      if (process !== expectedProcess) {
-        return
-      }
-      isServerAlive = true
-      statusVersion.incrementAndGet()
-    }
-    notifyStatusListeners(true, statusVersionSnapshot)
-  }
+            try {
+                localServer?.exit()
+            } catch (t: Throwable) {
+                LOG.debug("Error while sending exit to Dart LSP server", t)
+            }
+        }
 
-  private fun notifyDeadIfChanged() {
-    val statusVersionSnapshot = synchronized(lock) {
-      if (!isServerAlive) return
-      isServerAlive = false
-      statusVersion.incrementAndGet()
-    }
-    notifyStatusListeners(false, statusVersionSnapshot)
-  }
+        if (localProcess != null && localProcess.isAlive) {
+            localProcess.destroy()
+            try {
+                if (!localProcess.waitFor(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    localProcess.destroyForcibly()
+                }
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                localProcess.destroyForcibly()
+            }
+        }
 
-  private fun notifyStatusListeners(isAlive: Boolean, statusVersionSnapshot: Long) {
-    statusListeners.forEach { listener ->
-      notifyStatusListener(listener, isAlive, statusVersionSnapshot)
+        localListeningFuture?.cancel(true)
     }
-  }
 
-  private fun notifyStatusListener(listener: AnalysisServerStatusListener, isAlive: Boolean, statusVersionSnapshot: Long) {
-    if (!recordNotificationVersion(listener, statusVersionSnapshot)) return
+    private fun initializeServer(server: LanguageServer) {
+        val initializeParams =
+            InitializeParams().apply {
+                capabilities = ClientCapabilities()
+                val basePath = project.basePath
+                if (basePath != null) {
+                    workspaceFolders = listOf(WorkspaceFolder(VfsUtilCore.pathToUrl(basePath), project.name))
+                } else {
+                    LOG.warn("Dart LSP: project.basePath is null, workspaceFolders not set")
+                }
+                val currentPid = ProcessHandle.current().pid()
+                if (currentPid in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+                    processId = currentPid.toInt()
+                }
+            }
 
-    try {
-      listener.isAliveServer(isAlive)
+        val initializeResult = server.initialize(initializeParams).get(INITIALIZE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        serverTextDocumentSyncKind = extractTextDocumentSyncKind(initializeResult)
+        server.initialized(InitializedParams())
     }
-    catch (t: Throwable) {
-      LOG.warn("Error in LSP status listener", t)
-    }
-  }
 
-  private fun recordNotificationVersion(listener: AnalysisServerStatusListener, statusVersionSnapshot: Long): Boolean {
-    while (true) {
-        val previousVersion = listenerStatusVersions.putIfAbsent(listener, statusVersionSnapshot) ?: return true
-        if (previousVersion >= statusVersionSnapshot) {
-        return false
-      }
-      if (listenerStatusVersions.replace(listener, previousVersion, statusVersionSnapshot)) {
-        return true
-      }
+    private fun extractTextDocumentSyncKind(initializeResult: InitializeResult?): TextDocumentSyncKind {
+        val capabilities = initializeResult?.capabilities ?: return TextDocumentSyncKind.Full
+        val textDocumentSync = capabilities.textDocumentSync ?: return TextDocumentSyncKind.Full
+        return if (textDocumentSync.isLeft) {
+            textDocumentSync.left ?: TextDocumentSyncKind.Full
+        } else {
+            textDocumentSync.right?.change ?: TextDocumentSyncKind.Full
+        }
     }
-  }
+
+    private fun textDocumentService(): TextDocumentService {
+        val server =
+            synchronized(lock) { remoteServer }
+                ?: throw IllegalStateException("Dart LSP server is not running")
+        return server.textDocumentService
+    }
+
+    private fun notifyAliveIfCurrent(expectedProcess: Process) {
+        val statusVersionSnapshot =
+            synchronized(lock) {
+                if (process !== expectedProcess) {
+                    return
+                }
+                isServerAlive = true
+                statusVersion.incrementAndGet()
+            }
+        notifyStatusListeners(true, statusVersionSnapshot)
+    }
+
+    private fun notifyDeadIfChanged() {
+        val statusVersionSnapshot =
+            synchronized(lock) {
+                if (!isServerAlive) return
+                isServerAlive = false
+                statusVersion.incrementAndGet()
+            }
+        notifyStatusListeners(false, statusVersionSnapshot)
+    }
+
+    private fun notifyStatusListeners(
+        isAlive: Boolean,
+        statusVersionSnapshot: Long,
+    ) {
+        statusListeners.forEach { listener ->
+            notifyStatusListener(listener, isAlive, statusVersionSnapshot)
+        }
+    }
+
+    private fun notifyStatusListener(
+        listener: AnalysisServerStatusListener,
+        isAlive: Boolean,
+        statusVersionSnapshot: Long,
+    ) {
+        if (!recordNotificationVersion(listener, statusVersionSnapshot)) return
+
+        try {
+            listener.isAliveServer(isAlive)
+        } catch (t: Throwable) {
+            LOG.warn("Error in LSP status listener", t)
+        }
+    }
+
+    private fun recordNotificationVersion(
+        listener: AnalysisServerStatusListener,
+        statusVersionSnapshot: Long,
+    ): Boolean {
+        while (true) {
+            val previousVersion = listenerStatusVersions.putIfAbsent(listener, statusVersionSnapshot) ?: return true
+            if (previousVersion >= statusVersionSnapshot) {
+                return false
+            }
+            if (listenerStatusVersions.replace(listener, previousVersion, statusVersionSnapshot)) {
+                return true
+            }
+        }
+    }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
@@ -21,14 +21,23 @@ import org.eclipse.lsp4j.DidChangeTextDocumentParams
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
+import org.eclipse.lsp4j.ExecuteCommandParams
+import org.eclipse.lsp4j.FileRename
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.InitializedParams
+import org.eclipse.lsp4j.PrepareRenameDefaultBehavior
+import org.eclipse.lsp4j.PrepareRenameParams
+import org.eclipse.lsp4j.PrepareRenameResult
 import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.RenameFilesParams
+import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.TextDocumentSyncKind
+import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import org.eclipse.lsp4j.services.LanguageServer
 import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
@@ -47,6 +56,9 @@ internal class LspClientConnectionManager(
     private val sdk: DartSdk,
     private val suppressAnalytics: Boolean,
     onPublishDiagnostics: (PublishDiagnosticsParams) -> Unit = {},
+    onApplyEdit: (
+        org.eclipse.lsp4j.ApplyWorkspaceEditParams,
+    ) -> org.eclipse.lsp4j.ApplyWorkspaceEditResponse = { org.eclipse.lsp4j.ApplyWorkspaceEditResponse(false) },
 ) {
     private companion object {
         private val LOG = Logger.getInstance(LspClientConnectionManager::class.java)
@@ -85,7 +97,7 @@ internal class LspClientConnectionManager(
     @Volatile
     private var serverTextDocumentSyncKind = TextDocumentSyncKind.Full
 
-    private val languageClient = DartLspLanguageClient(onPublishDiagnostics)
+    private val languageClient = DartLspLanguageClient(onPublishDiagnostics, onApplyEdit)
     private val workspaceFoldersManager = LspWorkspaceFoldersManager()
 
     private class StartupSession(
@@ -228,6 +240,27 @@ internal class LspClientConnectionManager(
 
     fun codeAction(params: CodeActionParams): CompletableFuture<List<Either<Command, CodeAction>>> {
         return textDocumentService().codeAction(params)
+    }
+
+    fun prepareRename(
+        params: PrepareRenameParams,
+    ): CompletableFuture<Either3<org.eclipse.lsp4j.Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> {
+        return textDocumentService().prepareRename(params)
+    }
+
+    fun rename(params: RenameParams): CompletableFuture<WorkspaceEdit> {
+        return textDocumentService().rename(params)
+    }
+
+    fun executeCommand(
+        command: String,
+        arguments: List<Any?>,
+    ): CompletableFuture<Any> {
+        return workspaceService().executeCommand(ExecuteCommandParams(command, ArrayList(arguments)))
+    }
+
+    fun willRenameFiles(files: List<FileRename>): CompletableFuture<WorkspaceEdit> {
+        return workspaceService().willRenameFiles(RenameFilesParams(files))
     }
 
     fun didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspClientConnectionManager.kt
@@ -15,11 +15,17 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
 import org.eclipse.lsp4j.ClientCapabilities
+import org.eclipse.lsp4j.DidChangeTextDocumentParams
+import org.eclipse.lsp4j.DidCloseTextDocumentParams
+import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.InitializedParams
+import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.services.LanguageServer
+import org.eclipse.lsp4j.services.TextDocumentService
 import java.util.MissingResourceException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
@@ -68,6 +74,9 @@ internal class LspClientConnectionManager(
 
   @Volatile
   private var isServerAlive = false
+
+  @Volatile
+  private var serverTextDocumentSyncKind = TextDocumentSyncKind.Full
 
   private val languageClient = NoOpDartLanguageClient()
 
@@ -189,6 +198,20 @@ internal class LspClientConnectionManager(
     val server = synchronized(lock) { remoteServer }
                  ?: throw IllegalStateException("Dart LSP server is not running")
     return server.diagnosticServer()
+  }
+
+  fun textDocumentSyncKind(): TextDocumentSyncKind = serverTextDocumentSyncKind
+
+  fun didOpen(params: DidOpenTextDocumentParams) {
+    textDocumentService().didOpen(params)
+  }
+
+  fun didChange(params: DidChangeTextDocumentParams) {
+    textDocumentService().didChange(params)
+  }
+
+  fun didClose(params: DidCloseTextDocumentParams) {
+    textDocumentService().didClose(params)
   }
 
   fun isSocketOpen(): Boolean = process?.isAlive == true
@@ -374,8 +397,26 @@ internal class LspClientConnectionManager(
       }
     }
 
-    server.initialize(initializeParams).get(INITIALIZE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    val initializeResult = server.initialize(initializeParams).get(INITIALIZE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    serverTextDocumentSyncKind = extractTextDocumentSyncKind(initializeResult)
     server.initialized(InitializedParams())
+  }
+
+  private fun extractTextDocumentSyncKind(initializeResult: InitializeResult?): TextDocumentSyncKind {
+    val capabilities = initializeResult?.capabilities ?: return TextDocumentSyncKind.Full
+    val textDocumentSync = capabilities.textDocumentSync ?: return TextDocumentSyncKind.Full
+    return if (textDocumentSync.isLeft) {
+      textDocumentSync.left ?: TextDocumentSyncKind.Full
+    }
+    else {
+      textDocumentSync.right?.change ?: TextDocumentSyncKind.Full
+    }
+  }
+
+  private fun textDocumentService(): TextDocumentService {
+    val server = synchronized(lock) { remoteServer }
+                 ?: throw IllegalStateException("Dart LSP server is not running")
+    return server.textDocumentService
   }
 
   private fun notifyAliveIfCurrent(expectedProcess: Process) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -33,8 +33,10 @@ import com.google.dart.server.RequestListener
 import com.google.dart.server.ResponseListener
 import com.google.dart.server.SortMembersConsumer
 import com.google.dart.server.UpdateContentConsumer
+import com.google.dart.server.internal.BroadcastAnalysisServerListener
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
@@ -45,6 +47,7 @@ import com.jetbrains.lang.dart.analyzer.DartClient
 import com.jetbrains.lang.dart.analyzer.getDartFileInfo
 import com.jetbrains.lang.dart.sdk.DartSdk
 import org.dartlang.analysis.server.protocol.AddContentOverlay
+import org.dartlang.analysis.server.protocol.AnalysisError
 import org.dartlang.analysis.server.protocol.AnalysisOptions
 import org.dartlang.analysis.server.protocol.ImportedElements
 import org.dartlang.analysis.server.protocol.RefactoringOptions
@@ -58,6 +61,7 @@ import org.eclipse.lsp4j.CodeActionKind
 import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.lsp4j.CodeActionTriggerKind
 import org.eclipse.lsp4j.Command
+import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceFolder
@@ -81,7 +85,10 @@ internal class LspDartAnalysisClient(
         private val ASSIST_ACTION_KINDS = listOf(CodeActionKind.Refactor)
     }
 
-    private val lspClientConnectionManager = LspClientConnectionManager(project, sdk, suppressAnalytics)
+    private val analysisServerListeners = BroadcastAnalysisServerListener()
+    private val diagnosticConverter = LspDiagnosticConverter(project)
+    private val lspClientConnectionManager =
+        LspClientConnectionManager(project, sdk, suppressAnalytics, ::handlePublishDiagnostics)
     private val sourceChangeConverter = LspSourceChangeConverter(project)
     private val documentLock = Any()
     private val documentSync =
@@ -98,9 +105,13 @@ internal class LspDartAnalysisClient(
 
     override fun isSocketOpen(): Boolean = lspClientConnectionManager.isSocketOpen()
 
-    override fun addAnalysisServerListener(listener: AnalysisServerListener) {}
+    override fun addAnalysisServerListener(listener: AnalysisServerListener) {
+        analysisServerListeners.addListener(listener)
+    }
 
-    override fun removeAnalysisServerListener(listener: AnalysisServerListener) {}
+    override fun removeAnalysisServerListener(listener: AnalysisServerListener) {
+        analysisServerListeners.removeListener(listener)
+    }
 
     override fun addRequestListener(listener: RequestListener) {}
 
@@ -285,6 +296,17 @@ internal class LspDartAnalysisClient(
         return current
     }
 
+    private fun handlePublishDiagnostics(params: PublishDiagnosticsParams) {
+        val fileUri = params.uri ?: return
+        val errors =
+            ReadAction.compute<List<AnalysisError>, RuntimeException> {
+                synchronized(documentLock) {
+                    diagnosticConverter.toAnalysisErrors(params)
+                }
+            }
+        analysisServerListeners.computedErrors(fileUri, errors)
+    }
+
     private fun toAssistSourceChange(actionResult: Either<Command, CodeAction>): SourceChange? {
         if (actionResult.isLeft) {
             val command = actionResult.left ?: return null
@@ -310,7 +332,7 @@ internal class LspDartAnalysisClient(
             return false
         }
         val kind = action.kind ?: return true
-        return ASSIST_ACTION_KINDS.any { kind == it || kind.startsWith("${it}.") }
+        return ASSIST_ACTION_KINDS.any { kind == it || kind.startsWith("$it.") }
     }
 
     private fun extractWorkspaceEdit(action: CodeAction): WorkspaceEdit? {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -39,24 +39,12 @@ import com.intellij.openapi.project.Project
 import com.jetbrains.lang.dart.DartBundle
 import com.jetbrains.lang.dart.analyzer.DartClient
 import com.jetbrains.lang.dart.sdk.DartSdk
-import org.dartlang.analysis.server.protocol.AddContentOverlay
 import org.dartlang.analysis.server.protocol.AnalysisOptions
 import org.dartlang.analysis.server.protocol.ImportedElements
-import org.dartlang.analysis.server.protocol.RemoveContentOverlay
 import org.dartlang.analysis.server.protocol.RefactoringOptions
 import org.dartlang.analysis.server.protocol.RequestError
 import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression
 import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
-import org.eclipse.lsp4j.DidChangeTextDocumentParams
-import org.eclipse.lsp4j.DidCloseTextDocumentParams
-import org.eclipse.lsp4j.DidOpenTextDocumentParams
-import org.eclipse.lsp4j.Position
-import org.eclipse.lsp4j.Range
-import org.eclipse.lsp4j.TextDocumentContentChangeEvent
-import org.eclipse.lsp4j.TextDocumentIdentifier
-import org.eclipse.lsp4j.TextDocumentItem
-import org.eclipse.lsp4j.TextDocumentSyncKind
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import java.util.UUID
 import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutionException
@@ -70,16 +58,15 @@ internal class LspDartAnalysisClient(
   private companion object {
     private val LOG = Logger.getInstance(LspDartAnalysisClient::class.java)
     private const val DIAGNOSTIC_SERVER_TIMEOUT_MS = 30_000L
-    private const val DART_LANGUAGE_ID = "dart"
   }
 
   private val lifecycle = LspClientConnectionManager(project, sdk, suppressAnalytics)
   private val documentLock = Any()
-  private val openDocuments = mutableMapOf<String, OpenDocumentState>()
-
-  private data class OpenDocumentState(
-    val version: Int,
-    val content: String,
+  private val documentSync = LspDocumentSyncManager(
+    onDidOpen = lifecycle::didOpen,
+    onDidChange = lifecycle::didChange,
+    onDidClose = lifecycle::didClose,
+    syncKindProvider = lifecycle::textDocumentSyncKind,
   )
 
   override fun start() {
@@ -110,7 +97,7 @@ internal class LspDartAnalysisClient(
     try {
       synchronized(documentLock) {
         files.forEach { (uri, overlay) ->
-          applyOverlay(uri, overlay)
+          documentSync.applyOverlay(uri, overlay)
         }
       }
     }
@@ -284,7 +271,7 @@ internal class LspDartAnalysisClient(
 
   override fun server_shutdown() {
     synchronized(documentLock) {
-      openDocuments.clear()
+      documentSync.clear()
     }
     lifecycle.shutdown()
   }
@@ -298,86 +285,4 @@ internal class LspDartAnalysisClient(
   override fun lspMessage_dart_textDocumentContent(uri: String, consumer: DartLspTextDocumentContentConsumer) {}
 
   override fun lsp_connectToDtd(uri: String) {}
-
-  private fun applyOverlay(uri: String, overlay: Any) {
-    when (overlay) {
-      is AddContentOverlay -> applyContent(uri, overlay.content)
-      is RemoveContentOverlay -> removeContent(uri)
-      else -> throw IllegalArgumentException("Unsupported content overlay type ${overlay::class.java.name} for $uri")
-    }
-  }
-
-  private fun applyContent(uri: String, newContent: String) {
-    val currentState = openDocuments[uri]
-    if (currentState == null) {
-      lifecycle.didOpen(
-        DidOpenTextDocumentParams(
-          TextDocumentItem(uri, DART_LANGUAGE_ID, 1, newContent),
-        ),
-      )
-      openDocuments[uri] = OpenDocumentState(1, newContent)
-      return
-    }
-
-    if (currentState.content == newContent) return
-
-    val nextVersion = currentState.version + 1
-    lifecycle.didChange(
-      DidChangeTextDocumentParams(
-        VersionedTextDocumentIdentifier(uri, nextVersion),
-        listOf(createChangeEvent(currentState.content, newContent)),
-      ),
-    )
-    openDocuments[uri] = OpenDocumentState(nextVersion, newContent)
-  }
-
-  private fun removeContent(uri: String) {
-    if (openDocuments.containsKey(uri)) {
-      lifecycle.didClose(DidCloseTextDocumentParams(TextDocumentIdentifier(uri)))
-      openDocuments.remove(uri)
-    }
-  }
-
-  private fun createChangeEvent(previousContent: String, newContent: String): TextDocumentContentChangeEvent {
-    return if (lifecycle.textDocumentSyncKind() == TextDocumentSyncKind.Incremental) {
-      //Behavior is just like the Full for now
-      //The only problem is performance
-      TextDocumentContentChangeEvent().apply {
-        range = fullDocumentRange(previousContent)
-        text = newContent
-      }
-    }
-    else {
-      TextDocumentContentChangeEvent(newContent)
-    }
-  }
-
-  private fun fullDocumentRange(content: String): Range {
-    return Range(Position(0, 0), endPosition(content))
-  }
-
-  private fun endPosition(content: String): Position {
-    var line = 0
-    var character = 0
-    var index = 0
-    while (index < content.length) {
-      val ch = content[index]
-      if (ch == '\n') {
-        line++
-        character = 0
-      }
-      else if (ch == '\r') {
-        line++
-        character = 0
-        if (index + 1 < content.length && content[index + 1] == '\n') {
-          index++
-        }
-      }
-      else {
-        character++
-      }
-      index++
-    }
-    return Position(line, character)
-  }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -48,6 +48,7 @@ import com.jetbrains.lang.dart.analyzer.getDartFileInfo
 import com.jetbrains.lang.dart.sdk.DartSdk
 import org.dartlang.analysis.server.protocol.AddContentOverlay
 import org.dartlang.analysis.server.protocol.AnalysisError
+import org.dartlang.analysis.server.protocol.AnalysisErrorFixes
 import org.dartlang.analysis.server.protocol.AnalysisOptions
 import org.dartlang.analysis.server.protocol.ImportedElements
 import org.dartlang.analysis.server.protocol.RefactoringOptions
@@ -61,6 +62,7 @@ import org.eclipse.lsp4j.CodeActionKind
 import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.lsp4j.CodeActionTriggerKind
 import org.eclipse.lsp4j.Command
+import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceEdit
@@ -82,8 +84,27 @@ internal class LspDartAnalysisClient(
         private const val DIAGNOSTIC_SERVER_TIMEOUT_MS = 30_000L
         private const val ASSISTS_RETRY_TIMEOUT_MS = 1_000L
         private const val ASSISTS_RETRY_INTERVAL_MS = 100L
+        private const val FIXES_RETRY_TIMEOUT_MS = 1_000L
+        private const val FIXES_RETRY_INTERVAL_MS = 100L
         private val ASSIST_ACTION_KINDS = listOf(CodeActionKind.Refactor)
+        private val FIX_ACTION_KINDS = listOf(CodeActionKind.QuickFix)
     }
+
+    private data class CachedDiagnostic(
+        val lspDiagnostic: Diagnostic,
+        val analysisError: AnalysisError,
+    )
+
+    private data class DiagnosticKey(
+        val startLine: Int?,
+        val startCharacter: Int?,
+        val endLine: Int?,
+        val endCharacter: Int?,
+        val severity: Int?,
+        val code: String?,
+        val source: String?,
+        val message: String?,
+    )
 
     private val analysisServerListeners = BroadcastAnalysisServerListener()
     private val diagnosticConverter = LspDiagnosticConverter(project)
@@ -91,6 +112,7 @@ internal class LspDartAnalysisClient(
         LspClientConnectionManager(project, sdk, suppressAnalytics, ::handlePublishDiagnostics)
     private val sourceChangeConverter = LspSourceChangeConverter(project)
     private val documentLock = Any()
+    private val diagnosticsByFileUri = mutableMapOf<String, List<CachedDiagnostic>>()
     private val documentSync =
         LspDocumentSyncManager(
             onDidOpen = lspClientConnectionManager::didOpen,
@@ -298,12 +320,17 @@ internal class LspDartAnalysisClient(
 
     private fun handlePublishDiagnostics(params: PublishDiagnosticsParams) {
         val fileUri = params.uri ?: return
-        val errors =
-            ReadAction.compute<List<AnalysisError>, RuntimeException> {
+        val diagnostics =
+            ReadAction.compute<List<CachedDiagnostic>, RuntimeException> {
                 synchronized(documentLock) {
-                    diagnosticConverter.toAnalysisErrors(params)
+                    diagnosticConverter
+                        .toConvertedDiagnostics(params)
+                        .map { convertedDiagnostic ->
+                            CachedDiagnostic(convertedDiagnostic.diagnostic, convertedDiagnostic.analysisError)
+                        }.also { diagnosticsByFileUri[fileUri] = it }
                 }
             }
+        val errors = diagnostics.map(CachedDiagnostic::analysisError)
         analysisServerListeners.computedErrors(fileUri, errors)
     }
 
@@ -335,6 +362,107 @@ internal class LspDartAnalysisClient(
         return ASSIST_ACTION_KINDS.any { kind == it || kind.startsWith("$it.") }
     }
 
+    private fun toAnalysisErrorFixes(
+        matchingDiagnostics: List<CachedDiagnostic>,
+        actionResults: List<Either<Command, CodeAction>>,
+    ): List<AnalysisErrorFixes> {
+        val fixesByDiagnostic = LinkedHashMap<CachedDiagnostic, MutableList<SourceChange>>()
+        matchingDiagnostics.forEach { diagnostic ->
+            fixesByDiagnostic[diagnostic] = mutableListOf()
+        }
+
+        actionResults.forEach { actionResult ->
+            val sourceChange = toFixSourceChange(actionResult) ?: return@forEach
+            val diagnostics = associatedDiagnostics(actionResult, matchingDiagnostics)
+            diagnostics.forEach { diagnostic ->
+                fixesByDiagnostic.getOrPut(diagnostic, ::mutableListOf).add(sourceChange)
+            }
+        }
+
+        return fixesByDiagnostic.mapNotNull { (diagnostic, fixes) ->
+            if (fixes.isEmpty()) {
+                null
+            } else {
+                AnalysisErrorFixes(diagnostic.analysisError, fixes)
+            }
+        }
+    }
+
+    private fun toFixSourceChange(actionResult: Either<Command, CodeAction>): SourceChange? {
+        if (actionResult.isLeft) {
+            val command = actionResult.left ?: return null
+            val workspaceEdit = extractWorkspaceEdit(command) ?: return null
+            return sourceChangeConverter.toSourceChange(command.title, command.command, workspaceEdit)
+        }
+
+        val action = actionResult.right ?: return null
+        if (!isFixAction(action)) {
+            return null
+        }
+
+        val workspaceEdit = extractWorkspaceEdit(action) ?: return null
+        if (!sourceChangeConverter.hasTranslatableChanges(workspaceEdit)) {
+            return null
+        }
+
+        return sourceChangeConverter.toSourceChange(action, workspaceEdit)
+    }
+
+    private fun isFixAction(action: CodeAction): Boolean {
+        if (action.disabled != null) {
+            return false
+        }
+        val kind = action.kind ?: return true
+        return FIX_ACTION_KINDS.any { kind == it || kind.startsWith("$it.") }
+    }
+
+    private fun associatedDiagnostics(
+        actionResult: Either<Command, CodeAction>,
+        matchingDiagnostics: List<CachedDiagnostic>,
+    ): List<CachedDiagnostic> {
+        if (matchingDiagnostics.size <= 1) {
+            // If only one diagnostic matches the requested offset, attribute the returned fix to it even if
+            // the server omits CodeAction.diagnostics. That preserves the existing one-error/one-fix UX.
+            return matchingDiagnostics
+        }
+
+        val action = actionResult.takeIf(Either<Command, CodeAction>::isRight)?.right ?: return matchingDiagnostics
+        val actionDiagnostics = action.diagnostics.orEmpty()
+        if (actionDiagnostics.isEmpty()) {
+            // Some servers omit the per-action diagnostic list. Fall back to all matching diagnostics so
+            // fix actions are still surfaced instead of being dropped on the floor.
+            return matchingDiagnostics
+        }
+
+        val matchingDiagnosticsByKey = matchingDiagnostics.associateBy { diagnostic -> diagnostic.key() }
+        return actionDiagnostics.mapNotNull { diagnostic ->
+            matchingDiagnosticsByKey[diagnostic.key()]
+        }
+    }
+
+    private fun CachedDiagnostic.matchesOffset(offset: Int): Boolean {
+        val startOffset = analysisError.location.offset
+        val length = analysisError.location.length
+        if (length <= 0) {
+            return offset == startOffset
+        }
+        return offset in startOffset until (startOffset + length)
+    }
+
+    private fun CachedDiagnostic.key(): DiagnosticKey = lspDiagnostic.key()
+
+    private fun Diagnostic.key(): DiagnosticKey =
+        DiagnosticKey(
+            range?.start?.line,
+            range?.start?.character,
+            range?.end?.line,
+            range?.end?.character,
+            severity?.value,
+            getCodeAsString(),
+            source,
+            message,
+        )
+
     private fun extractWorkspaceEdit(action: CodeAction): WorkspaceEdit? {
         action.edit?.let { return it }
         return extractWorkspaceEdit(action.command)
@@ -363,7 +491,59 @@ internal class LspDartAnalysisClient(
         file: String,
         offset: Int,
         consumer: GetFixesConsumer,
-    ) {}
+    ) {
+        val matchingDiagnostics =
+            try {
+                synchronized(documentLock) {
+                    ensureWorkspaceFolderForFile(file)
+                    loadCurrentContent(file)?.let { content ->
+                        documentSync.applyOverlay(file, AddContentOverlay(content))
+                    }
+                    diagnosticsByFileUri[file].orEmpty().filter { it.matchesOffset(offset) }
+                }
+            } catch (t: Throwable) {
+                consumer.onError(toRequestError(t))
+                return
+            }
+
+        if (matchingDiagnostics.isEmpty()) {
+            consumer.computedFixes(emptyList())
+            return
+        }
+
+        val params =
+            try {
+                CodeActionParams(
+                    TextDocumentIdentifier(file),
+                    sourceChangeConverter.toRange(file, offset, 0),
+                    CodeActionContext(matchingDiagnostics.map(CachedDiagnostic::lspDiagnostic)).apply {
+                        only = FIX_ACTION_KINDS
+                        triggerKind = CodeActionTriggerKind.Invoked
+                    },
+                )
+            } catch (t: Throwable) {
+                consumer.onError(toRequestError(t))
+                return
+            }
+
+        try {
+            val deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(FIXES_RETRY_TIMEOUT_MS)
+            while (true) {
+                val actions = lspClientConnectionManager.codeAction(params).get(FIXES_RETRY_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                val fixes = toAnalysisErrorFixes(matchingDiagnostics, actions.orEmpty())
+                if (fixes.isNotEmpty() || System.nanoTime() >= deadlineNs) {
+                    consumer.computedFixes(fixes)
+                    return
+                }
+                Thread.sleep(FIXES_RETRY_INTERVAL_MS)
+            }
+        } catch (t: Throwable) {
+            if (t is InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            consumer.onError(toRequestError(t))
+        }
+    }
 
     override fun search_findElementReferences(
         file: String,
@@ -497,6 +677,7 @@ internal class LspDartAnalysisClient(
     override fun server_shutdown() {
         synchronized(documentLock) {
             documentSync.clear()
+            diagnosticsByFileUri.clear()
         }
         lspClientConnectionManager.shutdown()
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -51,238 +51,325 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
 internal class LspDartAnalysisClient(
-  project: Project,
-  sdk: DartSdk,
-  suppressAnalytics: Boolean,
+    project: Project,
+    sdk: DartSdk,
+    suppressAnalytics: Boolean,
 ) : DartClient {
-  private companion object {
-    private val LOG = Logger.getInstance(LspDartAnalysisClient::class.java)
-    private const val DIAGNOSTIC_SERVER_TIMEOUT_MS = 30_000L
-  }
-
-  private val lifecycle = LspClientConnectionManager(project, sdk, suppressAnalytics)
-  private val documentLock = Any()
-  private val documentSync = LspDocumentSyncManager(
-    onDidOpen = lifecycle::didOpen,
-    onDidChange = lifecycle::didChange,
-    onDidClose = lifecycle::didClose,
-    syncKindProvider = lifecycle::textDocumentSyncKind,
-  )
-
-  override fun start() {
-    lifecycle.start()
-  }
-
-  override fun isSocketOpen(): Boolean = lifecycle.isSocketOpen()
-
-  override fun addAnalysisServerListener(listener: AnalysisServerListener) {}
-
-  override fun removeAnalysisServerListener(listener: AnalysisServerListener) {}
-
-  override fun addRequestListener(listener: RequestListener) {}
-
-  override fun removeRequestListener(listener: RequestListener) {}
-
-  override fun addResponseListener(listener: ResponseListener) {}
-
-  override fun removeResponseListener(listener: ResponseListener) {}
-
-  override fun addStatusListener(listener: AnalysisServerStatusListener) {
-    lifecycle.addStatusListener(listener)
-  }
-
-  override fun completion_setSubscriptions(subscriptions: List<String>) {}
-
-  override fun analysis_updateContent(files: Map<String, Any>, consumer: UpdateContentConsumer) {
-    try {
-      synchronized(documentLock) {
-        files.forEach { (uri, overlay) ->
-          documentSync.applyOverlay(uri, overlay)
-        }
-      }
-    }
-    catch (t: Throwable) {
-      LOG.warn("Failed to synchronize overlaid Dart document content over LSP", t)
-    }
-    finally {
-      // DartAnalysisServerService currently uses this callback for overlay cleanup and cache refresh.
-      // The real fix for partial-send failures is to defer its state commits until after a confirmed send.
-      consumer.onResponse()
-    }
-  }
-
-  override fun analysis_setAnalysisRoots(included: List<String>, excluded: List<String>, packageRoots: Map<String, String>?) {}
-
-  override fun analysis_getHover(file: String, offset: Int, consumer: GetHoverConsumer) {}
-
-  override fun analysis_getNavigation(file: String, offset: Int, length: Int, consumer: GetNavigationConsumer) {}
-
-  override fun edit_getAssists(file: String, offset: Int, length: Int, consumer: GetAssistsConsumer) {}
-
-  override fun edit_isPostfixCompletionApplicable(
-    file: String,
-    key: String,
-    offset: Int,
-    consumer: IsPostfixCompletionApplicableConsumer,
-  ) {}
-
-  override fun edit_listPostfixCompletionTemplates(consumer: ListPostfixCompletionTemplatesConsumer) {}
-
-  override fun edit_getPostfixCompletion(file: String, key: String, offset: Int, consumer: GetPostfixCompletionConsumer) {}
-
-  override fun edit_getStatementCompletion(file: String, offset: Int, consumer: GetStatementCompletionConsumer) {}
-
-  override fun diagnostic_getServerPort(consumer: GetServerPortConsumer) {
-    val future = try {
-      lifecycle.requestDiagnosticServer()
-    }
-    catch (t: Throwable) {
-      consumer.onError(toRequestError(t))
-      return
+    private companion object {
+        private val LOG = Logger.getInstance(LspDartAnalysisClient::class.java)
+        private const val DIAGNOSTIC_SERVER_TIMEOUT_MS = 30_000L
     }
 
-    future.orTimeout(DIAGNOSTIC_SERVER_TIMEOUT_MS, TimeUnit.MILLISECONDS).whenComplete { result, throwable ->
-      if (throwable != null) {
-        consumer.onError(toRequestError(throwable))
-        return@whenComplete
-      }
-
-      val port = result?.port
-      if (port == null || port <= 0) {
-        consumer.onError(
-          RequestError(
-            ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE,
-            DartBundle.message("analysis.server.show.diagnostics.error"),
-            null,
-          ),
+    private val lifecycle = LspClientConnectionManager(project, sdk, suppressAnalytics)
+    private val documentLock = Any()
+    private val documentSync =
+        LspDocumentSyncManager(
+            onDidOpen = lifecycle::didOpen,
+            onDidChange = lifecycle::didChange,
+            onDidClose = lifecycle::didClose,
+            syncKindProvider = lifecycle::textDocumentSyncKind,
         )
-        return@whenComplete
-      }
 
-      consumer.computedServerPort(port)
+    override fun start() {
+        lifecycle.start()
     }
-  }
 
-  private fun toRequestError(throwable: Throwable): RequestError {
-    val rootCause = unwrapCause(throwable)
-    val message = when {
-      rootCause is IllegalStateException -> DartBundle.message("analysis.server.not.running")
-      rootCause.message.isNullOrBlank() -> DartBundle.message("analysis.server.show.diagnostics.error")
-      else -> rootCause.message!!
+    override fun isSocketOpen(): Boolean = lifecycle.isSocketOpen()
+
+    override fun addAnalysisServerListener(listener: AnalysisServerListener) {}
+
+    override fun removeAnalysisServerListener(listener: AnalysisServerListener) {}
+
+    override fun addRequestListener(listener: RequestListener) {}
+
+    override fun removeRequestListener(listener: RequestListener) {}
+
+    override fun addResponseListener(listener: ResponseListener) {}
+
+    override fun removeResponseListener(listener: ResponseListener) {}
+
+    override fun addStatusListener(listener: AnalysisServerStatusListener) {
+        lifecycle.addStatusListener(listener)
     }
-    return RequestError(ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE, message, null)
-  }
 
-  private fun unwrapCause(throwable: Throwable): Throwable {
-    var current = throwable
-    while ((current is CompletionException || current is ExecutionException) && current.cause != null) {
-      current = current.cause!!
+    override fun completion_setSubscriptions(subscriptions: List<String>) {}
+
+    override fun analysis_updateContent(
+        files: Map<String, Any>,
+        consumer: UpdateContentConsumer,
+    ) {
+        try {
+            synchronized(documentLock) {
+                files.forEach { (uri, overlay) ->
+                    documentSync.applyOverlay(uri, overlay)
+                }
+            }
+        } catch (t: Throwable) {
+            LOG.warn("Failed to synchronize overlaid Dart document content over LSP", t)
+        } finally {
+            // DartAnalysisServerService currently uses this callback for overlay cleanup and cache refresh.
+            // The real fix for partial-send failures is to defer its state commits until after a confirmed send.
+            consumer.onResponse()
+        }
     }
-    return current
-  }
 
-  override fun edit_getFixes(file: String, offset: Int, consumer: GetFixesConsumer) {}
+    override fun analysis_setAnalysisRoots(
+        included: List<String>,
+        excluded: List<String>,
+        packageRoots: Map<String, String>?,
+    ) {}
 
-  override fun search_findElementReferences(
-    file: String,
-    offset: Int,
-    includePotential: Boolean,
-    consumer: FindElementReferencesConsumer,
-  ) {}
+    override fun analysis_getHover(
+        file: String,
+        offset: Int,
+        consumer: GetHoverConsumer,
+    ) {}
 
-  override fun search_getTypeHierarchy(file: String, offset: Int, superOnly: Boolean, consumer: GetTypeHierarchyConsumer) {}
+    override fun analysis_getNavigation(
+        file: String,
+        offset: Int,
+        length: Int,
+        consumer: GetNavigationConsumer,
+    ) {}
 
-  override fun completion_getSuggestionDetails(
-    file: String,
-    id: Int,
-    label: String,
-    offset: Int,
-    consumer: GetSuggestionDetailsConsumer,
-  ) {}
+    override fun edit_getAssists(
+        file: String,
+        offset: Int,
+        length: Int,
+        consumer: GetAssistsConsumer,
+    ) {}
 
-  override fun completion_getSuggestionDetails2(
-    file: String,
-    offset: Int,
-    completion: String,
-    libraryUri: String,
-    consumer: GetSuggestionDetailsConsumer2,
-  ) {}
+    override fun edit_isPostfixCompletionApplicable(
+        file: String,
+        key: String,
+        offset: Int,
+        consumer: IsPostfixCompletionApplicableConsumer,
+    ) {}
 
-  override fun completion_getSuggestions(file: String, offset: Int, consumer: GetSuggestionsConsumer) {}
+    override fun edit_listPostfixCompletionTemplates(consumer: ListPostfixCompletionTemplatesConsumer) {}
 
-  override fun completion_getSuggestions2(
-    file: String,
-    offset: Int,
-    maxResults: Int,
-    completionCaseMatchingMode: String,
-    completionMode: String,
-    invocationCount: Int,
-    timeout: Int,
-    consumer: GetSuggestionsConsumer2,
-  ) {}
+    override fun edit_getPostfixCompletion(
+        file: String,
+        key: String,
+        offset: Int,
+        consumer: GetPostfixCompletionConsumer,
+    ) {}
 
-  override fun edit_format(file: String, selectionOffset: Int, selectionLength: Int, lineLength: Int, consumer: FormatConsumer) {}
+    override fun edit_getStatementCompletion(
+        file: String,
+        offset: Int,
+        consumer: GetStatementCompletionConsumer,
+    ) {}
 
-  override fun analysis_getImportedElements(file: String, offset: Int, length: Int, consumer: GetImportedElementsConsumer) {}
+    override fun diagnostic_getServerPort(consumer: GetServerPortConsumer) {
+        val future =
+            try {
+                lifecycle.requestDiagnosticServer()
+            } catch (t: Throwable) {
+                consumer.onError(toRequestError(t))
+                return
+            }
 
-  override fun edit_importElements(file: String, elements: List<ImportedElements>, offset: Int, consumer: ImportElementsConsumer) {}
+        future.orTimeout(DIAGNOSTIC_SERVER_TIMEOUT_MS, TimeUnit.MILLISECONDS).whenComplete { result, throwable ->
+            if (throwable != null) {
+                consumer.onError(toRequestError(throwable))
+                return@whenComplete
+            }
 
-  override fun edit_getRefactoring(
-    kind: String,
-    file: String,
-    offset: Int,
-    length: Int,
-    validateOnly: Boolean,
-    options: RefactoringOptions?,
-    consumer: GetRefactoringConsumer,
-  ) {}
+            val port = result?.port
+            if (port == null || port <= 0) {
+                consumer.onError(
+                    RequestError(
+                        ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE,
+                        DartBundle.message("analysis.server.show.diagnostics.error"),
+                        null,
+                    ),
+                )
+                return@whenComplete
+            }
 
-  override fun edit_organizeDirectives(file: String, consumer: OrganizeDirectivesConsumer) {}
-
-  override fun edit_sortMembers(file: String, consumer: SortMembersConsumer) {}
-
-  override fun analysis_reanalyze() {}
-
-  override fun analysis_setPriorityFiles(files: List<String>) {}
-
-  override fun analysis_setSubscriptions(subscriptions: Map<String, List<String>>) {}
-
-  override fun execution_createContext(contextRoot: String, consumer: CreateContextConsumer) {}
-
-  override fun execution_deleteContext(contextId: String) {}
-
-  override fun execution_getSuggestions(
-    code: String,
-    offset: Int,
-    contextFile: String,
-    contextOffset: Int,
-    variables: List<RuntimeCompletionVariable>,
-    expressions: List<RuntimeCompletionExpression>?,
-    consumer: GetRuntimeCompletionConsumer,
-  ) {}
-
-  override fun execution_mapUri(id: String, file: String?, uri: String?, consumer: MapUriConsumer) {}
-
-  override fun server_setSubscriptions(subscriptions: List<String>) {}
-
-  override fun analysis_updateOptions(options: AnalysisOptions) {}
-
-  override fun server_setClientCapabilities(requests: List<String>, supportsUris: Boolean, supportsWorkspaceApplyEdits: Boolean) {}
-
-  override fun server_shutdown() {
-    synchronized(documentLock) {
-      documentSync.clear()
+            consumer.computedServerPort(port)
+        }
     }
-    lifecycle.shutdown()
-  }
 
-  override fun generateUniqueId(): String = UUID.randomUUID().toString()
+    private fun toRequestError(throwable: Throwable): RequestError {
+        val rootCause = unwrapCause(throwable)
+        val message =
+            when {
+                rootCause is IllegalStateException -> DartBundle.message("analysis.server.not.running")
+                rootCause.message.isNullOrBlank() -> DartBundle.message("analysis.server.show.diagnostics.error")
+                else -> rootCause.message!!
+            }
+        return RequestError(ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE, message, null)
+    }
 
-  override fun sendRequestToServer(id: String, request: JsonObject) {}
+    private fun unwrapCause(throwable: Throwable): Throwable {
+        var current = throwable
+        while ((current is CompletionException || current is ExecutionException) && current.cause != null) {
+            current = current.cause!!
+        }
+        return current
+    }
 
-  override fun sendRequestToServer(id: String, request: JsonObject, consumer: Consumer) {}
+    override fun edit_getFixes(
+        file: String,
+        offset: Int,
+        consumer: GetFixesConsumer,
+    ) {}
 
-  override fun lspMessage_dart_textDocumentContent(uri: String, consumer: DartLspTextDocumentContentConsumer) {}
+    override fun search_findElementReferences(
+        file: String,
+        offset: Int,
+        includePotential: Boolean,
+        consumer: FindElementReferencesConsumer,
+    ) {}
 
-  override fun lsp_connectToDtd(uri: String) {}
+    override fun search_getTypeHierarchy(
+        file: String,
+        offset: Int,
+        superOnly: Boolean,
+        consumer: GetTypeHierarchyConsumer,
+    ) {}
+
+    override fun completion_getSuggestionDetails(
+        file: String,
+        id: Int,
+        label: String,
+        offset: Int,
+        consumer: GetSuggestionDetailsConsumer,
+    ) {}
+
+    override fun completion_getSuggestionDetails2(
+        file: String,
+        offset: Int,
+        completion: String,
+        libraryUri: String,
+        consumer: GetSuggestionDetailsConsumer2,
+    ) {}
+
+    override fun completion_getSuggestions(
+        file: String,
+        offset: Int,
+        consumer: GetSuggestionsConsumer,
+    ) {}
+
+    override fun completion_getSuggestions2(
+        file: String,
+        offset: Int,
+        maxResults: Int,
+        completionCaseMatchingMode: String,
+        completionMode: String,
+        invocationCount: Int,
+        timeout: Int,
+        consumer: GetSuggestionsConsumer2,
+    ) {}
+
+    override fun edit_format(
+        file: String,
+        selectionOffset: Int,
+        selectionLength: Int,
+        lineLength: Int,
+        consumer: FormatConsumer,
+    ) {}
+
+    override fun analysis_getImportedElements(
+        file: String,
+        offset: Int,
+        length: Int,
+        consumer: GetImportedElementsConsumer,
+    ) {}
+
+    override fun edit_importElements(
+        file: String,
+        elements: List<ImportedElements>,
+        offset: Int,
+        consumer: ImportElementsConsumer,
+    ) {}
+
+    override fun edit_getRefactoring(
+        kind: String,
+        file: String,
+        offset: Int,
+        length: Int,
+        validateOnly: Boolean,
+        options: RefactoringOptions?,
+        consumer: GetRefactoringConsumer,
+    ) {}
+
+    override fun edit_organizeDirectives(
+        file: String,
+        consumer: OrganizeDirectivesConsumer,
+    ) {}
+
+    override fun edit_sortMembers(
+        file: String,
+        consumer: SortMembersConsumer,
+    ) {}
+
+    override fun analysis_reanalyze() {}
+
+    override fun analysis_setPriorityFiles(files: List<String>) {}
+
+    override fun analysis_setSubscriptions(subscriptions: Map<String, List<String>>) {}
+
+    override fun execution_createContext(
+        contextRoot: String,
+        consumer: CreateContextConsumer,
+    ) {}
+
+    override fun execution_deleteContext(contextId: String) {}
+
+    override fun execution_getSuggestions(
+        code: String,
+        offset: Int,
+        contextFile: String,
+        contextOffset: Int,
+        variables: List<RuntimeCompletionVariable>,
+        expressions: List<RuntimeCompletionExpression>?,
+        consumer: GetRuntimeCompletionConsumer,
+    ) {}
+
+    override fun execution_mapUri(
+        id: String,
+        file: String?,
+        uri: String?,
+        consumer: MapUriConsumer,
+    ) {}
+
+    override fun server_setSubscriptions(subscriptions: List<String>) {}
+
+    override fun analysis_updateOptions(options: AnalysisOptions) {}
+
+    override fun server_setClientCapabilities(
+        requests: List<String>,
+        supportsUris: Boolean,
+        supportsWorkspaceApplyEdits: Boolean,
+    ) {}
+
+    override fun server_shutdown() {
+        synchronized(documentLock) {
+            documentSync.clear()
+        }
+        lifecycle.shutdown()
+    }
+
+    override fun generateUniqueId(): String = UUID.randomUUID().toString()
+
+    override fun sendRequestToServer(
+        id: String,
+        request: JsonObject,
+    ) {}
+
+    override fun sendRequestToServer(
+        id: String,
+        request: JsonObject,
+        consumer: Consumer,
+    ) {}
+
+    override fun lspMessage_dart_textDocumentContent(
+        uri: String,
+        consumer: DartLspTextDocumentContentConsumer,
+    ) {}
+
+    override fun lsp_connectToDtd(uri: String) {}
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -34,16 +34,29 @@ import com.google.dart.server.ResponseListener
 import com.google.dart.server.SortMembersConsumer
 import com.google.dart.server.UpdateContentConsumer
 import com.google.gson.JsonObject
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.jetbrains.lang.dart.DartBundle
 import com.jetbrains.lang.dart.analyzer.DartClient
 import com.jetbrains.lang.dart.sdk.DartSdk
+import org.dartlang.analysis.server.protocol.AddContentOverlay
 import org.dartlang.analysis.server.protocol.AnalysisOptions
 import org.dartlang.analysis.server.protocol.ImportedElements
-import org.dartlang.analysis.server.protocol.RequestError
+import org.dartlang.analysis.server.protocol.RemoveContentOverlay
 import org.dartlang.analysis.server.protocol.RefactoringOptions
+import org.dartlang.analysis.server.protocol.RequestError
 import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression
 import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
+import org.eclipse.lsp4j.DidChangeTextDocumentParams
+import org.eclipse.lsp4j.DidCloseTextDocumentParams
+import org.eclipse.lsp4j.DidOpenTextDocumentParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.TextDocumentSyncKind
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import java.util.UUID
 import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutionException
@@ -55,10 +68,19 @@ internal class LspDartAnalysisClient(
   suppressAnalytics: Boolean,
 ) : DartClient {
   private companion object {
+    private val LOG = Logger.getInstance(LspDartAnalysisClient::class.java)
     private const val DIAGNOSTIC_SERVER_TIMEOUT_MS = 30_000L
+    private const val DART_LANGUAGE_ID = "dart"
   }
 
   private val lifecycle = LspClientConnectionManager(project, sdk, suppressAnalytics)
+  private val documentLock = Any()
+  private val openDocuments = mutableMapOf<String, OpenDocumentState>()
+
+  private data class OpenDocumentState(
+    val version: Int,
+    val content: String,
+  )
 
   override fun start() {
     lifecycle.start()
@@ -84,7 +106,23 @@ internal class LspDartAnalysisClient(
 
   override fun completion_setSubscriptions(subscriptions: List<String>) {}
 
-  override fun analysis_updateContent(files: Map<String, Any>, consumer: UpdateContentConsumer) {}
+  override fun analysis_updateContent(files: Map<String, Any>, consumer: UpdateContentConsumer) {
+    try {
+      synchronized(documentLock) {
+        files.forEach { (uri, overlay) ->
+          applyOverlay(uri, overlay)
+        }
+      }
+    }
+    catch (t: Throwable) {
+      LOG.warn("Failed to synchronize overlaid Dart document content over LSP", t)
+    }
+    finally {
+      // DartAnalysisServerService currently uses this callback for overlay cleanup and cache refresh.
+      // The real fix for partial-send failures is to defer its state commits until after a confirmed send.
+      consumer.onResponse()
+    }
+  }
 
   override fun analysis_setAnalysisRoots(included: List<String>, excluded: List<String>, packageRoots: Map<String, String>?) {}
 
@@ -245,6 +283,9 @@ internal class LspDartAnalysisClient(
   override fun server_setClientCapabilities(requests: List<String>, supportsUris: Boolean, supportsWorkspaceApplyEdits: Boolean) {}
 
   override fun server_shutdown() {
+    synchronized(documentLock) {
+      openDocuments.clear()
+    }
     lifecycle.shutdown()
   }
 
@@ -257,4 +298,86 @@ internal class LspDartAnalysisClient(
   override fun lspMessage_dart_textDocumentContent(uri: String, consumer: DartLspTextDocumentContentConsumer) {}
 
   override fun lsp_connectToDtd(uri: String) {}
+
+  private fun applyOverlay(uri: String, overlay: Any) {
+    when (overlay) {
+      is AddContentOverlay -> applyContent(uri, overlay.content)
+      is RemoveContentOverlay -> removeContent(uri)
+      else -> throw IllegalArgumentException("Unsupported content overlay type ${overlay::class.java.name} for $uri")
+    }
+  }
+
+  private fun applyContent(uri: String, newContent: String) {
+    val currentState = openDocuments[uri]
+    if (currentState == null) {
+      lifecycle.didOpen(
+        DidOpenTextDocumentParams(
+          TextDocumentItem(uri, DART_LANGUAGE_ID, 1, newContent),
+        ),
+      )
+      openDocuments[uri] = OpenDocumentState(1, newContent)
+      return
+    }
+
+    if (currentState.content == newContent) return
+
+    val nextVersion = currentState.version + 1
+    lifecycle.didChange(
+      DidChangeTextDocumentParams(
+        VersionedTextDocumentIdentifier(uri, nextVersion),
+        listOf(createChangeEvent(currentState.content, newContent)),
+      ),
+    )
+    openDocuments[uri] = OpenDocumentState(nextVersion, newContent)
+  }
+
+  private fun removeContent(uri: String) {
+    if (openDocuments.containsKey(uri)) {
+      lifecycle.didClose(DidCloseTextDocumentParams(TextDocumentIdentifier(uri)))
+      openDocuments.remove(uri)
+    }
+  }
+
+  private fun createChangeEvent(previousContent: String, newContent: String): TextDocumentContentChangeEvent {
+    return if (lifecycle.textDocumentSyncKind() == TextDocumentSyncKind.Incremental) {
+      //Behavior is just like the Full for now
+      //The only problem is performance
+      TextDocumentContentChangeEvent().apply {
+        range = fullDocumentRange(previousContent)
+        text = newContent
+      }
+    }
+    else {
+      TextDocumentContentChangeEvent(newContent)
+    }
+  }
+
+  private fun fullDocumentRange(content: String): Range {
+    return Range(Position(0, 0), endPosition(content))
+  }
+
+  private fun endPosition(content: String): Position {
+    var line = 0
+    var character = 0
+    var index = 0
+    while (index < content.length) {
+      val ch = content[index]
+      if (ch == '\n') {
+        line++
+        character = 0
+      }
+      else if (ch == '\r') {
+        line++
+        character = 0
+        if (index + 1 < content.length && content[index + 1] == '\n') {
+          index++
+        }
+      }
+      else {
+        character++
+      }
+      index++
+    }
+    return Position(line, character)
+  }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -1,0 +1,260 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import com.google.dart.server.AnalysisServerListener
+import com.google.dart.server.AnalysisServerStatusListener
+import com.google.dart.server.Consumer
+import com.google.dart.server.CreateContextConsumer
+import com.google.dart.server.DartLspTextDocumentContentConsumer
+import com.google.dart.server.ExtendedRequestErrorCode
+import com.google.dart.server.FindElementReferencesConsumer
+import com.google.dart.server.FormatConsumer
+import com.google.dart.server.GetAssistsConsumer
+import com.google.dart.server.GetFixesConsumer
+import com.google.dart.server.GetHoverConsumer
+import com.google.dart.server.GetImportedElementsConsumer
+import com.google.dart.server.GetNavigationConsumer
+import com.google.dart.server.GetPostfixCompletionConsumer
+import com.google.dart.server.GetRefactoringConsumer
+import com.google.dart.server.GetRuntimeCompletionConsumer
+import com.google.dart.server.GetServerPortConsumer
+import com.google.dart.server.GetStatementCompletionConsumer
+import com.google.dart.server.GetSuggestionDetailsConsumer
+import com.google.dart.server.GetSuggestionDetailsConsumer2
+import com.google.dart.server.GetSuggestionsConsumer
+import com.google.dart.server.GetSuggestionsConsumer2
+import com.google.dart.server.GetTypeHierarchyConsumer
+import com.google.dart.server.ImportElementsConsumer
+import com.google.dart.server.IsPostfixCompletionApplicableConsumer
+import com.google.dart.server.ListPostfixCompletionTemplatesConsumer
+import com.google.dart.server.MapUriConsumer
+import com.google.dart.server.OrganizeDirectivesConsumer
+import com.google.dart.server.RequestListener
+import com.google.dart.server.ResponseListener
+import com.google.dart.server.SortMembersConsumer
+import com.google.dart.server.UpdateContentConsumer
+import com.google.gson.JsonObject
+import com.intellij.openapi.project.Project
+import com.jetbrains.lang.dart.DartBundle
+import com.jetbrains.lang.dart.analyzer.DartClient
+import com.jetbrains.lang.dart.sdk.DartSdk
+import org.dartlang.analysis.server.protocol.AnalysisOptions
+import org.dartlang.analysis.server.protocol.ImportedElements
+import org.dartlang.analysis.server.protocol.RequestError
+import org.dartlang.analysis.server.protocol.RefactoringOptions
+import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression
+import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
+import java.util.UUID
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+
+internal class LspDartAnalysisClient(
+  project: Project,
+  sdk: DartSdk,
+  suppressAnalytics: Boolean,
+) : DartClient {
+  private companion object {
+    private const val DIAGNOSTIC_SERVER_TIMEOUT_MS = 30_000L
+  }
+
+  private val lifecycle = LspClientConnectionManager(project, sdk, suppressAnalytics)
+
+  override fun start() {
+    lifecycle.start()
+  }
+
+  override fun isSocketOpen(): Boolean = lifecycle.isSocketOpen()
+
+  override fun addAnalysisServerListener(listener: AnalysisServerListener) {}
+
+  override fun removeAnalysisServerListener(listener: AnalysisServerListener) {}
+
+  override fun addRequestListener(listener: RequestListener) {}
+
+  override fun removeRequestListener(listener: RequestListener) {}
+
+  override fun addResponseListener(listener: ResponseListener) {}
+
+  override fun removeResponseListener(listener: ResponseListener) {}
+
+  override fun addStatusListener(listener: AnalysisServerStatusListener) {
+    lifecycle.addStatusListener(listener)
+  }
+
+  override fun completion_setSubscriptions(subscriptions: List<String>) {}
+
+  override fun analysis_updateContent(files: Map<String, Any>, consumer: UpdateContentConsumer) {}
+
+  override fun analysis_setAnalysisRoots(included: List<String>, excluded: List<String>, packageRoots: Map<String, String>?) {}
+
+  override fun analysis_getHover(file: String, offset: Int, consumer: GetHoverConsumer) {}
+
+  override fun analysis_getNavigation(file: String, offset: Int, length: Int, consumer: GetNavigationConsumer) {}
+
+  override fun edit_getAssists(file: String, offset: Int, length: Int, consumer: GetAssistsConsumer) {}
+
+  override fun edit_isPostfixCompletionApplicable(
+    file: String,
+    key: String,
+    offset: Int,
+    consumer: IsPostfixCompletionApplicableConsumer,
+  ) {}
+
+  override fun edit_listPostfixCompletionTemplates(consumer: ListPostfixCompletionTemplatesConsumer) {}
+
+  override fun edit_getPostfixCompletion(file: String, key: String, offset: Int, consumer: GetPostfixCompletionConsumer) {}
+
+  override fun edit_getStatementCompletion(file: String, offset: Int, consumer: GetStatementCompletionConsumer) {}
+
+  override fun diagnostic_getServerPort(consumer: GetServerPortConsumer) {
+    val future = try {
+      lifecycle.requestDiagnosticServer()
+    }
+    catch (t: Throwable) {
+      consumer.onError(toRequestError(t))
+      return
+    }
+
+    future.orTimeout(DIAGNOSTIC_SERVER_TIMEOUT_MS, TimeUnit.MILLISECONDS).whenComplete { result, throwable ->
+      if (throwable != null) {
+        consumer.onError(toRequestError(throwable))
+        return@whenComplete
+      }
+
+      val port = result?.port
+      if (port == null || port <= 0) {
+        consumer.onError(
+          RequestError(
+            ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE,
+            DartBundle.message("analysis.server.show.diagnostics.error"),
+            null,
+          ),
+        )
+        return@whenComplete
+      }
+
+      consumer.computedServerPort(port)
+    }
+  }
+
+  private fun toRequestError(throwable: Throwable): RequestError {
+    val rootCause = unwrapCause(throwable)
+    val message = when {
+      rootCause is IllegalStateException -> DartBundle.message("analysis.server.not.running")
+      rootCause.message.isNullOrBlank() -> DartBundle.message("analysis.server.show.diagnostics.error")
+      else -> rootCause.message!!
+    }
+    return RequestError(ExtendedRequestErrorCode.INVALID_SERVER_RESPONSE, message, null)
+  }
+
+  private fun unwrapCause(throwable: Throwable): Throwable {
+    var current = throwable
+    while ((current is CompletionException || current is ExecutionException) && current.cause != null) {
+      current = current.cause!!
+    }
+    return current
+  }
+
+  override fun edit_getFixes(file: String, offset: Int, consumer: GetFixesConsumer) {}
+
+  override fun search_findElementReferences(
+    file: String,
+    offset: Int,
+    includePotential: Boolean,
+    consumer: FindElementReferencesConsumer,
+  ) {}
+
+  override fun search_getTypeHierarchy(file: String, offset: Int, superOnly: Boolean, consumer: GetTypeHierarchyConsumer) {}
+
+  override fun completion_getSuggestionDetails(
+    file: String,
+    id: Int,
+    label: String,
+    offset: Int,
+    consumer: GetSuggestionDetailsConsumer,
+  ) {}
+
+  override fun completion_getSuggestionDetails2(
+    file: String,
+    offset: Int,
+    completion: String,
+    libraryUri: String,
+    consumer: GetSuggestionDetailsConsumer2,
+  ) {}
+
+  override fun completion_getSuggestions(file: String, offset: Int, consumer: GetSuggestionsConsumer) {}
+
+  override fun completion_getSuggestions2(
+    file: String,
+    offset: Int,
+    maxResults: Int,
+    completionCaseMatchingMode: String,
+    completionMode: String,
+    invocationCount: Int,
+    timeout: Int,
+    consumer: GetSuggestionsConsumer2,
+  ) {}
+
+  override fun edit_format(file: String, selectionOffset: Int, selectionLength: Int, lineLength: Int, consumer: FormatConsumer) {}
+
+  override fun analysis_getImportedElements(file: String, offset: Int, length: Int, consumer: GetImportedElementsConsumer) {}
+
+  override fun edit_importElements(file: String, elements: List<ImportedElements>, offset: Int, consumer: ImportElementsConsumer) {}
+
+  override fun edit_getRefactoring(
+    kind: String,
+    file: String,
+    offset: Int,
+    length: Int,
+    validateOnly: Boolean,
+    options: RefactoringOptions?,
+    consumer: GetRefactoringConsumer,
+  ) {}
+
+  override fun edit_organizeDirectives(file: String, consumer: OrganizeDirectivesConsumer) {}
+
+  override fun edit_sortMembers(file: String, consumer: SortMembersConsumer) {}
+
+  override fun analysis_reanalyze() {}
+
+  override fun analysis_setPriorityFiles(files: List<String>) {}
+
+  override fun analysis_setSubscriptions(subscriptions: Map<String, List<String>>) {}
+
+  override fun execution_createContext(contextRoot: String, consumer: CreateContextConsumer) {}
+
+  override fun execution_deleteContext(contextId: String) {}
+
+  override fun execution_getSuggestions(
+    code: String,
+    offset: Int,
+    contextFile: String,
+    contextOffset: Int,
+    variables: List<RuntimeCompletionVariable>,
+    expressions: List<RuntimeCompletionExpression>?,
+    consumer: GetRuntimeCompletionConsumer,
+  ) {}
+
+  override fun execution_mapUri(id: String, file: String?, uri: String?, consumer: MapUriConsumer) {}
+
+  override fun server_setSubscriptions(subscriptions: List<String>) {}
+
+  override fun analysis_updateOptions(options: AnalysisOptions) {}
+
+  override fun server_setClientCapabilities(requests: List<String>, supportsUris: Boolean, supportsWorkspaceApplyEdits: Boolean) {}
+
+  override fun server_shutdown() {
+    lifecycle.shutdown()
+  }
+
+  override fun generateUniqueId(): String = UUID.randomUUID().toString()
+
+  override fun sendRequestToServer(id: String, request: JsonObject) {}
+
+  override fun sendRequestToServer(id: String, request: JsonObject, consumer: Consumer) {}
+
+  override fun lspMessage_dart_textDocumentContent(uri: String, consumer: DartLspTextDocumentContentConsumer) {}
+
+  override fun lsp_connectToDtd(uri: String) {}
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -33,48 +33,70 @@ import com.google.dart.server.RequestListener
 import com.google.dart.server.ResponseListener
 import com.google.dart.server.SortMembersConsumer
 import com.google.dart.server.UpdateContentConsumer
+import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VfsUtilCore
 import com.jetbrains.lang.dart.DartBundle
 import com.jetbrains.lang.dart.analyzer.DartClient
+import com.jetbrains.lang.dart.analyzer.getDartFileInfo
 import com.jetbrains.lang.dart.sdk.DartSdk
+import org.dartlang.analysis.server.protocol.AddContentOverlay
 import org.dartlang.analysis.server.protocol.AnalysisOptions
 import org.dartlang.analysis.server.protocol.ImportedElements
 import org.dartlang.analysis.server.protocol.RefactoringOptions
 import org.dartlang.analysis.server.protocol.RequestError
 import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression
 import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
+import org.dartlang.analysis.server.protocol.SourceChange
+import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.CodeActionContext
+import org.eclipse.lsp4j.CodeActionKind
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.lsp4j.CodeActionTriggerKind
+import org.eclipse.lsp4j.Command
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.WorkspaceEdit
+import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import java.util.UUID
 import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
 internal class LspDartAnalysisClient(
-    project: Project,
+    private val project: Project,
     sdk: DartSdk,
     suppressAnalytics: Boolean,
 ) : DartClient {
     private companion object {
         private val LOG = Logger.getInstance(LspDartAnalysisClient::class.java)
+        private val GSON = Gson()
         private const val DIAGNOSTIC_SERVER_TIMEOUT_MS = 30_000L
+        private const val ASSISTS_RETRY_TIMEOUT_MS = 1_000L
+        private const val ASSISTS_RETRY_INTERVAL_MS = 100L
+        private val ASSIST_ACTION_KINDS = listOf(CodeActionKind.Refactor)
     }
 
-    private val lifecycle = LspClientConnectionManager(project, sdk, suppressAnalytics)
+    private val lspClientConnectionManager = LspClientConnectionManager(project, sdk, suppressAnalytics)
+    private val sourceChangeConverter = LspSourceChangeConverter(project)
     private val documentLock = Any()
     private val documentSync =
         LspDocumentSyncManager(
-            onDidOpen = lifecycle::didOpen,
-            onDidChange = lifecycle::didChange,
-            onDidClose = lifecycle::didClose,
-            syncKindProvider = lifecycle::textDocumentSyncKind,
+            onDidOpen = lspClientConnectionManager::didOpen,
+            onDidChange = lspClientConnectionManager::didChange,
+            onDidClose = lspClientConnectionManager::didClose,
+            syncKindProvider = lspClientConnectionManager::textDocumentSyncKind,
         )
 
     override fun start() {
-        lifecycle.start()
+        lspClientConnectionManager.start()
     }
 
-    override fun isSocketOpen(): Boolean = lifecycle.isSocketOpen()
+    override fun isSocketOpen(): Boolean = lspClientConnectionManager.isSocketOpen()
 
     override fun addAnalysisServerListener(listener: AnalysisServerListener) {}
 
@@ -89,7 +111,7 @@ internal class LspDartAnalysisClient(
     override fun removeResponseListener(listener: ResponseListener) {}
 
     override fun addStatusListener(listener: AnalysisServerStatusListener) {
-        lifecycle.addStatusListener(listener)
+        lspClientConnectionManager.addStatusListener(listener)
     }
 
     override fun completion_setSubscriptions(subscriptions: List<String>) {}
@@ -100,9 +122,7 @@ internal class LspDartAnalysisClient(
     ) {
         try {
             synchronized(documentLock) {
-                files.forEach { (uri, overlay) ->
-                    documentSync.applyOverlay(uri, overlay)
-                }
+                files.forEach { (uri, overlay) -> documentSync.applyOverlay(uri, overlay) }
             }
         } catch (t: Throwable) {
             LOG.warn("Failed to synchronize overlaid Dart document content over LSP", t)
@@ -117,7 +137,13 @@ internal class LspDartAnalysisClient(
         included: List<String>,
         excluded: List<String>,
         packageRoots: Map<String, String>?,
-    ) {}
+    ) {
+        try {
+            lspClientConnectionManager.synchronizeWorkspaceFolders(included.toSet(), ::toWorkspaceFolder)
+        } catch (t: Throwable) {
+            LOG.warn("Failed to synchronize Dart LSP analysis roots", t)
+        }
+    }
 
     override fun analysis_getHover(
         file: String,
@@ -137,7 +163,55 @@ internal class LspDartAnalysisClient(
         offset: Int,
         length: Int,
         consumer: GetAssistsConsumer,
-    ) {}
+    ) {
+        try {
+            synchronized(documentLock) {
+                ensureWorkspaceFolderForFile(file)
+                loadCurrentContent(file)?.let { content ->
+                    documentSync.applyOverlay(file, AddContentOverlay(content))
+                }
+            }
+        } catch (t: Throwable) {
+            consumer.onError(toRequestError(t))
+            return
+        }
+
+        val params =
+            try {
+                CodeActionParams(
+                    TextDocumentIdentifier(file),
+                    sourceChangeConverter.toRange(file, offset, length),
+                    CodeActionContext(emptyList()).apply {
+                        only = ASSIST_ACTION_KINDS
+                        triggerKind = CodeActionTriggerKind.Invoked
+                    },
+                )
+            } catch (t: Throwable) {
+                consumer.onError(toRequestError(t))
+                return
+            }
+
+        try {
+            val deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ASSISTS_RETRY_TIMEOUT_MS)
+            while (true) {
+                val actions = lspClientConnectionManager.codeAction(params).get(ASSISTS_RETRY_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                val sourceChanges =
+                    actions
+                        .orEmpty()
+                        .mapNotNull(::toAssistSourceChange)
+                if (sourceChanges.isNotEmpty() || System.nanoTime() >= deadlineNs) {
+                    consumer.computedSourceChanges(sourceChanges)
+                    return
+                }
+                Thread.sleep(ASSISTS_RETRY_INTERVAL_MS)
+            }
+        } catch (t: Throwable) {
+            if (t is InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            consumer.onError(toRequestError(t))
+        }
+    }
 
     override fun edit_isPostfixCompletionApplicable(
         file: String,
@@ -164,7 +238,7 @@ internal class LspDartAnalysisClient(
     override fun diagnostic_getServerPort(consumer: GetServerPortConsumer) {
         val future =
             try {
-                lifecycle.requestDiagnosticServer()
+                lspClientConnectionManager.requestDiagnosticServer()
             } catch (t: Throwable) {
                 consumer.onError(toRequestError(t))
                 return
@@ -209,6 +283,58 @@ internal class LspDartAnalysisClient(
             current = current.cause!!
         }
         return current
+    }
+
+    private fun toAssistSourceChange(actionResult: Either<Command, CodeAction>): SourceChange? {
+        if (actionResult.isLeft) {
+            val command = actionResult.left ?: return null
+            val workspaceEdit = extractWorkspaceEdit(command) ?: return null
+            return sourceChangeConverter.toSourceChange(command.title, command.command, workspaceEdit)
+        }
+
+        val action = actionResult.right ?: return null
+        if (!isAssistAction(action)) {
+            return null
+        }
+
+        val workspaceEdit = extractWorkspaceEdit(action) ?: return null
+        if (!sourceChangeConverter.hasTranslatableChanges(workspaceEdit)) {
+            return null
+        }
+
+        return sourceChangeConverter.toSourceChange(action, workspaceEdit)
+    }
+
+    private fun isAssistAction(action: CodeAction): Boolean {
+        if (action.disabled != null || !action.diagnostics.isNullOrEmpty()) {
+            return false
+        }
+        val kind = action.kind ?: return true
+        return ASSIST_ACTION_KINDS.any { kind == it || kind.startsWith("${it}.") }
+    }
+
+    private fun extractWorkspaceEdit(action: CodeAction): WorkspaceEdit? {
+        action.edit?.let { return it }
+        return extractWorkspaceEdit(action.command)
+    }
+
+    private fun extractWorkspaceEdit(command: Command?): WorkspaceEdit? {
+        val safeCommand = command ?: return null
+        safeCommand.arguments.orEmpty().forEach { argument ->
+            val candidate =
+                try {
+                    when (argument) {
+                        is WorkspaceEdit -> argument
+                        else -> GSON.fromJson(GSON.toJsonTree(argument), WorkspaceEdit::class.java)
+                    }
+                } catch (_: Throwable) {
+                    null
+                }
+            if (sourceChangeConverter.hasTranslatableChanges(candidate)) {
+                return candidate
+            }
+        }
+        return null
     }
 
     override fun edit_getFixes(
@@ -350,7 +476,7 @@ internal class LspDartAnalysisClient(
         synchronized(documentLock) {
             documentSync.clear()
         }
-        lifecycle.shutdown()
+        lspClientConnectionManager.shutdown()
     }
 
     override fun generateUniqueId(): String = UUID.randomUUID().toString()
@@ -372,4 +498,23 @@ internal class LspDartAnalysisClient(
     ) {}
 
     override fun lsp_connectToDtd(uri: String) {}
+
+    private fun loadCurrentContent(fileUri: String): String? {
+        val virtualFile = getDartFileInfo(project, fileUri).findFile() ?: return null
+        return FileDocumentManager.getInstance().getDocument(virtualFile)?.text ?: VfsUtilCore.loadText(virtualFile)
+    }
+
+    private fun toWorkspaceFolder(uri: String): WorkspaceFolder {
+        val name =
+            getDartFileInfo(project, uri).findFile()?.name
+                ?: StringUtil.trimEnd(uri.substringAfterLast('/'), '/')
+        return WorkspaceFolder(uri, name)
+    }
+
+    private fun ensureWorkspaceFolderForFile(fileUri: String) {
+        val virtualFile = getDartFileInfo(project, fileUri).findFile() ?: return
+        val parent = virtualFile.parent ?: return
+        val workspaceFolderUri = VfsUtilCore.pathToUrl(parent.path)
+        lspClientConnectionManager.ensureWorkspaceFolderRegistered(workspaceFolderUri, ::toWorkspaceFolder)
+    }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDartAnalysisClient.kt
@@ -40,9 +40,13 @@ import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.util.PathUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.psi.PsiManager
+import com.jetbrains.lang.dart.DartComponentType
 import com.jetbrains.lang.dart.DartBundle
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.analyzer.DartClient
 import com.jetbrains.lang.dart.analyzer.getDartFileInfo
 import com.jetbrains.lang.dart.sdk.DartSdk
@@ -50,12 +54,27 @@ import org.dartlang.analysis.server.protocol.AddContentOverlay
 import org.dartlang.analysis.server.protocol.AnalysisError
 import org.dartlang.analysis.server.protocol.AnalysisErrorFixes
 import org.dartlang.analysis.server.protocol.AnalysisOptions
+import org.dartlang.analysis.server.protocol.ExtractMethodFeedback
+import org.dartlang.analysis.server.protocol.ExtractMethodOptions
+import org.dartlang.analysis.server.protocol.ExtractLocalVariableFeedback
+import org.dartlang.analysis.server.protocol.ExtractLocalVariableOptions
 import org.dartlang.analysis.server.protocol.ImportedElements
+import org.dartlang.analysis.server.protocol.MoveFileOptions
+import org.dartlang.analysis.server.protocol.RefactoringKind
+import org.dartlang.analysis.server.protocol.RefactoringMethodParameter
 import org.dartlang.analysis.server.protocol.RefactoringOptions
+import org.dartlang.analysis.server.protocol.RefactoringProblem
+import org.dartlang.analysis.server.protocol.RefactoringProblemSeverity
+import org.dartlang.analysis.server.protocol.RemoveContentOverlay
+import org.dartlang.analysis.server.protocol.RenameFeedback
+import org.dartlang.analysis.server.protocol.RenameOptions
 import org.dartlang.analysis.server.protocol.RequestError
 import org.dartlang.analysis.server.protocol.RuntimeCompletionExpression
 import org.dartlang.analysis.server.protocol.RuntimeCompletionVariable
 import org.dartlang.analysis.server.protocol.SourceChange
+import org.dartlang.analysis.server.protocol.SourceEdit
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionContext
 import org.eclipse.lsp4j.CodeActionKind
@@ -63,11 +82,19 @@ import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.lsp4j.CodeActionTriggerKind
 import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.FileRename
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.PrepareRenameDefaultBehavior
+import org.eclipse.lsp4j.PrepareRenameParams
+import org.eclipse.lsp4j.PrepareRenameResult
 import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.RenameParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import java.util.UUID
 import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutionException
@@ -86,8 +113,15 @@ internal class LspDartAnalysisClient(
         private const val ASSISTS_RETRY_INTERVAL_MS = 100L
         private const val FIXES_RETRY_TIMEOUT_MS = 1_000L
         private const val FIXES_RETRY_INTERVAL_MS = 100L
+        private const val RENAME_RETRY_TIMEOUT_MS = 1_000L
+        private const val RENAME_RETRY_INTERVAL_MS = 100L
+        private const val MOVE_FILE_RETRY_INTERVAL_MS = 100L
+        private const val REFACTORING_COMMAND_TIMEOUT_MS = 5_000L
+        private const val REFACTOR_VALIDATE_COMMAND = "refactor.validate"
+        private const val REFACTOR_PERFORM_COMMAND = "refactor.perform"
         private val ASSIST_ACTION_KINDS = listOf(CodeActionKind.Refactor)
         private val FIX_ACTION_KINDS = listOf(CodeActionKind.QuickFix)
+        private val SIMPLE_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
     }
 
     private data class CachedDiagnostic(
@@ -106,13 +140,48 @@ internal class LspDartAnalysisClient(
         val message: String?,
     )
 
+    private data class ValidateRefactorCommandResult(
+        val valid: Boolean = false,
+        val message: String? = null,
+    )
+
+    private data class PendingWorkspaceEditCapture(
+        val future: java.util.concurrent.CompletableFuture<WorkspaceEdit>,
+    )
+
+    private data class RefactoringCommandContext(
+        val content: String?,
+        val filePath: String,
+        val fileUri: String,
+        val offset: Int,
+        val length: Int,
+    )
+
+    private data class RenamePreparation(
+        val feedback: RenameFeedback,
+        val position: Position,
+    )
+
+    private data class RenameLocation(
+        val originalOffset: Int,
+        val originalLength: Int,
+        val currentOffset: Int,
+    )
+
+    private data class RenameSyncState(
+        val content: String?,
+        val workspaceFolderUri: String?,
+        val currentOffset: Int,
+    )
+
     private val analysisServerListeners = BroadcastAnalysisServerListener()
     private val diagnosticConverter = LspDiagnosticConverter(project)
     private val lspClientConnectionManager =
-        LspClientConnectionManager(project, sdk, suppressAnalytics, ::handlePublishDiagnostics)
+        LspClientConnectionManager(project, sdk, suppressAnalytics, ::handlePublishDiagnostics, ::handleApplyEdit)
     private val sourceChangeConverter = LspSourceChangeConverter(project)
     private val documentLock = Any()
     private val diagnosticsByFileUri = mutableMapOf<String, List<CachedDiagnostic>>()
+    private var pendingWorkspaceEditCapture: PendingWorkspaceEditCapture? = null
     private val documentSync =
         LspDocumentSyncManager(
             onDidOpen = lspClientConnectionManager::didOpen,
@@ -155,7 +224,12 @@ internal class LspDartAnalysisClient(
     ) {
         try {
             synchronized(documentLock) {
-                files.forEach { (uri, overlay) -> documentSync.applyOverlay(uri, overlay) }
+                files.forEach { (uri, overlay) ->
+                    if (overlay is RemoveContentOverlay) {
+                        diagnosticsByFileUri.remove(uri)
+                    }
+                    documentSync.applyOverlay(uri, overlay)
+                }
             }
         } catch (t: Throwable) {
             LOG.warn("Failed to synchronize overlaid Dart document content over LSP", t)
@@ -332,6 +406,23 @@ internal class LspDartAnalysisClient(
             }
         val errors = diagnostics.map(CachedDiagnostic::analysisError)
         analysisServerListeners.computedErrors(fileUri, errors)
+    }
+
+    private fun handleApplyEdit(params: ApplyWorkspaceEditParams): ApplyWorkspaceEditResponse {
+        val capture =
+            synchronized(documentLock) {
+                pendingWorkspaceEditCapture
+            }
+
+        val edit = params.edit
+        if (capture == null || edit == null) {
+            return ApplyWorkspaceEditResponse(false).apply {
+                failureReason = "No active LSP refactoring command is waiting for a workspace edit"
+            }
+        }
+
+        capture.future.complete(edit)
+        return ApplyWorkspaceEditResponse(true)
     }
 
     private fun toAssistSourceChange(actionResult: Either<Command, CodeAction>): SourceChange? {
@@ -622,7 +713,888 @@ internal class LspDartAnalysisClient(
         validateOnly: Boolean,
         options: RefactoringOptions?,
         consumer: GetRefactoringConsumer,
-    ) {}
+    ) {
+        when (kind) {
+            RefactoringKind.MOVE_FILE -> {
+                edit_getMoveFileRefactoring(file, validateOnly, options, consumer)
+            }
+            RefactoringKind.RENAME -> {
+                edit_getRenameRefactoring(file, offset, validateOnly, options, consumer)
+            }
+            RefactoringKind.EXTRACT_METHOD,
+            RefactoringKind.EXTRACT_LOCAL_VARIABLE,
+            RefactoringKind.EXTRACT_WIDGET,
+            RefactoringKind.CONVERT_GETTER_TO_METHOD,
+            RefactoringKind.CONVERT_METHOD_TO_GETTER,
+            RefactoringKind.INLINE_LOCAL_VARIABLE,
+            RefactoringKind.INLINE_METHOD -> {
+                edit_getCommandBackedRefactoring(kind, file, offset, length, validateOnly, options, consumer)
+            }
+            else -> {
+                reportUnsupportedRefactoring(kind, validateOnly, consumer)
+            }
+        }
+    }
+
+    private fun edit_getMoveFileRefactoring(
+        file: String,
+        validateOnly: Boolean,
+        options: RefactoringOptions?,
+        consumer: GetRefactoringConsumer,
+    ) {
+        val moveOptions = options as? MoveFileOptions
+        val newFileUri = moveOptions?.newFile
+        if (newFileUri.isNullOrBlank()) {
+            reportRefactoringOptionsProblem(consumer, null, "A target file path must be provided for move file refactoring.")
+            return
+        }
+
+        try {
+            synchronized(documentLock) {
+                ensureWorkspaceFolderForFile(file)
+                workspaceFolderUriForTargetFile(newFileUri)?.let { workspaceFolderUri ->
+                    lspClientConnectionManager.ensureWorkspaceFolderRegistered(workspaceFolderUri, ::toWorkspaceFolder)
+                }
+            }
+            val deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(REFACTORING_COMMAND_TIMEOUT_MS)
+            var workspaceEdit: WorkspaceEdit? = null
+            while (true) {
+                workspaceEdit =
+                    lspClientConnectionManager
+                        .willRenameFiles(listOf(FileRename(file, newFileUri)))
+                        .get(REFACTORING_COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+
+                if (workspaceEdit != null || System.nanoTime() >= deadlineNs) {
+                    break
+                }
+
+                Thread.sleep(MOVE_FILE_RETRY_INTERVAL_MS)
+            }
+
+            if (validateOnly) {
+                consumer.computedRefactorings(emptyList(), emptyList(), emptyList(), null, null, emptyList())
+                return
+            }
+
+            val sourceChange =
+                workspaceEdit?.let { edit ->
+                    ReadAction.compute<SourceChange?, RuntimeException> {
+                        sourceChangeConverter.toSourceChange(
+                            "Move File",
+                            "workspace/willRenameFiles",
+                            edit,
+                        )
+                    }
+                } ?: emptySourceChange("Move File", "workspace/willRenameFiles")
+
+            consumer.computedRefactorings(emptyList(), emptyList(), emptyList(), null, sourceChange, emptyList())
+        } catch (t: Throwable) {
+            if (t is InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            reportRefactoringProblem(
+                RefactoringKind.MOVE_FILE,
+                validateOnly,
+                consumer,
+                unwrapCause(t).message ?: "Move file refactoring failed.",
+            )
+        }
+    }
+
+    private fun edit_getRenameRefactoring(
+        file: String,
+        offset: Int,
+        validateOnly: Boolean,
+        options: RefactoringOptions?,
+        consumer: GetRefactoringConsumer,
+    ) {
+        val result = computeRenameRefactoring(file, offset, validateOnly, (options as? RenameOptions)?.getNewName())
+        consumer.computedRefactorings(
+            result.initialProblems,
+            result.optionsProblems,
+            result.finalProblems,
+            result.feedback,
+            result.change,
+            result.potentialEdits,
+        )
+    }
+
+    fun computeRenameRefactoring(
+        file: String,
+        offset: Int,
+        validateOnly: Boolean,
+        newName: String?,
+    ): LspRenameRefactoringResult {
+        val syncState: RenameSyncState
+        try {
+            syncState =
+                ReadAction.compute<RenameSyncState, RuntimeException> {
+                    val virtualFile = getDartFileInfo(project, file).findFile()
+                    val service = DartAnalysisServerService.getInstance(project)
+                    RenameSyncState(
+                        loadCurrentContent(file),
+                        workspaceFolderUriForFile(file),
+                        if (virtualFile != null) service.getConvertedOffset(virtualFile, offset) else offset,
+                    )
+                }
+            synchronized(documentLock) {
+                syncState.workspaceFolderUri?.let { workspaceFolderUri ->
+                    lspClientConnectionManager.ensureWorkspaceFolderRegistered(workspaceFolderUri, ::toWorkspaceFolder)
+                }
+                syncState.content?.let { content ->
+                    documentSync.applyOverlay(file, AddContentOverlay(content))
+                }
+            }
+        } catch (t: Throwable) {
+            throw asRefactoringFailure(t)
+        }
+
+        try {
+            val preparation = awaitRenamePreparation(file, offset, syncState.currentOffset, syncState.content)
+            if (preparation == null) {
+                return problemRenameResult(
+                    validateOnly,
+                    "LSP refactoring '${RefactoringKind.RENAME}' is not available at the current selection.",
+                )
+            }
+
+            val feedback = preparation.feedback
+            if (validateOnly && newName == null) {
+                return LspRenameRefactoringResult(feedback = feedback)
+            }
+
+            if (newName.isNullOrBlank()) {
+                return optionsProblemRenameResult(
+                    feedback,
+                    "A new name must be provided for rename refactoring.",
+                )
+            }
+
+            val workspaceEdit =
+                // LSP has no separate "validate this rename target" endpoint. A real rename request is the
+                // only way to let the server reject invalid names while still preserving the legacy
+                // checkInitialConditions/checkFinalConditions flow.
+                lspClientConnectionManager
+                    .rename(RenameParams(TextDocumentIdentifier(file), preparation.position, newName))
+                    .get(REFACTORING_COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+
+            if (validateOnly) {
+                return LspRenameRefactoringResult(feedback = feedback)
+            }
+
+            val sourceChange =
+                workspaceEdit?.let { edit ->
+                    ReadAction.compute<SourceChange?, RuntimeException> {
+                        sourceChangeConverter.toSourceChange(
+                            "Rename",
+                            "textDocument/rename",
+                            edit,
+                        )
+                    }
+                }
+
+            if (sourceChange == null) {
+                return problemRenameResult(false, "LSP refactoring '${RefactoringKind.RENAME}' is not available at the current selection.")
+            }
+
+            return LspRenameRefactoringResult(
+                feedback = feedback,
+                change = sourceChange,
+            )
+        } catch (t: Throwable) {
+            val message = unwrapCause(t).message ?: "Rename refactoring failed."
+            return if (validateOnly) optionsProblemRenameResult(null, message) else problemRenameResult(false, message)
+        }
+    }
+
+    private fun edit_getCommandBackedRefactoring(
+        kind: String,
+        file: String,
+        offset: Int,
+        length: Int,
+        validateOnly: Boolean,
+        options: RefactoringOptions?,
+        consumer: GetRefactoringConsumer,
+    ) {
+        var filePath = VfsUtilCore.urlToPath(file)
+        var docVersion: Int? = null
+        var currentContent: String? = null
+        var currentOffset = offset
+        var currentLength = length
+        try {
+            val fileState =
+                ReadAction.compute<RefactoringCommandContext, RuntimeException> {
+                    val virtualFile = getDartFileInfo(project, file).findFile()
+                    val resolvedPath =
+                        virtualFile?.path
+                            ?: VfsUtilCore.urlToPath(file)
+                    val service = DartAnalysisServerService.getInstance(project)
+                    val convertedOffset = if (virtualFile != null) service.getConvertedOffset(virtualFile, offset) else offset
+                    val convertedEnd = if (virtualFile != null) service.getConvertedOffset(virtualFile, offset + length) else (offset + length)
+                    RefactoringCommandContext(loadCurrentContent(file), resolvedPath, file, convertedOffset, convertedEnd - convertedOffset)
+                }
+            currentContent = fileState.content
+            filePath = fileState.filePath
+            currentOffset = fileState.offset
+            currentLength = fileState.length
+
+            synchronized(documentLock) {
+                ensureWorkspaceFolderForFile(fileState.fileUri)
+                currentContent?.let { content ->
+                    documentSync.applyOverlay(file, AddContentOverlay(content))
+                }
+                docVersion = documentSync.documentVersion(file)
+            }
+        } catch (t: Throwable) {
+            consumer.onError(toRequestError(t))
+            return
+        }
+
+        try {
+            if (
+                kind == RefactoringKind.EXTRACT_METHOD &&
+                options is ExtractMethodOptions &&
+                (options.createGetter() || (options.extractAll() && hasMultipleSelectedOccurrences(currentContent, currentOffset, currentLength)))
+            ) {
+                reportRefactoringProblem(
+                    kind,
+                    validateOnly,
+                    consumer,
+                    "LSP refactoring '$kind' does not support extract-all or getter mode yet.",
+                )
+                return
+            }
+            val suggestedName =
+                when (kind) {
+                    RefactoringKind.EXTRACT_LOCAL_VARIABLE -> suggestExtractLocalName(currentContent, currentOffset, currentLength)
+                    RefactoringKind.EXTRACT_METHOD -> suggestExtractMethodName(options as? ExtractMethodOptions)
+                    else -> null
+                }
+            val commandOptions = toRefactoringCommandOptions(options, suggestedName)
+            if (
+                kind == RefactoringKind.EXTRACT_LOCAL_VARIABLE &&
+                !validateOnly &&
+                options is ExtractLocalVariableOptions &&
+                options.extractAll() &&
+                hasMultipleSelectedOccurrences(currentContent, currentOffset, currentLength)
+            ) {
+                // The current Dart LSP refactor.perform handler always performs single-occurrence
+                // extraction for local variables, so fail explicitly rather than returning a
+                // misleading partial refactoring.
+                reportRefactoringProblem(
+                    kind,
+                    false,
+                    consumer,
+                    "LSP refactoring '$kind' does not support replacing all occurrences yet.",
+                )
+                return
+            }
+            val validationResult =
+                executeValidateRefactorCommand(
+                    kind,
+                    filePath,
+                    docVersion,
+                    currentOffset,
+                    currentLength,
+                    commandOptions,
+                )
+
+            if (!validationResult.valid) {
+                reportRefactoringProblem(
+                    kind,
+                    validateOnly,
+                    consumer,
+                    validationResult.message ?: "LSP refactoring '$kind' is not available at the current selection.",
+                )
+                return
+            }
+
+            val sourceChange =
+                if (validateOnly) {
+                    null
+                } else {
+                    executePerformRefactorCommand(
+                        kind,
+                        filePath,
+                        docVersion,
+                        currentOffset,
+                        currentLength,
+                        commandOptions,
+                    )?.let { workspaceEdit ->
+                        ReadAction.compute<SourceChange?, RuntimeException> {
+                            sourceChangeConverter.toSourceChange(
+                                "Perform Refactor",
+                                REFACTOR_PERFORM_COMMAND,
+                                workspaceEdit,
+                            )
+                        }
+                    }
+                }
+
+            if (!validateOnly && sourceChange == null) {
+                reportUnavailableRefactoring(kind, false, consumer)
+                return
+            }
+
+            val feedback =
+                when (kind) {
+                    RefactoringKind.EXTRACT_LOCAL_VARIABLE ->
+                        toExtractLocalVariableFeedback(offset, length, options as? ExtractLocalVariableOptions, sourceChange, suggestedName)
+                    RefactoringKind.EXTRACT_METHOD ->
+                        toExtractMethodFeedback(offset, length, options as? ExtractMethodOptions, sourceChange, suggestedName)
+                    else -> null
+                }
+
+            consumer.computedRefactorings(emptyList(), emptyList(), emptyList(), feedback, sourceChange, emptyList())
+        } catch (t: Throwable) {
+            if (t is InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            LOG.warn("LSP refactoring command failed for kind=$kind at $filePath:$currentOffset+$currentLength", t)
+            reportRefactoringProblem(
+                kind,
+                validateOnly,
+                consumer,
+                unwrapCause(t).message ?: "Refactoring '$kind' failed.",
+            )
+        }
+    }
+
+    private fun awaitRenamePreparation(
+        fileUri: String,
+        originalOffset: Int,
+        currentOffset: Int,
+        currentContent: String?,
+    ): RenamePreparation? {
+        val deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(RENAME_RETRY_TIMEOUT_MS)
+        var lastFailure: Throwable? = null
+        while (true) {
+            try {
+                prepareRename(fileUri, originalOffset, currentOffset, currentContent)?.let { return it }
+            } catch (t: Throwable) {
+                lastFailure = t
+            }
+            if (System.nanoTime() >= deadlineNs) {
+                if (lastFailure != null) {
+                    throw lastFailure
+                }
+                return null
+            }
+            Thread.sleep(RENAME_RETRY_INTERVAL_MS)
+        }
+    }
+
+    private fun executeValidateRefactorCommand(
+        kind: String,
+        filePath: String,
+        docVersion: Int?,
+        offset: Int,
+        length: Int,
+        options: Map<String, Any?>?,
+    ): ValidateRefactorCommandResult {
+        val result =
+            lspClientConnectionManager
+                .executeCommand(
+                    REFACTOR_VALIDATE_COMMAND,
+                    listOf(kind, filePath, docVersion, offset, length, options),
+                ).get(REFACTORING_COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+
+        return when (result) {
+            is ValidateRefactorCommandResult -> result
+            else -> GSON.fromJson(GSON.toJsonTree(result), ValidateRefactorCommandResult::class.java)
+        } ?: ValidateRefactorCommandResult(false, null)
+    }
+
+    private fun prepareRename(
+        fileUri: String,
+        originalOffset: Int,
+        currentOffset: Int,
+        currentContent: String?,
+    ): RenamePreparation? {
+        val position = toPosition(currentContent, currentOffset)
+        val prepareResult =
+            lspClientConnectionManager
+                .prepareRename(PrepareRenameParams(TextDocumentIdentifier(fileUri), position))
+                .get(REFACTORING_COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+
+        val rangeAndPlaceholder = toRenameRangeAndPlaceholder(prepareResult, position, currentContent, currentOffset) ?: return null
+        val feedback = toRenameFeedback(fileUri, rangeAndPlaceholder.first, rangeAndPlaceholder.second, originalOffset, currentOffset)
+        return RenamePreparation(feedback, position)
+    }
+
+    private fun toRenameRangeAndPlaceholder(
+        prepareResult: Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>?,
+        fallbackPosition: Position,
+        currentContent: String?,
+        currentOffset: Int,
+    ): Pair<Range, String>? {
+        prepareResult ?: return null
+        return when {
+            prepareResult.isFirst -> {
+                val range = prepareResult.first ?: return null
+                range to extractRenamePlaceholder(range, currentContent, currentOffset)
+            }
+            prepareResult.isSecond -> {
+                val result = prepareResult.second ?: return null
+                result.range to result.placeholder
+            }
+            prepareResult.isThird -> {
+                val range = Range(fallbackPosition, fallbackPosition)
+                range to extractRenamePlaceholder(range, currentContent, currentOffset)
+            }
+            else -> null
+        }
+    }
+
+    private fun extractRenamePlaceholder(
+        range: Range,
+        currentContent: String?,
+        currentOffset: Int,
+    ): String {
+        val text = currentContent ?: return "name"
+        val currentRange = toCurrentOffsets(text, range)
+        if (currentRange == null) {
+            val fallbackText = text.substring(currentOffset.coerceAtMost(text.length))
+            return SIMPLE_IDENTIFIER.find(fallbackText)?.value ?: "name"
+        }
+        return text.substring(currentRange.first, currentRange.second).takeIf(String::isNotEmpty) ?: "name"
+    }
+
+    private fun toRenameFeedback(
+        fileUri: String,
+        currentRange: Range,
+        placeholder: String,
+        originalOffsetFallback: Int,
+        currentOffset: Int,
+    ): RenameFeedback {
+        val renameLocation =
+            ReadAction.compute<RenameLocation, RuntimeException> {
+                val virtualFile = getDartFileInfo(project, fileUri).findFile()
+                val currentOffsets = toCurrentOffsets(loadCurrentContent(fileUri) ?: "", currentRange)
+                if (virtualFile == null || currentOffsets == null) {
+                    RenameLocation(originalOffsetFallback, placeholder.length, currentOffset)
+                } else {
+                    val service = DartAnalysisServerService.getInstance(project)
+                    val originalStart = service.getOriginalOffset(virtualFile, currentOffsets.first)
+                    val originalEnd = service.getOriginalOffset(virtualFile, currentOffsets.second)
+                    RenameLocation(originalStart, originalEnd - originalStart, currentOffsets.first)
+                }
+            }
+        val elementKindName = detectRenameElementKindName(fileUri, renameLocation.currentOffset)
+        return RenameFeedback(renameLocation.originalOffset, renameLocation.originalLength, elementKindName, placeholder)
+    }
+
+    private fun detectRenameElementKindName(
+        fileUri: String,
+        currentOffset: Int,
+    ): String {
+        return ReadAction.compute<String, RuntimeException> {
+            val virtualFile = getDartFileInfo(project, fileUri).findFile() ?: return@compute "element"
+            val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return@compute "element"
+            val elementAtOffset =
+                psiFile.findElementAt(currentOffset)
+                    ?: currentOffset.takeIf { it > 0 }?.let { psiFile.findElementAt(it - 1) }
+            DartComponentType.typeOf(elementAtOffset)?.usageType ?: "element"
+        }
+    }
+
+    private fun toCurrentOffsets(
+        content: String,
+        range: Range,
+    ): Pair<Int, Int>? {
+        val start = getOffset(content, range.start) ?: return null
+        val end = getOffset(content, range.end) ?: return null
+        return start to end
+    }
+
+    private fun getOffset(
+        content: String,
+        position: Position?,
+    ): Int? {
+        if (position == null) return null
+        if (position.line < 0 || position.character < 0) return null
+        var currentLine = 0
+        var lineStart = 0
+        var index = 0
+        while (currentLine < position.line && index < content.length) {
+            when (content[index]) {
+                '\n' -> {
+                    currentLine++
+                    lineStart = index + 1
+                }
+                '\r' -> {
+                    currentLine++
+                    lineStart = index + 1
+                    if (index + 1 < content.length && content[index + 1] == '\n') {
+                        index++
+                        lineStart = index + 1
+                    }
+                }
+            }
+            index++
+        }
+        if (currentLine != position.line) return null
+        var lineEnd = lineStart
+        while (lineEnd < content.length && content[lineEnd] != '\n' && content[lineEnd] != '\r') {
+            lineEnd++
+        }
+        return (lineStart + position.character).coerceAtMost(lineEnd)
+    }
+
+    private fun toPosition(
+        content: String?,
+        offset: Int,
+    ): Position {
+        val safeContent = content.orEmpty()
+        val clampedOffset = offset.coerceIn(0, safeContent.length)
+        var line = 0
+        var lineStart = 0
+        var index = 0
+        while (index < clampedOffset) {
+            when (safeContent[index]) {
+                '\n' -> {
+                    line++
+                    lineStart = index + 1
+                }
+                '\r' -> {
+                    line++
+                    lineStart = index + 1
+                    if (index + 1 < clampedOffset && safeContent[index + 1] == '\n') {
+                        index++
+                        lineStart = index + 1
+                    }
+                }
+            }
+            index++
+        }
+        return Position(line, clampedOffset - lineStart)
+    }
+
+    private fun executePerformRefactorCommand(
+        kind: String,
+        filePath: String,
+        docVersion: Int?,
+        offset: Int,
+        length: Int,
+        options: Map<String, Any?>?,
+    ): WorkspaceEdit? {
+        val capture = PendingWorkspaceEditCapture(java.util.concurrent.CompletableFuture())
+        synchronized(documentLock) {
+            pendingWorkspaceEditCapture = capture
+        }
+
+        try {
+            lspClientConnectionManager
+                .executeCommand(
+                    REFACTOR_PERFORM_COMMAND,
+                    listOf(kind, filePath, docVersion, offset, length, options),
+                ).get(REFACTORING_COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            return capture.future.get(REFACTORING_COMMAND_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        } finally {
+            synchronized(documentLock) {
+                if (pendingWorkspaceEditCapture === capture) {
+                    pendingWorkspaceEditCapture = null
+                }
+            }
+        }
+    }
+
+    private fun toRefactoringCommandOptions(
+        options: RefactoringOptions?,
+        suggestedName: String? = null,
+    ): Map<String, Any?>? {
+        if (options == null) {
+            return null
+        }
+
+        return when (options) {
+            is ExtractMethodOptions -> {
+                val mappedOptions =
+                    linkedMapOf<String, Any?>(
+                        "extractAll" to options.extractAll(),
+                        "createGetter" to options.createGetter(),
+                        "parameters" to options.getParameters(),
+                        "returnType" to options.getReturnType(),
+                    )
+                val requestedName = options.getName().takeUnless(StringUtil::isEmptyOrSpaces)
+                val refactoringName =
+                    if (requestedName != null && requestedName != "name") {
+                        requestedName
+                    } else {
+                        suggestedName
+                    }
+                if (refactoringName != null) {
+                    mappedOptions["name"] = refactoringName
+                }
+                mappedOptions
+            }
+            is ExtractLocalVariableOptions -> {
+                val mappedOptions = linkedMapOf<String, Any?>("extractAll" to options.extractAll())
+                val requestedName = options.getName().takeUnless(StringUtil::isEmptyOrSpaces)
+                val refactoringName =
+                    if (requestedName != null && requestedName != "name") {
+                        requestedName
+                    } else {
+                        suggestedName
+                    }
+                if (refactoringName != null) {
+                    mappedOptions["name"] = refactoringName
+                }
+                mappedOptions
+            }
+            else -> {
+                @Suppress("UNCHECKED_CAST")
+                GSON.fromJson(options.toJson(), LinkedHashMap::class.java) as? Map<String, Any?>
+            }
+        }
+    }
+
+    private fun extractLocalOccurrenceEdits(change: SourceChange): List<SourceEdit> {
+        val candidateEdits =
+            change.edits
+                .flatMap { it.edits }
+                .filter { edit ->
+                    edit.length > 0 &&
+                        !edit.replacement.isNullOrBlank() &&
+                        SIMPLE_IDENTIFIER.matches(edit.replacement)
+                }
+        if (candidateEdits.isEmpty()) {
+            return emptyList()
+        }
+
+        return candidateEdits
+            .groupBy(SourceEdit::getReplacement)
+            .maxByOrNull { (_, edits) -> edits.size }
+            ?.value
+            ?.sortedBy(SourceEdit::getOffset)
+            .orEmpty()
+    }
+
+    private fun extractMethodInvocationEdits(change: SourceChange): List<SourceEdit> {
+        val methodName = change.edits.flatMap { it.edits }.mapNotNull { edit -> SIMPLE_IDENTIFIER.find(edit.replacement)?.value }.firstOrNull()
+        val candidateEdits =
+            change.edits
+                .flatMap { it.edits }
+                .filter { edit ->
+                    edit.length > 0 &&
+                        !edit.replacement.isNullOrBlank() &&
+                        methodName != null &&
+                        edit.replacement.contains(methodName)
+                }
+        return candidateEdits.sortedBy(SourceEdit::getOffset)
+    }
+
+    private fun extractLocalSuggestedNames(
+        change: SourceChange,
+        occurrenceEdits: List<SourceEdit>,
+    ): List<String> {
+        val linkedNames =
+            change.linkedEditGroups
+                .asSequence()
+                .flatMap { it.suggestions.asSequence() }
+                .map { it.value }
+                .filter(String::isNotBlank)
+                .distinct()
+                .toList()
+        if (linkedNames.isNotEmpty()) {
+            return linkedNames
+        }
+
+        val replacementNames = occurrenceEdits.map(SourceEdit::getReplacement).filter(String::isNotBlank).distinct()
+        if (replacementNames.isNotEmpty()) {
+            return replacementNames
+        }
+
+        return listOf("name")
+    }
+
+    private fun toExtractLocalVariableFeedback(
+        offset: Int,
+        length: Int,
+        options: ExtractLocalVariableOptions?,
+        change: SourceChange?,
+        suggestedName: String?,
+    ): ExtractLocalVariableFeedback {
+        val occurrenceEdits = change?.let(::extractLocalOccurrenceEdits).orEmpty()
+        val names =
+            if (change != null && occurrenceEdits.isNotEmpty()) {
+                extractLocalSuggestedNames(change, occurrenceEdits)
+            } else {
+                listOf(
+                    options?.getName().takeUnless(StringUtil::isEmptyOrSpaces)?.takeUnless { it == "name" }
+                        ?: suggestedName
+                        ?: "newVariable",
+                )
+            }
+        val offsets = occurrenceEdits.map(SourceEdit::getOffset).ifEmpty { listOf(offset) }
+        val lengths = occurrenceEdits.map(SourceEdit::getLength).ifEmpty { listOf(length) }
+        return ExtractLocalVariableFeedback(
+            intArrayOf(offset),
+            intArrayOf(length),
+            names,
+            offsets.toIntArray(),
+            lengths.toIntArray(),
+        )
+    }
+
+    private fun toExtractMethodFeedback(
+        offset: Int,
+        length: Int,
+        options: ExtractMethodOptions?,
+        change: SourceChange?,
+        suggestedName: String?,
+    ): ExtractMethodFeedback {
+        val methodName =
+            options?.getName().takeUnless(StringUtil::isEmptyOrSpaces)?.takeUnless { it == "name" }
+                ?: suggestedName
+                ?: "newMethod"
+        val invocationEdits = change?.let(::extractMethodInvocationEdits).orEmpty()
+        val offsets = invocationEdits.map(SourceEdit::getOffset).ifEmpty { listOf(offset) }
+        val lengths = invocationEdits.map(SourceEdit::getLength).ifEmpty { listOf(length) }
+        return ExtractMethodFeedback(
+            offset,
+            length,
+            options?.getReturnType() ?: "",
+            listOf(methodName),
+            options?.createGetter() ?: false,
+            options?.getParameters() ?: emptyList<RefactoringMethodParameter>(),
+            offsets.toIntArray(),
+            lengths.toIntArray(),
+        )
+    }
+
+    private fun suggestExtractLocalName(
+        currentContent: String?,
+        offset: Int,
+        length: Int,
+    ): String? {
+        if (currentContent == null || length <= 0 || offset < 0 || offset + length > currentContent.length) {
+            return null
+        }
+
+        val selectedText = currentContent.substring(offset, offset + length).trim()
+        val identifiers = SIMPLE_IDENTIFIER.findAll(selectedText).map { it.value }.toList()
+        return identifiers.lastOrNull()
+    }
+
+    private fun suggestExtractMethodName(options: ExtractMethodOptions?): String? {
+        val requestedName = options?.getName()?.takeUnless(StringUtil::isEmptyOrSpaces)
+        return requestedName?.takeUnless { it == "name" } ?: "newMethod"
+    }
+
+    private fun hasMultipleSelectedOccurrences(
+        currentContent: String?,
+        offset: Int,
+        length: Int,
+    ): Boolean {
+        if (currentContent == null || length <= 0 || offset < 0 || offset + length > currentContent.length) {
+            return false
+        }
+
+        val selectedText = currentContent.substring(offset, offset + length)
+        if (selectedText.isEmpty()) {
+            return false
+        }
+
+        var occurrences = 0
+        var searchFrom = 0
+        while (true) {
+            val matchOffset = currentContent.indexOf(selectedText, searchFrom)
+            if (matchOffset < 0) {
+                return false
+            }
+
+            occurrences++
+            if (occurrences > 1) {
+                return true
+            }
+
+            searchFrom = matchOffset + selectedText.length
+        }
+    }
+
+    private fun reportUnsupportedRefactoring(
+        kind: String,
+        validateOnly: Boolean,
+        consumer: GetRefactoringConsumer,
+    ) {
+        reportRefactoringProblem(
+            kind,
+            validateOnly,
+            consumer,
+            "LSP refactoring '$kind' is not implemented yet.",
+        )
+    }
+
+    private fun reportUnavailableRefactoring(
+        kind: String,
+        validateOnly: Boolean,
+        consumer: GetRefactoringConsumer,
+    ) {
+        reportRefactoringProblem(
+            kind,
+            validateOnly,
+            consumer,
+            "LSP refactoring '$kind' is not available at the current selection.",
+        )
+    }
+
+    private fun reportRefactoringProblem(
+        kind: String,
+        validateOnly: Boolean,
+        consumer: GetRefactoringConsumer,
+        message: String,
+    ) {
+        val problem = RefactoringProblem(RefactoringProblemSeverity.FATAL, message, null)
+        val initialProblems = if (validateOnly) listOf(problem) else emptyList()
+        val finalProblems = if (validateOnly) emptyList() else listOf(problem)
+        consumer.computedRefactorings(initialProblems, emptyList(), finalProblems, null, null, emptyList())
+    }
+
+    private fun reportRefactoringOptionsProblem(
+        consumer: GetRefactoringConsumer,
+        feedback: org.dartlang.analysis.server.protocol.RefactoringFeedback?,
+        message: String,
+    ) {
+        val problem = RefactoringProblem(RefactoringProblemSeverity.FATAL, message, null)
+        consumer.computedRefactorings(emptyList(), listOf(problem), emptyList(), feedback, null, emptyList())
+    }
+
+    private fun problemRenameResult(
+        validateOnly: Boolean,
+        message: String,
+    ): LspRenameRefactoringResult {
+        val problem = RefactoringProblem(RefactoringProblemSeverity.FATAL, message, null)
+        val initialProblems = if (validateOnly) listOf(problem) else emptyList()
+        val finalProblems = if (validateOnly) emptyList() else listOf(problem)
+        return LspRenameRefactoringResult(
+            initialProblems = initialProblems,
+            finalProblems = finalProblems,
+        )
+    }
+
+    private fun optionsProblemRenameResult(
+        feedback: RenameFeedback?,
+        message: String,
+    ): LspRenameRefactoringResult {
+        val problem = RefactoringProblem(RefactoringProblemSeverity.FATAL, message, null)
+        return LspRenameRefactoringResult(
+            optionsProblems = listOf(problem),
+            feedback = feedback,
+        )
+    }
+
+    private fun asRefactoringFailure(t: Throwable): RuntimeException {
+        return when (t) {
+            is RuntimeException -> t
+            else -> RuntimeException(t)
+        }
+    }
+
+    private fun emptySourceChange(
+        message: String,
+        id: String?,
+    ): SourceChange = SourceChange(message, emptyList(), emptyList(), null, null, id)
 
     override fun edit_organizeDirectives(
         file: String,
@@ -715,9 +1687,21 @@ internal class LspDartAnalysisClient(
     }
 
     private fun ensureWorkspaceFolderForFile(fileUri: String) {
-        val virtualFile = getDartFileInfo(project, fileUri).findFile() ?: return
-        val parent = virtualFile.parent ?: return
-        val workspaceFolderUri = VfsUtilCore.pathToUrl(parent.path)
+        val workspaceFolderUri = workspaceFolderUriForFile(fileUri) ?: return
         lspClientConnectionManager.ensureWorkspaceFolderRegistered(workspaceFolderUri, ::toWorkspaceFolder)
+    }
+
+    private fun workspaceFolderUriForFile(fileUri: String): String? {
+        val virtualFile = getDartFileInfo(project, fileUri).findFile() ?: return null
+        val parent = virtualFile.parent ?: return null
+        return VfsUtilCore.pathToUrl(parent.path)
+    }
+
+    private fun workspaceFolderUriForTargetFile(fileUri: String): String? {
+        val filePath = VfsUtilCore.urlToPath(fileUri)
+        if (filePath.isBlank()) return null
+        val parentPath = PathUtil.getParentPath(filePath)
+        if (parentPath.isBlank()) return null
+        return VfsUtilCore.pathToUrl(parentPath)
     }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDiagnosticConverter.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDiagnosticConverter.kt
@@ -1,0 +1,225 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.jetbrains.lang.dart.analyzer.getDartFileInfo
+import org.dartlang.analysis.server.protocol.AnalysisError
+import org.dartlang.analysis.server.protocol.AnalysisErrorSeverity
+import org.dartlang.analysis.server.protocol.AnalysisErrorType
+import org.dartlang.analysis.server.protocol.DiagnosticMessage
+import org.dartlang.analysis.server.protocol.Location
+import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.DiagnosticRelatedInformation
+import org.eclipse.lsp4j.DiagnosticSeverity
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.Range
+
+internal class LspDiagnosticConverter(
+    private val project: Project,
+) {
+    fun toAnalysisErrors(params: PublishDiagnosticsParams): List<AnalysisError> {
+        val fileUri = params.uri ?: return emptyList()
+        val documentText = getDocumentText(fileUri) ?: return emptyList()
+        return params.diagnostics.orEmpty().mapNotNull { diagnostic ->
+            toAnalysisError(fileUri, documentText, diagnostic)
+        }
+    }
+
+    private fun toAnalysisError(
+        fileUri: String,
+        documentText: DocumentText,
+        diagnostic: Diagnostic,
+    ): AnalysisError? {
+        val location = toLocation(fileUri, documentText, diagnostic.range) ?: return null
+        val (message, correction) = splitMessageAndCorrection(diagnostic.message)
+        val contextMessages =
+            diagnostic.relatedInformation
+                ?.mapNotNull { toDiagnosticMessage(it) }
+                ?.takeIf { it.isNotEmpty() }
+        return AnalysisError(
+            toSeverity(diagnostic.severity),
+            toType(diagnostic),
+            location,
+            message,
+            correction,
+            diagnostic.getCodeAsString() ?: "LSP",
+            diagnostic.codeDescription?.href,
+            contextMessages,
+            null,
+        )
+    }
+
+    private fun toDiagnosticMessage(relatedInformation: DiagnosticRelatedInformation): DiagnosticMessage? {
+        val relatedLocation = relatedInformation.location ?: return null
+        val uri = relatedLocation.uri ?: return null
+        val documentText = getDocumentText(uri) ?: return null
+        val location = toLocation(uri, documentText, relatedLocation.range) ?: return null
+        return DiagnosticMessage(relatedInformation.message, location)
+    }
+
+    private fun toLocation(
+        fileUri: String,
+        documentText: DocumentText,
+        range: Range?,
+    ): Location? {
+        val safeRange = range ?: return null
+        val startOffset = toOffset(documentText, safeRange.start) ?: return null
+        val endOffset = toOffset(documentText, safeRange.end) ?: return null
+        if (endOffset < startOffset) return null
+
+        val startLine = safeRange.start.line + 1
+        val startColumn = safeRange.start.character + 1
+        val endLine = safeRange.end.line + 1
+        val endColumn = safeRange.end.character + 1
+        return Location(fileUri, startOffset, endOffset - startOffset, startLine, startColumn, endLine, endColumn)
+    }
+
+    private fun toOffset(
+        documentText: DocumentText,
+        position: Position?,
+    ): Int? {
+        if (position == null) return null
+
+        val lineCount = documentText.lineCount
+        val line = position.line
+        var character = position.character
+        if (line == lineCount && character == 0) return documentText.textLength
+        if (line < 0 || line >= lineCount || character < 0) return null
+
+        val lineStartOffset = documentText.getLineStartOffset(line)
+        val lineEndOffset = documentText.getLineEndOffset(line)
+        character = character.coerceAtMost(lineEndOffset - lineStartOffset)
+
+        val offset = lineStartOffset + character
+        return offset.takeIf { it <= documentText.textLength }
+    }
+
+    private fun getDocumentText(fileUri: String): DocumentText? {
+        val virtualFile = getDartFileInfo(project, fileUri).findFile() ?: return null
+        val document = FileDocumentManager.getInstance().getDocument(virtualFile)
+        if (document != null) {
+            return DocumentText.FromDocument(document)
+        }
+        return DocumentText.FromString(VfsUtilCore.loadText(virtualFile))
+    }
+
+    private fun toSeverity(severity: DiagnosticSeverity?): String =
+        when (severity) {
+            DiagnosticSeverity.Error -> AnalysisErrorSeverity.ERROR
+            DiagnosticSeverity.Warning -> AnalysisErrorSeverity.WARNING
+            DiagnosticSeverity.Information, DiagnosticSeverity.Hint, null -> AnalysisErrorSeverity.INFO
+        }
+
+    private fun toType(diagnostic: Diagnostic): String =
+        when (diagnostic.severity) {
+            DiagnosticSeverity.Error -> AnalysisErrorType.COMPILE_TIME_ERROR
+            DiagnosticSeverity.Warning -> {
+                val source = diagnostic.source.orEmpty()
+                if (source.contains("lint", ignoreCase = true)) AnalysisErrorType.LINT else AnalysisErrorType.STATIC_WARNING
+            }
+            DiagnosticSeverity.Information, DiagnosticSeverity.Hint, null -> AnalysisErrorType.HINT
+        }
+
+    private fun Diagnostic.getCodeAsString(): String? {
+        val diagnosticCode = code ?: return null
+        return if (diagnosticCode.isLeft) diagnosticCode.left else diagnosticCode.right?.toString()
+    }
+
+    private fun splitMessageAndCorrection(message: String): Pair<String, String?> {
+        val lines = StringUtil.splitByLinesDontTrim(message)
+        if (lines.size < 2) return message to null
+
+        val primaryMessage = lines.first().trimEnd()
+        val correction = lines.drop(1).joinToString("\n").trim()
+        if (!looksLikeCorrection(correction)) return message to null
+
+        return primaryMessage to correction
+    }
+
+    private fun looksLikeCorrection(text: String): Boolean {
+        if (text.isEmpty()) return false
+
+        return text.startsWith("Try ") ||
+            text.startsWith("Consider ") ||
+            text.startsWith("Remove ") ||
+            text.startsWith("Use ") ||
+            text.startsWith("Add ") ||
+            text.startsWith("Replace ") ||
+            text.startsWith("Change ")
+    }
+
+    private sealed interface DocumentText {
+        val lineCount: Int
+        val textLength: Int
+
+        fun getLineStartOffset(line: Int): Int
+
+        fun getLineEndOffset(line: Int): Int
+
+        data class FromDocument(
+            private val document: com.intellij.openapi.editor.Document,
+        ) : DocumentText {
+            override val lineCount: Int get() = document.lineCount
+            override val textLength: Int get() = document.textLength
+
+            override fun getLineStartOffset(line: Int): Int = document.getLineStartOffset(line)
+
+            override fun getLineEndOffset(line: Int): Int = document.getLineEndOffset(line)
+        }
+
+        data class FromString(
+            private val text: String,
+        ) : DocumentText {
+            private val lineStartOffsets = buildLineStartOffsets(text)
+
+            override val lineCount: Int get() = lineStartOffsets.size
+            override val textLength: Int get() = text.length
+
+            override fun getLineStartOffset(line: Int): Int = lineStartOffsets[line]
+
+            override fun getLineEndOffset(line: Int): Int {
+                val lineStart = lineStartOffsets[line]
+                val nextLineStart = lineStartOffsets.getOrNull(line + 1) ?: text.length
+                var lineEnd = nextLineStart
+                if (lineEnd > lineStart && text[lineEnd - 1] == '\n') {
+                    lineEnd--
+                    if (lineEnd > lineStart && text[lineEnd - 1] == '\r') {
+                        lineEnd--
+                    }
+                } else if (lineEnd > lineStart && text[lineEnd - 1] == '\r') {
+                    lineEnd--
+                }
+                return lineEnd
+            }
+
+            private fun buildLineStartOffsets(text: String): IntArray {
+                val offsets = ArrayList<Int>()
+                offsets.add(0)
+                var index = 0
+                while (index < text.length) {
+                    when (text[index]) {
+                        '\r' -> {
+                            index++
+                            if (index < text.length && text[index] == '\n') {
+                                index++
+                            }
+                            offsets.add(index)
+                        }
+
+                        '\n' -> {
+                            index++
+                            offsets.add(index)
+                        }
+
+                        else -> index++
+                    }
+                }
+                return offsets.toIntArray()
+            }
+        }
+    }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDiagnosticConverter.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDiagnosticConverter.kt
@@ -21,35 +21,47 @@ import org.eclipse.lsp4j.Range
 internal class LspDiagnosticConverter(
     private val project: Project,
 ) {
+    data class ConvertedDiagnostic(
+        val diagnostic: Diagnostic,
+        val analysisError: AnalysisError,
+    )
+
     fun toAnalysisErrors(params: PublishDiagnosticsParams): List<AnalysisError> {
+        return toConvertedDiagnostics(params).map(ConvertedDiagnostic::analysisError)
+    }
+
+    fun toConvertedDiagnostics(params: PublishDiagnosticsParams): List<ConvertedDiagnostic> {
         val fileUri = params.uri ?: return emptyList()
         val documentText = getDocumentText(fileUri) ?: return emptyList()
         return params.diagnostics.orEmpty().mapNotNull { diagnostic ->
-            toAnalysisError(fileUri, documentText, diagnostic)
+            toConvertedDiagnostic(fileUri, documentText, diagnostic)
         }
     }
 
-    private fun toAnalysisError(
+    private fun toConvertedDiagnostic(
         fileUri: String,
         documentText: DocumentText,
         diagnostic: Diagnostic,
-    ): AnalysisError? {
+    ): ConvertedDiagnostic? {
         val location = toLocation(fileUri, documentText, diagnostic.range) ?: return null
         val (message, correction) = splitMessageAndCorrection(diagnostic.message)
         val contextMessages =
             diagnostic.relatedInformation
                 ?.mapNotNull { toDiagnosticMessage(it) }
                 ?.takeIf { it.isNotEmpty() }
-        return AnalysisError(
-            toSeverity(diagnostic.severity),
-            toType(diagnostic),
-            location,
-            message,
-            correction,
-            diagnostic.getCodeAsString() ?: "LSP",
-            diagnostic.codeDescription?.href,
-            contextMessages,
-            null,
+        return ConvertedDiagnostic(
+            diagnostic,
+            AnalysisError(
+                toSeverity(diagnostic.severity),
+                toType(diagnostic),
+                location,
+                message,
+                correction,
+                diagnostic.getCodeAsString() ?: "LSP",
+                diagnostic.codeDescription?.href,
+                contextMessages,
+                null,
+            ),
         )
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDiagnosticUtils.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDiagnosticUtils.kt
@@ -1,0 +1,9 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.eclipse.lsp4j.Diagnostic
+
+internal fun Diagnostic.getCodeAsString(): String? {
+    val diagnosticCode = code ?: return null
+    return if (diagnosticCode.isLeft) diagnosticCode.left else diagnosticCode.right?.toString()
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
@@ -15,102 +15,108 @@ import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 
 internal class LspDocumentSyncManager(
-  private val onDidOpen: (DidOpenTextDocumentParams) -> Unit,
-  private val onDidChange: (DidChangeTextDocumentParams) -> Unit,
-  private val onDidClose: (DidCloseTextDocumentParams) -> Unit,
-  private val syncKindProvider: () -> TextDocumentSyncKind,
-  private val languageId: String = "dart",
+    private val onDidOpen: (DidOpenTextDocumentParams) -> Unit,
+    private val onDidChange: (DidChangeTextDocumentParams) -> Unit,
+    private val onDidClose: (DidCloseTextDocumentParams) -> Unit,
+    private val syncKindProvider: () -> TextDocumentSyncKind,
+    private val languageId: String = "dart",
 ) {
-  private val openDocuments = mutableMapOf<String, OpenDocumentState>()
+    private val openDocuments = mutableMapOf<String, OpenDocumentState>()
 
-  private data class OpenDocumentState(
-    val version: Int,
-    val content: String,
-  )
-
-  fun applyOverlay(uri: String, overlay: Any) {
-    when (overlay) {
-      is AddContentOverlay -> applyContent(uri, overlay.content)
-      is RemoveContentOverlay -> removeContent(uri)
-      else -> throw IllegalArgumentException("Unsupported content overlay type ${overlay::class.java.name} for $uri")
-    }
-  }
-
-  fun clear() {
-    openDocuments.clear()
-  }
-
-  private fun applyContent(uri: String, newContent: String) {
-    val currentState = openDocuments[uri]
-    if (currentState == null) {
-      onDidOpen(
-        DidOpenTextDocumentParams(
-          TextDocumentItem(uri, languageId, 1, newContent),
-        ),
-      )
-      openDocuments[uri] = OpenDocumentState(1, newContent)
-      return
-    }
-
-    if (currentState.content == newContent) return
-
-    val nextVersion = currentState.version + 1
-    onDidChange(
-      DidChangeTextDocumentParams(
-        VersionedTextDocumentIdentifier(uri, nextVersion),
-        listOf(createChangeEvent(currentState.content, newContent)),
-      ),
+    private data class OpenDocumentState(
+        val version: Int,
+        val content: String,
     )
-    openDocuments[uri] = OpenDocumentState(nextVersion, newContent)
-  }
 
-  private fun removeContent(uri: String) {
-    if (openDocuments.containsKey(uri)) {
-      onDidClose(DidCloseTextDocumentParams(TextDocumentIdentifier(uri)))
-      openDocuments.remove(uri)
-    }
-  }
-
-  private fun createChangeEvent(previousContent: String, newContent: String): TextDocumentContentChangeEvent {
-    return if (syncKindProvider() == TextDocumentSyncKind.Incremental) {
-      // In incremental mode we currently send a full-document replacement range.
-      // This is valid LSP for the compatibility layer and can be optimized away in a native LSP service.
-      TextDocumentContentChangeEvent().apply {
-        range = fullDocumentRange(previousContent)
-        text = newContent
-      }
-    }
-    else {
-      TextDocumentContentChangeEvent(newContent)
-    }
-  }
-
-  private fun fullDocumentRange(content: String): Range {
-    return Range(Position(0, 0), endPosition(content))
-  }
-
-  private fun endPosition(content: String): Position {
-    var line = 0
-    var character = 0
-    var index = 0
-    while (index < content.length) {
-      val ch = content[index]
-      if (ch == '\n') {
-        line++
-        character = 0
-      }
-      else if (ch == '\r') {
-        line++
-        character = 0
-        if (index + 1 < content.length && content[index + 1] == '\n') {
-          index++
+    fun applyOverlay(
+        uri: String,
+        overlay: Any,
+    ) {
+        when (overlay) {
+            is AddContentOverlay -> applyContent(uri, overlay.content)
+            is RemoveContentOverlay -> removeContent(uri)
+            else -> throw IllegalArgumentException("Unsupported content overlay type ${overlay::class.java.name} for $uri")
         }
-      }
-      else {
-        character++
-      }
-      index++
     }
-    return Position(line, character)
-  }
+
+    fun clear() {
+        openDocuments.clear()
+    }
+
+    private fun applyContent(
+        uri: String,
+        newContent: String,
+    ) {
+        val currentState = openDocuments[uri]
+        if (currentState == null) {
+            onDidOpen(
+                DidOpenTextDocumentParams(
+                    TextDocumentItem(uri, languageId, 1, newContent),
+                ),
+            )
+            openDocuments[uri] = OpenDocumentState(1, newContent)
+            return
+        }
+
+        if (currentState.content == newContent) return
+
+        val nextVersion = currentState.version + 1
+        onDidChange(
+            DidChangeTextDocumentParams(
+                VersionedTextDocumentIdentifier(uri, nextVersion),
+                listOf(createChangeEvent(currentState.content, newContent)),
+            ),
+        )
+        openDocuments[uri] = OpenDocumentState(nextVersion, newContent)
+    }
+
+    private fun removeContent(uri: String) {
+        if (openDocuments.containsKey(uri)) {
+            onDidClose(DidCloseTextDocumentParams(TextDocumentIdentifier(uri)))
+            openDocuments.remove(uri)
+        }
+    }
+
+    private fun createChangeEvent(
+        previousContent: String,
+        newContent: String,
+    ): TextDocumentContentChangeEvent {
+        return if (syncKindProvider() == TextDocumentSyncKind.Incremental) {
+            // In incremental mode we currently send a full-document replacement range.
+            // This is valid LSP for the compatibility layer and can be optimized away in a native LSP service.
+            TextDocumentContentChangeEvent().apply {
+                range = fullDocumentRange(previousContent)
+                text = newContent
+            }
+        } else {
+            TextDocumentContentChangeEvent(newContent)
+        }
+    }
+
+    private fun fullDocumentRange(content: String): Range {
+        return Range(Position(0, 0), endPosition(content))
+    }
+
+    private fun endPosition(content: String): Position {
+        var line = 0
+        var character = 0
+        var index = 0
+        while (index < content.length) {
+            val ch = content[index]
+            if (ch == '\n') {
+                line++
+                character = 0
+            } else if (ch == '\r') {
+                line++
+                character = 0
+                if (index + 1 < content.length && content[index + 1] == '\n') {
+                    index++
+                }
+            } else {
+                character++
+            }
+            index++
+        }
+        return Position(line, character)
+    }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
@@ -1,0 +1,116 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.dartlang.analysis.server.protocol.AddContentOverlay
+import org.dartlang.analysis.server.protocol.RemoveContentOverlay
+import org.eclipse.lsp4j.DidChangeTextDocumentParams
+import org.eclipse.lsp4j.DidCloseTextDocumentParams
+import org.eclipse.lsp4j.DidOpenTextDocumentParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TextDocumentItem
+import org.eclipse.lsp4j.TextDocumentSyncKind
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+
+internal class LspDocumentSyncManager(
+  private val onDidOpen: (DidOpenTextDocumentParams) -> Unit,
+  private val onDidChange: (DidChangeTextDocumentParams) -> Unit,
+  private val onDidClose: (DidCloseTextDocumentParams) -> Unit,
+  private val syncKindProvider: () -> TextDocumentSyncKind,
+  private val languageId: String = "dart",
+) {
+  private val openDocuments = mutableMapOf<String, OpenDocumentState>()
+
+  private data class OpenDocumentState(
+    val version: Int,
+    val content: String,
+  )
+
+  fun applyOverlay(uri: String, overlay: Any) {
+    when (overlay) {
+      is AddContentOverlay -> applyContent(uri, overlay.content)
+      is RemoveContentOverlay -> removeContent(uri)
+      else -> throw IllegalArgumentException("Unsupported content overlay type ${overlay::class.java.name} for $uri")
+    }
+  }
+
+  fun clear() {
+    openDocuments.clear()
+  }
+
+  private fun applyContent(uri: String, newContent: String) {
+    val currentState = openDocuments[uri]
+    if (currentState == null) {
+      onDidOpen(
+        DidOpenTextDocumentParams(
+          TextDocumentItem(uri, languageId, 1, newContent),
+        ),
+      )
+      openDocuments[uri] = OpenDocumentState(1, newContent)
+      return
+    }
+
+    if (currentState.content == newContent) return
+
+    val nextVersion = currentState.version + 1
+    onDidChange(
+      DidChangeTextDocumentParams(
+        VersionedTextDocumentIdentifier(uri, nextVersion),
+        listOf(createChangeEvent(currentState.content, newContent)),
+      ),
+    )
+    openDocuments[uri] = OpenDocumentState(nextVersion, newContent)
+  }
+
+  private fun removeContent(uri: String) {
+    if (openDocuments.containsKey(uri)) {
+      onDidClose(DidCloseTextDocumentParams(TextDocumentIdentifier(uri)))
+      openDocuments.remove(uri)
+    }
+  }
+
+  private fun createChangeEvent(previousContent: String, newContent: String): TextDocumentContentChangeEvent {
+    return if (syncKindProvider() == TextDocumentSyncKind.Incremental) {
+      // In incremental mode we currently send a full-document replacement range.
+      // This is valid LSP for the compatibility layer and can be optimized away in a native LSP service.
+      TextDocumentContentChangeEvent().apply {
+        range = fullDocumentRange(previousContent)
+        text = newContent
+      }
+    }
+    else {
+      TextDocumentContentChangeEvent(newContent)
+    }
+  }
+
+  private fun fullDocumentRange(content: String): Range {
+    return Range(Position(0, 0), endPosition(content))
+  }
+
+  private fun endPosition(content: String): Position {
+    var line = 0
+    var character = 0
+    var index = 0
+    while (index < content.length) {
+      val ch = content[index]
+      if (ch == '\n') {
+        line++
+        character = 0
+      }
+      else if (ch == '\r') {
+        line++
+        character = 0
+        if (index + 1 < content.length && content[index + 1] == '\n') {
+          index++
+        }
+      }
+      else {
+        character++
+      }
+      index++
+    }
+    return Position(line, character)
+  }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
@@ -40,6 +40,8 @@ internal class LspDocumentSyncManager(
     }
 
     fun clear() {
+        // This manager is cleared only during connection teardown, so the server is
+        // already going away and does not need individual didClose notifications.
         openDocuments.clear()
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManager.kt
@@ -45,6 +45,8 @@ internal class LspDocumentSyncManager(
         openDocuments.clear()
     }
 
+    fun documentVersion(uri: String): Int? = openDocuments[uri]?.version
+
     private fun applyContent(
         uri: String,
         newContent: String,

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspRenameRefactoringResult.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspRenameRefactoringResult.kt
@@ -1,0 +1,15 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.dartlang.analysis.server.protocol.RefactoringProblem
+import org.dartlang.analysis.server.protocol.RenameFeedback
+import org.dartlang.analysis.server.protocol.SourceChange
+
+data class LspRenameRefactoringResult(
+    val initialProblems: List<RefactoringProblem> = emptyList(),
+    val optionsProblems: List<RefactoringProblem> = emptyList(),
+    val finalProblems: List<RefactoringProblem> = emptyList(),
+    val feedback: RenameFeedback? = null,
+    val change: SourceChange? = null,
+    val potentialEdits: List<String> = emptyList(),
+)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspSnippetTextEditDecoder.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspSnippetTextEditDecoder.kt
@@ -1,0 +1,177 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+internal data class DecodedSnippetTextEdit(
+    val text: String,
+    val placeholders: List<DecodedSnippetPlaceholder>,
+)
+
+internal data class DecodedSnippetPlaceholder(
+    val number: Int,
+    val offset: Int,
+    val length: Int,
+    val choices: List<String>?,
+)
+
+internal object LspSnippetTextEditDecoder {
+    fun decode(text: String): DecodedSnippetTextEdit? {
+        if ('$' !in text && '\\' !in text) return null
+
+        val output = StringBuilder()
+        val placeholders = mutableListOf<DecodedSnippetPlaceholder>()
+        var index = 0
+        while (index < text.length) {
+            when (val char = text[index]) {
+                '\\' -> {
+                    if (index + 1 >= text.length) return null
+                    output.append(text[index + 1])
+                    index += 2
+                }
+
+                '$' -> {
+                    val snippetElement = parseSnippetElement(text, index, output.length) ?: return null
+                    output.append(snippetElement.insertedText)
+                    placeholders.add(
+                        DecodedSnippetPlaceholder(
+                            snippetElement.number,
+                            snippetElement.offset,
+                            snippetElement.insertedText.length,
+                            snippetElement.choices,
+                        ),
+                    )
+                    index = snippetElement.nextIndex
+                }
+
+                else -> {
+                    output.append(char)
+                    index++
+                }
+            }
+        }
+
+        if (placeholders.isEmpty() && output.toString() == text) {
+            return null
+        }
+        return DecodedSnippetTextEdit(output.toString(), placeholders)
+    }
+
+    private fun parseSnippetElement(
+        text: String,
+        startIndex: Int,
+        outputOffset: Int,
+    ): ParsedSnippetElement? {
+        if (startIndex + 1 >= text.length) return null
+
+        val next = text[startIndex + 1]
+        if (next.isDigit()) {
+            val (number, nextIndex) = parseNumber(text, startIndex + 1) ?: return null
+            return ParsedSnippetElement(number, "", null, outputOffset, nextIndex)
+        }
+        if (next != '{') return null
+
+        val (number, suffixIndex) = parseNumber(text, startIndex + 2) ?: return null
+        if (suffixIndex >= text.length) return null
+
+        return when (text[suffixIndex]) {
+            '}' -> ParsedSnippetElement(number, "", null, outputOffset, suffixIndex + 1)
+            ':' -> {
+                val parsedText = parseUntilTerminator(text, suffixIndex + 1, '}') ?: return null
+                ParsedSnippetElement(number, parsedText.value, null, outputOffset, parsedText.nextIndex)
+            }
+
+            '|' -> {
+                val parsedChoices = parseChoices(text, suffixIndex + 1) ?: return null
+                val insertedText = parsedChoices.choices.firstOrNull().orEmpty()
+                ParsedSnippetElement(number, insertedText, parsedChoices.choices, outputOffset, parsedChoices.nextIndex)
+            }
+
+            else -> null
+        }
+    }
+
+    private fun parseNumber(
+        text: String,
+        startIndex: Int,
+    ): Pair<Int, Int>? {
+        var index = startIndex
+        while (index < text.length && text[index].isDigit()) {
+            index++
+        }
+        if (index == startIndex) return null
+        return text.substring(startIndex, index).toIntOrNull()?.let { it to index }
+    }
+
+    private fun parseUntilTerminator(
+        text: String,
+        startIndex: Int,
+        terminator: Char,
+    ): ParsedText? {
+        val output = StringBuilder()
+        var index = startIndex
+        while (index < text.length) {
+            val char = text[index]
+            if (char == '\\') {
+                if (index + 1 >= text.length) return null
+                output.append(text[index + 1])
+                index += 2
+                continue
+            }
+            if (char == terminator) {
+                return ParsedText(output.toString(), index + 1)
+            }
+            output.append(char)
+            index++
+        }
+        return null
+    }
+
+    private fun parseChoices(
+        text: String,
+        startIndex: Int,
+    ): ParsedChoices? {
+        val choices = mutableListOf<String>()
+        val currentChoice = StringBuilder()
+        var index = startIndex
+        while (index < text.length) {
+            val char = text[index]
+            if (char == '\\') {
+                if (index + 1 >= text.length) return null
+                currentChoice.append(text[index + 1])
+                index += 2
+                continue
+            }
+            if (char == ',') {
+                choices.add(currentChoice.toString())
+                currentChoice.setLength(0)
+                index++
+                continue
+            }
+            if (char == '|') {
+                if (index + 1 >= text.length || text[index + 1] != '}') return null
+                choices.add(currentChoice.toString())
+                return ParsedChoices(choices, index + 2)
+            }
+            currentChoice.append(char)
+            index++
+        }
+        return null
+    }
+
+    private data class ParsedSnippetElement(
+        val number: Int,
+        val insertedText: String,
+        val choices: List<String>?,
+        val offset: Int,
+        val nextIndex: Int,
+    )
+
+    private data class ParsedText(
+        val value: String,
+        val nextIndex: Int,
+    )
+
+    private data class ParsedChoices(
+        val choices: List<String>,
+        val nextIndex: Int,
+    )
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspSourceChangeConverter.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspSourceChangeConverter.kt
@@ -1,0 +1,217 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.jetbrains.lang.dart.analyzer.getDartFileInfo
+import org.dartlang.analysis.server.protocol.LinkedEditGroup
+import org.dartlang.analysis.server.protocol.LinkedEditSuggestion
+import org.dartlang.analysis.server.protocol.SourceChange
+import org.dartlang.analysis.server.protocol.SourceEdit
+import org.dartlang.analysis.server.protocol.SourceFileEdit
+import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentEdit
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.WorkspaceEdit
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import kotlin.math.min
+import org.dartlang.analysis.server.protocol.Position as ServerPosition
+
+internal class LspSourceChangeConverter(
+    private val project: Project,
+) {
+    fun toRange(
+        fileUri: String,
+        offset: Int,
+        length: Int,
+    ): Range {
+        val document = getDocument(fileUri)
+        val start = toPosition(document, offset)
+        val end = toPosition(document, offset + length)
+        return Range(start, end)
+    }
+
+    fun toSourceChange(
+        action: CodeAction,
+        workspaceEdit: WorkspaceEdit,
+    ): SourceChange? = toSourceChange(action.title, action.command?.command ?: action.kind ?: action.title, workspaceEdit)
+
+    fun toSourceChange(
+        message: String,
+        id: String?,
+        workspaceEdit: WorkspaceEdit,
+    ): SourceChange? {
+        val fileEdits = mutableListOf<SourceFileEdit>()
+        val linkedEditGroups = mutableListOf<LinkedEditGroup>()
+        var selection: ServerPosition? = null
+        var selectionLength: Int? = null
+        workspaceEdit.changes?.forEach { (fileUri, textEdits) ->
+            val convertedEdit = toSourceFileEdit(fileUri, textEdits) ?: return null
+            fileEdits.add(convertedEdit.fileEdit)
+            linkedEditGroups.addAll(convertedEdit.linkedEditGroups)
+            if (selection == null && convertedEdit.selection != null) {
+                selection = convertedEdit.selection
+                selectionLength = convertedEdit.selectionLength
+            }
+        }
+        workspaceEdit.documentChanges?.forEach { change ->
+            if (!change.isLeft) {
+                return null
+            }
+            val documentChange = change.left ?: return null
+            val convertedEdit = toSourceFileEdit(documentChange) ?: return null
+            fileEdits.add(convertedEdit.fileEdit)
+            linkedEditGroups.addAll(convertedEdit.linkedEditGroups)
+            if (selection == null && convertedEdit.selection != null) {
+                selection = convertedEdit.selection
+                selectionLength = convertedEdit.selectionLength
+            }
+        }
+        if (fileEdits.isEmpty()) {
+            return null
+        }
+        return SourceChange(message, fileEdits, linkedEditGroups, selection, selectionLength, id)
+    }
+
+    fun hasTranslatableChanges(workspaceEdit: WorkspaceEdit?): Boolean {
+        if (workspaceEdit == null) return false
+        if (!workspaceEdit.changes.isNullOrEmpty()) return true
+        return workspaceEdit.documentChanges?.all(Either<TextDocumentEdit, *>::isLeft) == true &&
+            !workspaceEdit.documentChanges.isNullOrEmpty()
+    }
+
+    private fun toSourceFileEdit(documentEdit: TextDocumentEdit): ConvertedSourceFileEdit? {
+        val fileUri = documentEdit.textDocument.uri ?: return null
+        return toSourceFileEdit(fileUri, documentEdit.edits)
+    }
+
+    private fun toSourceFileEdit(
+        fileUri: String,
+        textEdits: List<TextEdit>,
+    ): ConvertedSourceFileEdit? {
+        val document = getDocument(fileUri)
+        val convertedEdits =
+            textEdits.map { textEdit ->
+                toConvertedTextEdit(fileUri, document, textEdit) ?: return null
+            }
+        val sourceEdits = convertedEdits.map { it.sourceEdit }.sortedByDescending(SourceEdit::getOffset)
+        val selection = convertedEdits.firstNotNullOfOrNull(ConvertedTextEdit::selection)
+        val selectionLength = convertedEdits.firstOrNull { it.selection != null }?.selectionLength
+        val linkedEditGroups = convertedEdits.flatMap(ConvertedTextEdit::linkedEditGroups)
+        return ConvertedSourceFileEdit(
+            SourceFileEdit(fileUri, getFileStamp(fileUri), sourceEdits),
+            selection,
+            selectionLength,
+            linkedEditGroups,
+        )
+    }
+
+    private fun toConvertedTextEdit(
+        fileUri: String,
+        document: Document,
+        textEdit: TextEdit,
+    ): ConvertedTextEdit? {
+        val startOffset = getOffset(document, textEdit.range.start) ?: return null
+        val endOffset = getOffset(document, textEdit.range.end) ?: return null
+        val newText = textEdit.newText ?: ""
+        val decodedSnippet = LspSnippetTextEditDecoder.decode(newText)
+        val replacement = decodedSnippet?.text ?: newText
+        val sourceEdit = SourceEdit(startOffset, endOffset - startOffset, replacement, null, null)
+        if (decodedSnippet == null || decodedSnippet.placeholders.isEmpty()) {
+            return ConvertedTextEdit(sourceEdit, null, null, emptyList())
+        }
+
+        val linkedEditGroups = mutableListOf<LinkedEditGroup>()
+        var selection: ServerPosition? = null
+        var selectionLength: Int? = null
+        decodedSnippet.placeholders.groupBy(DecodedSnippetPlaceholder::number).forEach { (number, placeholders) ->
+            val sortedPlaceholders = placeholders.sortedBy(DecodedSnippetPlaceholder::offset)
+            val choices = sortedPlaceholders.firstNotNullOfOrNull(DecodedSnippetPlaceholder::choices)
+            if (number == 0 && shouldUsePlaceholderGroupAsSelection(sortedPlaceholders, choices)) {
+                val placeholder = sortedPlaceholders.first()
+                selection = ServerPosition(fileUri, startOffset + placeholder.offset)
+                selectionLength = placeholder.length
+            } else {
+                linkedEditGroups.add(
+                    LinkedEditGroup(
+                        sortedPlaceholders.map { placeholder ->
+                            ServerPosition(fileUri, startOffset + placeholder.offset)
+                        },
+                        sortedPlaceholders.first().length,
+                        choices
+                            .orEmpty()
+                            .map { choice ->
+                                LinkedEditSuggestion(choice, "")
+                            },
+                    ),
+                )
+            }
+        }
+
+        return ConvertedTextEdit(sourceEdit, selection, selectionLength, linkedEditGroups)
+    }
+
+    private fun shouldUsePlaceholderGroupAsSelection(
+        placeholders: List<DecodedSnippetPlaceholder>,
+        choices: List<String>?,
+    ): Boolean = placeholders.size == 1 && placeholders.first().length == 0 && choices.isNullOrEmpty()
+
+    private data class ConvertedSourceFileEdit(
+        val fileEdit: SourceFileEdit,
+        val selection: ServerPosition?,
+        val selectionLength: Int?,
+        val linkedEditGroups: List<LinkedEditGroup>,
+    )
+
+    private data class ConvertedTextEdit(
+        val sourceEdit: SourceEdit,
+        val selection: ServerPosition?,
+        val selectionLength: Int?,
+        val linkedEditGroups: List<LinkedEditGroup>,
+    )
+
+    private fun getDocument(fileUri: String): Document {
+        val virtualFile =
+            getDartFileInfo(project, fileUri).findFile()
+                ?: throw IllegalStateException("Unable to resolve Dart file for $fileUri")
+        return FileDocumentManager.getInstance().getDocument(virtualFile)
+            ?: throw IllegalStateException("Unable to load document for $fileUri")
+    }
+
+    private fun getFileStamp(fileUri: String): Long {
+        return getDartFileInfo(project, fileUri).findFile()?.modificationStamp ?: 0L
+    }
+
+    private fun toPosition(
+        document: Document,
+        offset: Int,
+    ): Position {
+        val clampedOffset = offset.coerceIn(0, document.textLength)
+        val line = document.getLineNumber(clampedOffset)
+        val character = clampedOffset - document.getLineStartOffset(line)
+        return Position(line, character)
+    }
+
+    private fun getOffset(
+        document: Document,
+        position: Position?,
+    ): Int? {
+        if (position == null) return null
+
+        val lineCount = document.lineCount
+        val line = position.line
+        var character = position.character
+        if (line == lineCount && character == 0) return document.textLength
+        if (line < 0 || line >= lineCount || character < 0) return null
+
+        val lineStartOffset = document.getLineStartOffset(line)
+        val lineEndOffset = document.getLineEndOffset(line)
+        character = min(character, lineEndOffset - lineStartOffset)
+
+        val offset = lineStartOffset + character
+        return offset.takeIf { it <= document.textLength }
+    }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspSourceChangeConverter.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspSourceChangeConverter.kt
@@ -4,6 +4,8 @@ package com.jetbrains.lang.dart.analyzer.lsp
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.analyzer.getDartFileInfo
 import org.dartlang.analysis.server.protocol.LinkedEditGroup
 import org.dartlang.analysis.server.protocol.LinkedEditSuggestion
@@ -29,8 +31,9 @@ internal class LspSourceChangeConverter(
         length: Int,
     ): Range {
         val document = getDocument(fileUri)
-        val start = toPosition(document, offset)
-        val end = toPosition(document, offset + length)
+        val virtualFile = findVirtualFile(fileUri)
+        val start = toPosition(document, toCurrentOffset(virtualFile, offset))
+        val end = toPosition(document, toCurrentOffset(virtualFile, offset + length))
         return Range(start, end)
     }
 
@@ -48,26 +51,30 @@ internal class LspSourceChangeConverter(
         val linkedEditGroups = mutableListOf<LinkedEditGroup>()
         var selection: ServerPosition? = null
         var selectionLength: Int? = null
-        workspaceEdit.changes?.forEach { (fileUri, textEdits) ->
-            val convertedEdit = toSourceFileEdit(fileUri, textEdits) ?: return null
-            fileEdits.add(convertedEdit.fileEdit)
-            linkedEditGroups.addAll(convertedEdit.linkedEditGroups)
-            if (selection == null && convertedEdit.selection != null) {
-                selection = convertedEdit.selection
-                selectionLength = convertedEdit.selectionLength
+        val documentChanges = workspaceEdit.documentChanges
+        if (!documentChanges.isNullOrEmpty()) {
+            documentChanges.forEach { change ->
+                if (!change.isLeft) {
+                    return null
+                }
+                val documentChange = change.left ?: return null
+                val convertedEdit = toSourceFileEdit(documentChange) ?: return null
+                fileEdits.add(convertedEdit.fileEdit)
+                linkedEditGroups.addAll(convertedEdit.linkedEditGroups)
+                if (selection == null && convertedEdit.selection != null) {
+                    selection = convertedEdit.selection
+                    selectionLength = convertedEdit.selectionLength
+                }
             }
-        }
-        workspaceEdit.documentChanges?.forEach { change ->
-            if (!change.isLeft) {
-                return null
-            }
-            val documentChange = change.left ?: return null
-            val convertedEdit = toSourceFileEdit(documentChange) ?: return null
-            fileEdits.add(convertedEdit.fileEdit)
-            linkedEditGroups.addAll(convertedEdit.linkedEditGroups)
-            if (selection == null && convertedEdit.selection != null) {
-                selection = convertedEdit.selection
-                selectionLength = convertedEdit.selectionLength
+        } else {
+            workspaceEdit.changes?.forEach { (fileUri, textEdits) ->
+                val convertedEdit = toSourceFileEdit(fileUri, textEdits) ?: return null
+                fileEdits.add(convertedEdit.fileEdit)
+                linkedEditGroups.addAll(convertedEdit.linkedEditGroups)
+                if (selection == null && convertedEdit.selection != null) {
+                    selection = convertedEdit.selection
+                    selectionLength = convertedEdit.selectionLength
+                }
             }
         }
         if (fileEdits.isEmpty()) {
@@ -116,10 +123,13 @@ internal class LspSourceChangeConverter(
     ): ConvertedTextEdit? {
         val startOffset = getOffset(document, textEdit.range.start) ?: return null
         val endOffset = getOffset(document, textEdit.range.end) ?: return null
+        val virtualFile = findVirtualFile(fileUri)
         val newText = textEdit.newText ?: ""
         val decodedSnippet = LspSnippetTextEditDecoder.decode(newText)
         val replacement = decodedSnippet?.text ?: newText
-        val sourceEdit = SourceEdit(startOffset, endOffset - startOffset, replacement, null, null)
+        val sourceStartOffset = toOriginalOffset(virtualFile, startOffset)
+        val sourceEndOffset = toOriginalOffset(virtualFile, endOffset)
+        val sourceEdit = SourceEdit(sourceStartOffset, sourceEndOffset - sourceStartOffset, replacement, null, null)
         if (decodedSnippet == null || decodedSnippet.placeholders.isEmpty()) {
             return ConvertedTextEdit(sourceEdit, null, null, emptyList())
         }
@@ -132,13 +142,13 @@ internal class LspSourceChangeConverter(
             val choices = sortedPlaceholders.firstNotNullOfOrNull(DecodedSnippetPlaceholder::choices)
             if (number == 0 && shouldUsePlaceholderGroupAsSelection(sortedPlaceholders, choices)) {
                 val placeholder = sortedPlaceholders.first()
-                selection = ServerPosition(fileUri, startOffset + placeholder.offset)
+                selection = ServerPosition(fileUri, toOriginalOffset(virtualFile, startOffset + placeholder.offset))
                 selectionLength = placeholder.length
             } else {
                 linkedEditGroups.add(
                     LinkedEditGroup(
                         sortedPlaceholders.map { placeholder ->
-                            ServerPosition(fileUri, startOffset + placeholder.offset)
+                            ServerPosition(fileUri, toOriginalOffset(virtualFile, startOffset + placeholder.offset))
                         },
                         sortedPlaceholders.first().length,
                         choices
@@ -174,15 +184,31 @@ internal class LspSourceChangeConverter(
     )
 
     private fun getDocument(fileUri: String): Document {
-        val virtualFile =
-            getDartFileInfo(project, fileUri).findFile()
-                ?: throw IllegalStateException("Unable to resolve Dart file for $fileUri")
+        val virtualFile = findVirtualFile(fileUri) ?: throw IllegalStateException("Unable to resolve Dart file for $fileUri")
         return FileDocumentManager.getInstance().getDocument(virtualFile)
             ?: throw IllegalStateException("Unable to load document for $fileUri")
     }
 
     private fun getFileStamp(fileUri: String): Long {
-        return getDartFileInfo(project, fileUri).findFile()?.modificationStamp ?: 0L
+        return findVirtualFile(fileUri)?.modificationStamp ?: 0L
+    }
+
+    private fun findVirtualFile(fileUri: String): VirtualFile? = getDartFileInfo(project, fileUri).findFile()
+
+    private fun toCurrentOffset(
+        virtualFile: VirtualFile?,
+        originalOffset: Int,
+    ): Int {
+        if (virtualFile == null) return originalOffset
+        return DartAnalysisServerService.getInstance(project).getConvertedOffset(virtualFile, originalOffset)
+    }
+
+    private fun toOriginalOffset(
+        virtualFile: VirtualFile?,
+        currentOffset: Int,
+    ): Int {
+        if (virtualFile == null) return currentOffset
+        return DartAnalysisServerService.getInstance(project).getOriginalOffset(virtualFile, currentOffset)
     }
 
     private fun toPosition(

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspWorkspaceFoldersManager.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/LspWorkspaceFoldersManager.kt
@@ -1,0 +1,85 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
+import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent
+
+internal class LspWorkspaceFoldersManager {
+    private val registeredWorkspaceFolderUris = mutableSetOf<String>()
+
+    fun clear() {
+        synchronized(this) {
+            registeredWorkspaceFolderUris.clear()
+        }
+    }
+
+    fun resetRegisteredWorkspaceFolders(initialWorkspaceFolderUris: Collection<String>) {
+        synchronized(this) {
+            registeredWorkspaceFolderUris.clear()
+            registeredWorkspaceFolderUris.addAll(initialWorkspaceFolderUris)
+        }
+    }
+
+    fun ensureWorkspaceFolderRegistered(
+        workspaceFolderUri: String,
+        toWorkspaceFolder: (String) -> WorkspaceFolder,
+        sendChange: (DidChangeWorkspaceFoldersParams) -> Unit,
+    ) {
+        synchronized(this) {
+            if (!registeredWorkspaceFolderUris.add(workspaceFolderUri)) return
+        }
+
+        try {
+            sendChange(
+                DidChangeWorkspaceFoldersParams(
+                    WorkspaceFoldersChangeEvent(
+                        listOf(toWorkspaceFolder(workspaceFolderUri)),
+                        emptyList(),
+                    ),
+                ),
+            )
+        } catch (t: Throwable) {
+            synchronized(this) {
+                registeredWorkspaceFolderUris.remove(workspaceFolderUri)
+            }
+            throw t
+        }
+    }
+
+    fun synchronizeWorkspaceFolders(
+        newWorkspaceFolderUris: Set<String>,
+        toWorkspaceFolder: (String) -> WorkspaceFolder,
+        sendChange: (DidChangeWorkspaceFoldersParams) -> Unit,
+    ) {
+        val previousWorkspaceFolderUris: Set<String>
+        val addedWorkspaceFolderUris: Set<String>
+        val removedWorkspaceFolderUris: Set<String>
+        synchronized(this) {
+            addedWorkspaceFolderUris = newWorkspaceFolderUris - registeredWorkspaceFolderUris
+            removedWorkspaceFolderUris = registeredWorkspaceFolderUris - newWorkspaceFolderUris
+            if (addedWorkspaceFolderUris.isEmpty() && removedWorkspaceFolderUris.isEmpty()) return
+
+            previousWorkspaceFolderUris = LinkedHashSet(registeredWorkspaceFolderUris)
+            registeredWorkspaceFolderUris.clear()
+            registeredWorkspaceFolderUris.addAll(newWorkspaceFolderUris)
+        }
+
+        try {
+            sendChange(
+                DidChangeWorkspaceFoldersParams(
+                    WorkspaceFoldersChangeEvent(
+                        addedWorkspaceFolderUris.map(toWorkspaceFolder),
+                        removedWorkspaceFolderUris.map(toWorkspaceFolder),
+                    ),
+                ),
+            )
+        } catch (t: Throwable) {
+            synchronized(this) {
+                registeredWorkspaceFolderUris.clear()
+                registeredWorkspaceFolderUris.addAll(previousWorkspaceFolderUris)
+            }
+            throw t
+        }
+    }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/NoOpDartLanguageClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/NoOpDartLanguageClient.kt
@@ -1,0 +1,23 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.eclipse.lsp4j.MessageActionItem
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.ShowMessageRequestParams
+import org.eclipse.lsp4j.services.LanguageClient
+import java.util.concurrent.CompletableFuture
+
+internal class NoOpDartLanguageClient : LanguageClient {
+  override fun telemetryEvent(`object`: Any?) {}
+
+  override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams) {}
+
+  override fun showMessage(messageParams: MessageParams) {}
+
+  override fun showMessageRequest(requestParams: ShowMessageRequestParams): CompletableFuture<MessageActionItem> {
+    return CompletableFuture.completedFuture(null)
+  }
+
+  override fun logMessage(message: MessageParams) {}
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/NoOpDartLanguageClient.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/lsp/NoOpDartLanguageClient.kt
@@ -9,15 +9,15 @@ import org.eclipse.lsp4j.services.LanguageClient
 import java.util.concurrent.CompletableFuture
 
 internal class NoOpDartLanguageClient : LanguageClient {
-  override fun telemetryEvent(`object`: Any?) {}
+    override fun telemetryEvent(`object`: Any?) {}
 
-  override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams) {}
+    override fun publishDiagnostics(diagnostics: PublishDiagnosticsParams) {}
 
-  override fun showMessage(messageParams: MessageParams) {}
+    override fun showMessage(messageParams: MessageParams) {}
 
-  override fun showMessageRequest(requestParams: ShowMessageRequestParams): CompletableFuture<MessageActionItem> {
-    return CompletableFuture.completedFuture(null)
-  }
+    override fun showMessageRequest(requestParams: ShowMessageRequestParams): CompletableFuture<MessageActionItem> {
+        return CompletableFuture.completedFuture(null)
+    }
 
-  override fun logMessage(message: MessageParams) {}
+    override fun logMessage(message: MessageParams) {}
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/DartRefactoringSupportProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/DartRefactoringSupportProvider.java
@@ -2,6 +2,7 @@
 package com.jetbrains.lang.dart.ide.refactoring;
 
 import com.intellij.lang.refactoring.RefactoringSupportProvider;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.LocalSearchScope;
 import com.intellij.refactoring.RefactoringActionHandler;
@@ -14,6 +15,10 @@ import org.jetbrains.annotations.Nullable;
 public final class DartRefactoringSupportProvider extends RefactoringSupportProvider {
   @Override
   public boolean isInplaceRenameAvailable(@NotNull PsiElement element, PsiElement context) {
+    if (Registry.is("dart.use.lsp.client", false)) {
+      return false;
+    }
+
     return element instanceof DartNamedElement &&
            element.getUseScope() instanceof LocalSearchScope;
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/DartServerRenameHandler.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/DartServerRenameHandler.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -47,7 +48,7 @@ public final class DartServerRenameHandler implements RenameHandler, TitledHandl
 
     final PsiElement psiElement = CommonDataKeys.PSI_ELEMENT.getData(dataContext);
     if (psiElement != null) {
-      if (psiElement.getUseScope() instanceof LocalSearchScope) {
+      if (!Registry.is("dart.use.lsp.client", false) && psiElement.getUseScope() instanceof LocalSearchScope) {
         // Standard VariableInplaceRenameHandler or PsiElementRenameHandler will do the trick (based on existing navigation data from Analysis Server)
         return false;
       }
@@ -101,4 +102,3 @@ public final class DartServerRenameHandler implements RenameHandler, TitledHandl
     new DartRenameDialog(project, editor, refactoring).show();
   }
 }
-

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerExtractLocalVariableRefactoring.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerExtractLocalVariableRefactoring.java
@@ -62,4 +62,8 @@ public class ServerExtractLocalVariableRefactoring extends ServerRefactoring {
     options.setName(name);
     setOptions(true, null);
   }
+
+  public void setNameWithoutValidation(@NotNull String name) {
+    options.setName(name);
+  }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoring.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerRefactoring.java
@@ -71,6 +71,14 @@ public abstract class ServerRefactoring {
     return file;
   }
 
+  protected int getOffset() {
+    return offset;
+  }
+
+  protected int getLength() {
+    return length;
+  }
+
   public @Nullable RefactoringStatus checkFinalConditions() {
     ProgressManager.getInstance().run(new Task.Modal(null, myRefactoringProgressTitle, true) {
       @Override

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerRenameRefactoring.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/ServerRenameRefactoring.java
@@ -1,13 +1,27 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.ide.refactoring;
 
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.analyzer.lsp.LspRenameRefactoringResult;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatus;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatusEntry;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatusSeverity;
 import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The LTK wrapper around the Analysis Server 'Rename' refactoring.
@@ -16,6 +30,16 @@ public class ServerRenameRefactoring extends ServerRefactoring {
   private RenameOptions options;
   private String elementKindName;
   private String oldName;
+  private final Object myLspStateLock = new Object();
+  private @Nullable ServerRefactoringListener myLspListener;
+  private @Nullable RefactoringStatus myLspServerErrorStatus;
+  private @Nullable RefactoringStatus myLspInitialStatus;
+  private @Nullable RefactoringStatus myLspOptionsStatus;
+  private @Nullable RefactoringStatus myLspFinalStatus;
+  private @Nullable SourceChange myLspChange;
+  private final @NotNull Set<String> myLspPotentialEdits = new HashSet<>();
+  private boolean myHasPendingLspRequests;
+  private int myLastLspValidationId;
 
   public ServerRenameRefactoring(final @NotNull Project project, final @NotNull VirtualFile file, final int offset, final int length) {
     super(project, DartBundle.message("progress.title.rename"), RefactoringKind.RENAME, file, offset, length);
@@ -30,8 +54,80 @@ public class ServerRenameRefactoring extends ServerRefactoring {
   }
 
   @Override
+  public @Nullable RefactoringStatus checkFinalConditions() {
+    if (!useNativeLspRename()) {
+      return super.checkFinalConditions();
+    }
+
+    ProgressManager.getInstance().run(new Task.Modal(null, DartBundle.message("progress.title.rename"), true) {
+      @Override
+      public void run(@NotNull ProgressIndicator indicator) {
+        indicator.setText(DartBundle.message("progress.text.validating.the.specified.parameters"));
+        indicator.setIndeterminate(true);
+        runNativeRenameRequest(false, getRequestedNewName());
+      }
+    });
+
+    synchronized (myLspStateLock) {
+      if (myLspServerErrorStatus != null) {
+        return myLspServerErrorStatus;
+      }
+      if (myLspFinalStatus == null) {
+        return null;
+      }
+      RefactoringStatus result = new RefactoringStatus();
+      result.merge(myLspOptionsStatus);
+      result.merge(myLspFinalStatus);
+      return result;
+    }
+  }
+
+  @Override
+  public @Nullable RefactoringStatus checkInitialConditions() {
+    if (!useNativeLspRename()) {
+      return super.checkInitialConditions();
+    }
+
+    ProgressManager.getInstance().run(new Task.Modal(null, DartBundle.message("progress.title.rename"), true) {
+      @Override
+      public void run(@NotNull ProgressIndicator indicator) {
+        indicator.setText(DartBundle.message("progress.text.checking.availability.at.the.selection"));
+        indicator.setIndeterminate(true);
+        runNativeRenameRequest(true, null);
+      }
+    });
+
+    synchronized (myLspStateLock) {
+      if (myLspServerErrorStatus != null) {
+        return myLspServerErrorStatus;
+      }
+      return myLspInitialStatus;
+    }
+  }
+
+  @Override
+  public @Nullable SourceChange getChange() {
+    if (!useNativeLspRename()) {
+      return super.getChange();
+    }
+    synchronized (myLspStateLock) {
+      return myLspChange;
+    }
+  }
+
+  @Override
   protected @Nullable RefactoringOptions getOptions() {
     return options;
+  }
+
+  @Override
+  public @NotNull Set<String> getPotentialEdits() {
+    if (!useNativeLspRename()) {
+      return super.getPotentialEdits();
+    }
+    synchronized (myLspStateLock) {
+      return new HashSet<>(myLspPotentialEdits);
+    }
   }
 
   @Override
@@ -44,8 +140,142 @@ public class ServerRenameRefactoring extends ServerRefactoring {
     }
   }
 
+  @Override
+  public void setListener(@Nullable ServerRefactoringListener listener) {
+    if (!useNativeLspRename()) {
+      super.setListener(listener);
+      return;
+    }
+    synchronized (myLspStateLock) {
+      myLspListener = listener;
+    }
+  }
+
   public void setNewName(@NotNull String newName) {
+    if (options == null) {
+      options = new RenameOptions(oldName == null ? "" : oldName);
+    }
     options.setNewName(newName);
-    setOptions(true, null);
+    if (!useNativeLspRename()) {
+      setOptions(true, null);
+      return;
+    }
+
+    final int validationId;
+    synchronized (myLspStateLock) {
+      validationId = ++myLastLspValidationId;
+      myHasPendingLspRequests = true;
+    }
+    notifyLspListener();
+
+    AppExecutorUtil.getAppExecutorService().execute(() -> {
+      LspRenameRefactoringResult result = null;
+      RefactoringStatus errorStatus = null;
+      try {
+        result = DartAnalysisServerService.getInstance(getProject()).lsp_getRenameRefactoring(getFile(), getOffset(), true, newName);
+        if (result == null) {
+          errorStatus = RefactoringStatus.createFatalErrorStatus("LSP rename backend is unavailable.");
+        }
+      }
+      catch (RuntimeException e) {
+        errorStatus = RefactoringStatus.createFatalErrorStatus(e.getMessage());
+      }
+
+      synchronized (myLspStateLock) {
+        if (validationId != myLastLspValidationId) {
+          return;
+        }
+        myHasPendingLspRequests = false;
+        if (errorStatus != null) {
+          myLspServerErrorStatus = errorStatus;
+          myLspOptionsStatus = errorStatus;
+        }
+        else if (result != null) {
+          applyLspResult(result);
+        }
+      }
+      notifyLspListener();
+    });
+  }
+
+  private void applyLspResult(@NotNull LspRenameRefactoringResult result) {
+    if (result.getFeedback() != null) {
+      setFeedback(result.getFeedback());
+    }
+    myLspServerErrorStatus = null;
+    myLspInitialStatus = toRefactoringStatus(result.getInitialProblems());
+    myLspOptionsStatus = toRefactoringStatus(result.getOptionsProblems());
+    myLspFinalStatus = toRefactoringStatus(result.getFinalProblems());
+    myLspChange = result.getChange();
+    myLspPotentialEdits.clear();
+    myLspPotentialEdits.addAll(result.getPotentialEdits());
+  }
+
+  private @Nullable String getRequestedNewName() {
+    return options == null ? null : options.getNewName();
+  }
+
+  private void notifyLspListener() {
+    final ServerRefactoringListener listener;
+    final boolean hasPendingRequests;
+    final RefactoringStatus optionsStatus;
+    synchronized (myLspStateLock) {
+      listener = myLspListener;
+      hasPendingRequests = myHasPendingLspRequests;
+      optionsStatus = myLspOptionsStatus != null ? myLspOptionsStatus : new RefactoringStatus();
+    }
+    if (listener != null) {
+      listener.requestStateChanged(hasPendingRequests, optionsStatus);
+    }
+  }
+
+  private void runNativeRenameRequest(boolean validateOnly, @Nullable String newName) {
+    final LspRenameRefactoringResult result = DartAnalysisServerService.getInstance(getProject())
+      .lsp_getRenameRefactoring(getFile(), getOffset(), validateOnly, newName);
+
+    synchronized (myLspStateLock) {
+      if (result == null) {
+        final RefactoringStatus errorStatus = RefactoringStatus.createFatalErrorStatus("LSP rename backend is unavailable.");
+        myLspServerErrorStatus = errorStatus;
+        myLspInitialStatus = errorStatus;
+        myLspOptionsStatus = errorStatus;
+        myLspFinalStatus = errorStatus;
+        myLspChange = null;
+        myLspPotentialEdits.clear();
+        return;
+      }
+      applyLspResult(result);
+      myHasPendingLspRequests = false;
+    }
+    notifyLspListener();
+  }
+
+  private boolean useNativeLspRename() {
+    return Registry.is("dart.use.lsp.client", false);
+  }
+
+  private static @NotNull RefactoringStatus toRefactoringStatus(@Nullable Collection<RefactoringProblem> problems) {
+    RefactoringStatus status = new RefactoringStatus();
+    if (problems == null) {
+      return status;
+    }
+
+    for (RefactoringProblem problem : problems) {
+      status.addEntry(new RefactoringStatusEntry(toProblemSeverity(problem.getSeverity()), problem.getMessage()));
+    }
+    return status;
+  }
+
+  private static @NotNull RefactoringStatusSeverity toProblemSeverity(@NotNull String severity) {
+    if (RefactoringProblemSeverity.FATAL.equals(severity)) {
+      return RefactoringStatusSeverity.FATAL;
+    }
+    if (RefactoringProblemSeverity.ERROR.equals(severity)) {
+      return RefactoringStatusSeverity.ERROR;
+    }
+    if (RefactoringProblemSeverity.WARNING.equals(severity)) {
+      return RefactoringStatusSeverity.WARNING;
+    }
+    return RefactoringStatusSeverity.OK;
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/introduce/DartServerExtractLocalVariableHandler.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/refactoring/introduce/DartServerExtractLocalVariableHandler.java
@@ -132,7 +132,9 @@ class ExtractLocalVariableProcessor {
   private void performInPlace() {
     final String[] names = refactoring.getNames();
     if (names.length != 0) {
-      refactoring.setName(names[0]);
+      // In-place extract immediately runs final validation afterwards, so avoid firing a
+      // separate async preview-validation request here and keep the LSP command flow single-shot.
+      refactoring.setNameWithoutValidation(names[0]);
     }
     // validate final status
     {

--- a/third_party/src/main/resources/META-INF/plugin.xml
+++ b/third_party/src/main/resources/META-INF/plugin.xml
@@ -261,6 +261,7 @@
     <registryKey key="dart.server.vm.options" defaultValue="" description="Dart VM options to use when starting Dart Analysis Server process"/>
     <registryKey key="dart.server.additional.arguments" defaultValue="" description="Dart Analysis Server command line arguments"/>
     <registryKey key="dart.projects.without.pubspec" defaultValue="false" description="For special internal Dart projects only"/>
+    <registryKey key="dart.use.lsp.client" defaultValue="false" description="Use LSP protocol instead of legacy analyzer protocol for Dart Analysis Server"/>
   </extensions>
 
   <extensions defaultExtensionNs="org.jetbrains">

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspExtractLocalVariableRefactoringTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspExtractLocalVariableRefactoringTest.java
@@ -1,0 +1,85 @@
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.ide.refactoring.ServerExtractLocalVariableRefactoring;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatus;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public class DartLspExtractLocalVariableRefactoringTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/extract/localVariable";
+  }
+
+  public void testExpressionSingle() {
+    doTest(getTestName(false) + ".dart", false);
+  }
+
+  @NotNull
+  private ServerExtractLocalVariableRefactoring createRefactoring(String filePath) {
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+    PsiFile psiFile = myFixture.configureByFile(filePath);
+
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        VfsUtil.saveText(psiFile.getVirtualFile(), StringUtil.convertLineSeparators(psiFile.getText(), "\r\n"));
+      }
+      catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    myFixture.doHighlighting();
+    int offset = getEditor().getSelectionModel().getSelectionStart();
+    int length = getEditor().getSelectionModel().getSelectionEnd() - offset;
+    return new ServerExtractLocalVariableRefactoring(getProject(), psiFile.getVirtualFile(), offset, length);
+  }
+
+  private void doTest(String filePath, boolean extractAll) {
+    ServerExtractLocalVariableRefactoring refactoring = createRefactoring(filePath);
+
+    RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.isOK());
+
+    refactoring.setExtractAll(extractAll);
+
+    RefactoringStatus finalConditions = refactoring.checkFinalConditions();
+    assertNotNull(finalConditions);
+    assertTrue(finalConditions.isOK());
+
+    SourceChange change = refactoring.getChange();
+    assertNotNull(change);
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        AssistUtils.applySourceChange(myFixture.getProject(), change, true);
+      }
+      catch (DartSourceEditException e) {
+        fail(e.getMessage());
+      }
+    });
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspExtractMethodRefactoringTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspExtractMethodRefactoringTest.java
@@ -1,0 +1,73 @@
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.SelectionModel;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.ide.refactoring.ServerExtractMethodRefactoring;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatus;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+public class DartLspExtractMethodRefactoringTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/extract/method";
+  }
+
+  public void testMethodSingle() {
+    doTest(getTestName(false) + ".dart");
+  }
+
+  @NotNull
+  private ServerExtractMethodRefactoring createRefactoring(String filePath) {
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+    final PsiFile psiFile = myFixture.configureByFile(filePath);
+    myFixture.doHighlighting();
+    final SelectionModel selectionModel = getEditor().getSelectionModel();
+    final int offset = selectionModel.getSelectionStart();
+    final int length = selectionModel.getSelectionEnd() - offset;
+    return new ServerExtractMethodRefactoring(getProject(), psiFile.getVirtualFile(), offset, length);
+  }
+
+  private void doTest(String filePath) {
+    final ServerExtractMethodRefactoring refactoring = createRefactoring(filePath);
+    final RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.isOK());
+
+    refactoring.setName("test");
+
+    final RefactoringStatus finalConditions = refactoring.checkFinalConditions();
+    assertNotNull(finalConditions);
+    assertTrue(finalConditions.isOK());
+
+    final SourceChange change = refactoring.getChange();
+    assertNotNull(change);
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        AssistUtils.applySourceChange(myFixture.getProject(), change, false);
+      }
+      catch (DartSourceEditException e) {
+        fail(e.getMessage());
+      }
+    });
+
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspInlineLocalRefactoringTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspInlineLocalRefactoringTest.java
@@ -1,0 +1,69 @@
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.ide.refactoring.ServerInlineLocalRefactoring;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatus;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+public class DartLspInlineLocalRefactoringTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/inline/local";
+  }
+
+  public void testTest() {
+    doTest(getTestName(false) + ".dart");
+  }
+
+  @NotNull
+  private ServerInlineLocalRefactoring createInlineLocalRefactoring(String filePath) {
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+    PsiFile psiFile = myFixture.configureByFile(filePath);
+    myFixture.doHighlighting();
+    int offset = getEditor().getCaretModel().getOffset();
+    return new ServerInlineLocalRefactoring(getProject(), psiFile.getVirtualFile(), offset, 0);
+  }
+
+  private void doTest(String filePath) {
+    ServerInlineLocalRefactoring refactoring = createInlineLocalRefactoring(filePath);
+
+    RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.isOK());
+
+    RefactoringStatus finalConditions = refactoring.checkFinalConditions();
+    assertNotNull(finalConditions);
+    assertTrue(finalConditions.isOK());
+
+    SourceChange change = refactoring.getChange();
+    assertNotNull(change);
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        AssistUtils.applySourceChange(myFixture.getProject(), change, false);
+      }
+      catch (DartSourceEditException e) {
+        fail(e.getMessage());
+      }
+    });
+
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspInlineMethodRefactoringTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspInlineMethodRefactoringTest.java
@@ -1,0 +1,78 @@
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.ide.refactoring.ServerInlineMethodRefactoring;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatus;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+public class DartLspInlineMethodRefactoringTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/inline/method";
+  }
+
+  public void testFunctionSingle() {
+    doTest(getTestName(false) + ".dart", false);
+  }
+
+  public void testFunctionAll() {
+    doTest(getTestName(false) + ".dart", true);
+  }
+
+  @NotNull
+  private ServerInlineMethodRefactoring createRefactoring(String filePath) {
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+    PsiFile psiFile = myFixture.configureByFile(filePath);
+    myFixture.doHighlighting();
+    int offset = getEditor().getCaretModel().getOffset();
+    return new ServerInlineMethodRefactoring(getProject(), psiFile.getVirtualFile(), offset, 0);
+  }
+
+  private void doTest(String filePath, boolean inlineAll) {
+    ServerInlineMethodRefactoring refactoring = createRefactoring(filePath);
+
+    RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.isOK());
+
+    if (inlineAll) {
+      refactoring.setInlineAll(true);
+      refactoring.setDeleteSource(true);
+    }
+
+    RefactoringStatus finalConditions = refactoring.checkFinalConditions();
+    assertNotNull(finalConditions);
+    assertTrue(finalConditions.isOK());
+
+    SourceChange change = refactoring.getChange();
+    assertNotNull(change);
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        AssistUtils.applySourceChange(myFixture.getProject(), change, false);
+      }
+      catch (DartSourceEditException e) {
+        fail(e.getMessage());
+      }
+    });
+
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspMoveFileRefactoringTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspMoveFileRefactoringTest.java
@@ -1,0 +1,74 @@
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.psi.PsiFile;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.ide.refactoring.moveFile.MoveFileRefactoring;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatus;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.SourceChange;
+
+public class DartLspMoveFileRefactoringTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  public void testFileMove() {
+    final PsiFile fooFile = myFixture.addFileToProject("web/src/foo.dart", "import \"bar.dart\";");
+    myFixture.addFileToProject("web/src/bar.dart", "");
+    final MoveFileRefactoring refactoring = createRefactoring(fooFile, "web/foo.dart");
+    applyRefactoring(refactoring);
+    myFixture.openFileInEditor(fooFile.getVirtualFile());
+    myFixture.checkResult("import \"src/bar.dart\";");
+  }
+
+  public void testTargetFileMove() {
+    final PsiFile fooFile = myFixture.addFileToProject("web/src/foo.dart", "import \"bar.dart\";");
+    final PsiFile barFile = myFixture.addFileToProject("web/src/bar.dart", "");
+    myFixture.openFileInEditor(fooFile.getVirtualFile());
+    myFixture.doHighlighting();
+    final MoveFileRefactoring refactoring = createRefactoring(barFile, "web/bar.dart");
+    applyRefactoring(refactoring);
+    myFixture.openFileInEditor(fooFile.getVirtualFile());
+    myFixture.checkResult("import \"../bar.dart\";");
+  }
+
+  private MoveFileRefactoring createRefactoring(PsiFile file, String newFilePath) {
+    final String currentPath = file.getVirtualFile().getPath();
+    final int webRootIndex = currentPath.indexOf("/web/");
+    assertTrue("Expected test file to live under a web/ root: " + currentPath, webRootIndex >= 0);
+    final String testContentRoot = currentPath.substring(0, webRootIndex);
+    return new MoveFileRefactoring(getProject(), file.getVirtualFile(), testContentRoot + "/" + newFilePath);
+  }
+
+  private void applyRefactoring(MoveFileRefactoring refactoring) {
+    final RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.isOK());
+
+    final RefactoringStatus finalConditions = refactoring.checkFinalConditions();
+    assertNotNull(finalConditions);
+    assertTrue(finalConditions.isOK());
+
+    final SourceChange change = refactoring.getChange();
+    assertNotNull(change);
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        AssistUtils.applySourceChange(myFixture.getProject(), change, false);
+      }
+      catch (DartSourceEditException e) {
+        fail(e.getMessage());
+      }
+    });
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspRenameRefactoringTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspRenameRefactoringTest.java
@@ -1,0 +1,113 @@
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.ide.refactoring.ServerRenameRefactoring;
+import com.jetbrains.lang.dart.ide.refactoring.status.RefactoringStatus;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+public class DartLspRenameRefactoringTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/refactoring/rename";
+  }
+
+  public void testCheckFinalConditionsNameFatalError() {
+    final ServerRenameRefactoring refactoring = createRenameRefactoring();
+    final RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.isOK());
+
+    refactoring.setNewName("bad name");
+    final RefactoringStatus finalConditions = refactoring.checkFinalConditions();
+    assertNotNull(finalConditions);
+    assertTrue(finalConditions.hasFatalError());
+  }
+
+  public void testCheckInitialConditionsCannotCreate() {
+    final ServerRenameRefactoring refactoring = createRenameRefactoring();
+    final RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.hasFatalError());
+  }
+
+  public void testClass() {
+    doTest("NewName");
+  }
+
+  public void testConstructorDefaultToNamed() {
+    doTest("newName");
+  }
+
+  public void testIgnorePotential() {
+    doTest("newName");
+  }
+
+  public void testMethod() {
+    doTest("newName");
+  }
+
+  public void testTypeAndImmediatelyRenameLocalVar() {
+    myFixture.configureByFile(getTestName(false) + ".dart");
+    myFixture.doHighlighting();
+    myFixture.type('\n');
+    final int offset = getEditor().getCaretModel().getOffset();
+    final ServerRenameRefactoring refactoring = new ServerRenameRefactoring(getProject(), getFile().getVirtualFile(), offset, 0);
+    doTest(refactoring, "newName");
+  }
+
+  private void doTest(@NotNull final String newName) {
+    final ServerRenameRefactoring refactoring = createRenameRefactoring();
+    doTest(refactoring, newName);
+  }
+
+  private void doTest(@NotNull final ServerRenameRefactoring refactoring, @NotNull final String newName) {
+    final RefactoringStatus initialConditions = refactoring.checkInitialConditions();
+    assertNotNull(initialConditions);
+    assertTrue(initialConditions.isOK());
+
+    refactoring.setNewName(newName);
+    final RefactoringStatus finalConditions = refactoring.checkFinalConditions();
+    assertNotNull(finalConditions);
+    assertTrue(finalConditions.isOK());
+
+    final SourceChange change = refactoring.getChange();
+    assertNotNull(change);
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        AssistUtils.applySourceChange(myFixture.getProject(), change, false, refactoring.getPotentialEdits());
+      }
+      catch (DartSourceEditException e) {
+        fail(e.getMessage());
+      }
+    });
+
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
+  }
+
+  @NotNull
+  private ServerRenameRefactoring createRenameRefactoring() {
+    myFixture.configureByFile(getTestName(false) + ".dart");
+    myFixture.doHighlighting();
+    final int offset = getEditor().getCaretModel().getOffset();
+    return new ServerRenameRefactoring(getProject(), getFile().getVirtualFile(), offset, 0);
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerHighlightingTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerHighlightingTest.java
@@ -1,0 +1,32 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+
+public class DartLspServerHighlightingTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/highlighting";
+  }
+
+  private void doHighlightingTest() {
+    myFixture.configureByFile(getTestName(false) + ".dart");
+    myFixture.checkHighlighting();
+  }
+
+  public void testErrorsAfterEOF() {
+    doHighlightingTest();
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerHighlightingTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerHighlightingTest.java
@@ -4,6 +4,7 @@ package com.jetbrains.dart.analysisServer;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.util.DartTestUtils;
 
 public class DartLspServerHighlightingTest extends CodeInsightFixtureTestCase {
@@ -12,6 +13,7 @@ public class DartLspServerHighlightingTest extends CodeInsightFixtureTestCase {
     super.setUp();
     Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
     DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
     myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
     ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
   }

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerIntentionsTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerIntentionsTest.java
@@ -1,0 +1,115 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.intellij.util.containers.ContainerUtil;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class DartLspServerIntentionsTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/intentions";
+  }
+
+  private void doTest(@NotNull String intentionName) {
+    myFixture.configureByFile(getTestName(false) + ".dart");
+    IntentionAction intention = myFixture.findSingleIntention(intentionName);
+
+    ApplicationManager.getApplication().runWriteAction(() -> intention.invoke(getProject(), getEditor(), getFile()));
+
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
+  }
+
+  public void testIntroduceVariableNoSelection() {
+    doTest("Assign value to new local variable");
+  }
+
+  public void testSurroundWithTryCatch() {
+    doTest("Surround with 'try-catch'");
+  }
+
+  public void testIntentionsOrder() {
+    myFixture.configureByText("foo.dart", """
+      void f() {
+        <selection><caret>var x = 3;</selection>
+      }
+      """);
+    final List<String> intentions = ContainerUtil.map(myFixture.getAvailableIntentions(), IntentionAction::getText);
+    assertOrderedEquals(intentions,
+                        "Surround with block",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Surround with 'if'",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Surround with 'while'",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Surround with 'for-in'",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Surround with 'for'",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Surround with 'do-while'",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Surround with 'try-catch'",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Surround with 'try-finally'",
+                        "Edit intention settings",
+                        "Disable 'Quick assists powered by the Dart Analysis Server'",
+                        "Assign shortcut…",
+                        "Adjust code style settings",
+                        "Assign shortcut…");
+  }
+
+  public void testIntentionPreview() {
+    myFixture.configureByText("foo.dart", """
+      main ( )  {
+       Foo<caret>
+         }""");
+    IntentionAction action = myFixture.findSingleIntention("Assign value to new local variable");
+    assertEquals("""
+                   main ( )  {
+                    var foo = Foo
+                      }""", myFixture.getIntentionPreviewText(action));
+  }
+
+  public void testAssistRequestDoesNotReturnQuickFixes() {
+    myFixture.configureByText("foo.dart", "<caret>ServerSocket f;\nclass ServerSockets {}");
+
+    DartAnalysisServerService service = DartAnalysisServerService.getInstance(getProject());
+    service.updateFilesContent();
+
+    List<SourceChange> assists = service.edit_getAssists(getFile().getVirtualFile(), getEditor().getCaretModel().getOffset(), 0);
+    assertEmpty(ContainerUtil.map(assists, SourceChange::getMessage));
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerQuickFixTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartLspServerQuickFixTest.java
@@ -1,0 +1,57 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.dart.analysisServer;
+
+import com.intellij.codeInsight.daemon.HighlightDisplayKey;
+import com.intellij.codeInsight.daemon.impl.HighlightVisitorBasedInspection;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.GlobalInspectionTool;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.util.DartTestUtils;
+
+public class DartLspServerQuickFixTest extends CodeInsightFixtureTestCase {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    Registry.get("dart.use.lsp.client").setValue(true, myFixture.getTestRootDisposable());
+    DartTestUtils.configureDartSdk(myModule, myFixture.getTestRootDisposable(), true);
+    DartAnalysisServerService.getInstance(getProject()).serverReadyForRequest();
+    myFixture.setTestDataPath(DartTestUtils.BASE_TEST_DATA_PATH + getBasePath());
+    ((CodeInsightTestFixtureImpl)myFixture).canChangeDocumentDuringHighlighting(true);
+  }
+
+  @Override
+  protected String getBasePath() {
+    return "/analysisServer/quickfix";
+  }
+
+  private void doQuickFixTest(String intentionStartText) {
+    myFixture.configureByFile(getTestName(false) + ".dart");
+
+    IntentionAction quickFix = myFixture.findSingleIntention(intentionStartText);
+    assertTrue(quickFix.isAvailable(getProject(), getEditor(), getFile()));
+
+    ApplicationManager.getApplication().runWriteAction(() -> quickFix.invoke(getProject(), getEditor(), getFile()));
+
+    myFixture.checkResultByFile(getTestName(false) + ".after.dart");
+  }
+
+  public void testCreateClass() {
+    doQuickFixTest("Create class 'A'");
+  }
+
+  public void testUseEqEqNull() {
+    doQuickFixTest("Use == null instead of 'is Null'");
+  }
+
+  public void testNoQuickFixes() {
+    GlobalInspectionTool tool = new HighlightVisitorBasedInspection().setRunAnnotators(true);
+    myFixture.enableInspections(tool);
+    assertNotNull(HighlightDisplayKey.find(tool.getShortName()));
+    myFixture.configureByText("foo.dart", "main(){ print(<caret>); }");
+    assertEmpty(myFixture.getAvailableIntentions());
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/LspContentSyncIntegrationTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/LspContentSyncIntegrationTest.kt
@@ -1,0 +1,245 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer
+
+import com.google.dart.server.GetServerPortConsumer
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.builders.ModuleFixtureBuilder
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
+import com.jetbrains.lang.dart.util.DartTestUtils
+import org.dartlang.analysis.server.protocol.RequestError
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Integration test that exercises the service-side overlaid content pipeline against
+ * a real Dart LSP server process.
+ *
+ * Requires DART_HOME to point at a valid Dart SDK.
+ */
+class LspContentSyncIntegrationTest : CodeInsightFixtureTestCase<ModuleFixtureBuilder<*>>() {
+    companion object {
+        private const val PORT_REQUEST_TIMEOUT_SECONDS = 30L
+    }
+
+    private val tempDirs = mutableListOf<Path>()
+
+    override fun setUp() {
+        super.setUp()
+        DartTestUtils.configureDartSdk(myModule, myFixture.testRootDisposable, true)
+    }
+
+    override fun tearDown() {
+        try {
+            if (project != null && !project.isDisposed) {
+                DartAnalysisServerService.getInstance(project).stopServer()
+            }
+        } catch (t: Throwable) {
+            addSuppressedException(t)
+        } finally {
+            try {
+                tempDirs.forEach { dir ->
+                    val walk = Files.walk(dir)
+                    try {
+                        walk.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+                    } finally {
+                        walk.close()
+                    }
+                }
+            } catch (t: Throwable) {
+                addSuppressedException(t)
+            } finally {
+                tempDirs.clear()
+                super.tearDown()
+            }
+        }
+    }
+
+    fun testSingleDocumentLifecycle() {
+        val service = startLspServer()
+        val file = createLocalDartFile("main.dart", "void main() {}")
+        val document = getDocument(file)
+
+        replaceDocumentText(document, "void main() { print('hello'); }")
+        service.updateFilesContent()
+        assertServerAlive(service, "after initial overlay sync")
+        assertTrackedFiles(service, file.path)
+
+        val firstTrackedTimestamp = trackedOverlayTimestamps(service)[file.path]
+        assertEquals(document.modificationStamp, firstTrackedTimestamp)
+
+        replaceDocumentText(document, "void main() { print('updated'); }")
+        service.updateFilesContent()
+        assertServerAlive(service, "after updated overlay sync")
+        assertTrackedFiles(service, file.path)
+        assertEquals(document.modificationStamp, trackedOverlayTimestamps(service)[file.path])
+
+        saveDocument(document)
+        service.updateFilesContent()
+        assertServerAlive(service, "after overlay removal")
+        assertTrackedFiles(service)
+
+        val port = requestDiagnosticPort(service)
+        assertTrue("Diagnostic port should be valid after full lifecycle, got: $port", port > 0)
+        assertPortReachable(port)
+    }
+
+    fun testMultipleDocuments() {
+        val service = startLspServer()
+        val fileA = createLocalDartFile("a.dart", "class A {}")
+        val fileB = createLocalDartFile("b.dart", "class B {}")
+        val documentA = getDocument(fileA)
+        val documentB = getDocument(fileB)
+
+        replaceDocumentText(documentA, "class A { void run() {} }")
+        replaceDocumentText(documentB, "class B { void run() {} }")
+        service.updateFilesContent()
+        assertServerAlive(service, "after initial multi-file sync")
+        assertTrackedFiles(service, fileA.path, fileB.path)
+
+        val initialTracked = trackedOverlayTimestamps(service)
+        val trackedBVersion = initialTracked[fileB.path]
+
+        saveDocument(documentA)
+        service.updateFilesContent()
+        assertServerAlive(service, "after saving A")
+        assertTrackedFiles(service, fileB.path)
+        assertEquals(trackedBVersion, trackedOverlayTimestamps(service)[fileB.path])
+
+        replaceDocumentText(documentB, "class B { void run() {} void close() {} }")
+        service.updateFilesContent()
+        assertServerAlive(service, "after changing B while A is saved")
+        assertTrackedFiles(service, fileB.path)
+        assertEquals(documentB.modificationStamp, trackedOverlayTimestamps(service)[fileB.path])
+
+        val port = requestDiagnosticPort(service)
+        assertTrue("Diagnostic port should be valid after multi-file lifecycle, got: $port", port > 0)
+    }
+
+    fun testReopenAfterClose() {
+        val service = startLspServer()
+        val file = createLocalDartFile("reopen.dart", "// v0")
+        val document = getDocument(file)
+
+        replaceDocumentText(document, "// v1")
+        service.updateFilesContent()
+        assertTrackedFiles(service, file.path)
+
+        saveDocument(document)
+        service.updateFilesContent()
+        assertTrackedFiles(service)
+
+        replaceDocumentText(document, "// v2")
+        service.updateFilesContent()
+        assertServerAlive(service, "after re-adding overlay")
+        assertTrackedFiles(service, file.path)
+        assertEquals(document.modificationStamp, trackedOverlayTimestamps(service)[file.path])
+    }
+
+    private fun assertServerAlive(
+        service: DartAnalysisServerService,
+        context: String,
+    ) {
+        assertTrue("Server should be alive $context", service.isServerProcessActive)
+    }
+
+    private fun startLspServer(): DartAnalysisServerService {
+        Registry.get("dart.use.lsp.client").setValue(true, myFixture.testRootDisposable)
+        return DartAnalysisServerService.getInstance(project).also { service ->
+            service.stopServer()
+            assertTrue("Failed to start LSP-protocol server", service.serverReadyForRequest())
+        }
+    }
+
+    private fun createLocalDartFile(
+        fileName: String,
+        content: String,
+    ): VirtualFile {
+        val dir = Files.createTempDirectory("dart-lsp-sync")
+        tempDirs.add(dir)
+        val filePath = dir.resolve(fileName)
+        Files.createDirectories(filePath.parent)
+        Files.writeString(filePath, content)
+        return LocalFileSystem.getInstance().refreshAndFindFileByNioFile(filePath)
+            ?: throw AssertionError("Failed to create local test file for $fileName")
+    }
+
+    private fun getDocument(file: VirtualFile): Document {
+        return FileDocumentManager.getInstance().getDocument(file)
+            ?: throw AssertionError("Expected document for ${file.path}")
+    }
+
+    private fun replaceDocumentText(
+        document: Document,
+        text: String,
+    ) {
+        ApplicationManager.getApplication().runWriteAction {
+            document.setText(text)
+        }
+    }
+
+    private fun saveDocument(document: Document) {
+        ApplicationManager.getApplication().runWriteAction {
+            FileDocumentManager.getInstance().saveDocument(document)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun trackedOverlayTimestamps(service: DartAnalysisServerService): Map<String, Long> {
+        val field = DartAnalysisServerService::class.java.getDeclaredField("myFilePathWithOverlaidContentToTimestamp")
+        field.isAccessible = true
+        return LinkedHashMap(field.get(service) as Map<String, Long>)
+    }
+
+    private fun assertTrackedFiles(
+        service: DartAnalysisServerService,
+        vararg expectedPaths: String,
+    ) {
+        assertEquals(expectedPaths.toSet(), trackedOverlayTimestamps(service).keys)
+    }
+
+    private fun requestDiagnosticPort(service: DartAnalysisServerService): Int {
+        val latch = CountDownLatch(1)
+        val port = AtomicInteger(-1)
+        val error = AtomicReference<RequestError>()
+
+        service.diagnostic_getServerPort(
+            object : GetServerPortConsumer {
+                override fun computedServerPort(value: Int) {
+                    port.set(value)
+                    latch.countDown()
+                }
+
+                override fun onError(requestError: RequestError) {
+                    error.set(requestError)
+                    latch.countDown()
+                }
+            },
+        )
+
+        assertTrue("Timed out waiting for diagnostic port response", latch.await(PORT_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        assertNull("Failed to get diagnostic port: ${toErrorMessage(error.get())}", error.get())
+        return port.get()
+    }
+
+    private fun toErrorMessage(error: RequestError?): String {
+        return if (error == null) "" else "${error.code}: ${error.message}"
+    }
+
+    private fun assertPortReachable(port: Int) {
+        Socket().use { socket ->
+            socket.connect(InetSocketAddress("127.0.0.1", port), 5000)
+        }
+    }
+}

--- a/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManagerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/lsp/LspDocumentSyncManagerTest.kt
@@ -1,0 +1,236 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.dartlang.analysis.server.protocol.AddContentOverlay
+import org.dartlang.analysis.server.protocol.RemoveContentOverlay
+import org.eclipse.lsp4j.DidChangeTextDocumentParams
+import org.eclipse.lsp4j.DidCloseTextDocumentParams
+import org.eclipse.lsp4j.DidOpenTextDocumentParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.TextDocumentSyncKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class LspDocumentSyncManagerTest {
+    private val openCalls = mutableListOf<DidOpenTextDocumentParams>()
+    private val changeCalls = mutableListOf<DidChangeTextDocumentParams>()
+    private val closeCalls = mutableListOf<DidCloseTextDocumentParams>()
+
+    @Before
+    fun setUp() {
+        openCalls.clear()
+        changeCalls.clear()
+        closeCalls.clear()
+    }
+
+    private fun createManager(syncKind: TextDocumentSyncKind = TextDocumentSyncKind.Full) =
+        LspDocumentSyncManager(
+            onDidOpen = { openCalls.add(it) },
+            onDidChange = { changeCalls.add(it) },
+            onDidClose = { closeCalls.add(it) },
+            syncKindProvider = { syncKind },
+        )
+
+    @Test
+    fun `first AddContentOverlay sends didOpen`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("void main() {}"))
+
+        assertEquals(1, openCalls.size)
+        assertEquals(0, changeCalls.size)
+        assertEquals(0, closeCalls.size)
+
+        val params = openCalls[0]
+        assertEquals("file:///test.dart", params.textDocument.uri)
+        assertEquals("dart", params.textDocument.languageId)
+        assertEquals(1, params.textDocument.version)
+        assertEquals("void main() {}", params.textDocument.text)
+    }
+
+    @Test
+    fun `second AddContentOverlay with different content sends didChange`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("void main() {}"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("void main() { print('hi'); }"))
+
+        assertEquals(1, openCalls.size)
+        assertEquals(1, changeCalls.size)
+
+        val params = changeCalls[0]
+        assertEquals("file:///test.dart", params.textDocument.uri)
+        assertEquals(2, params.textDocument.version)
+        assertEquals("void main() { print('hi'); }", params.contentChanges[0].text)
+    }
+
+    @Test
+    fun `second AddContentOverlay with same content is no-op`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("void main() {}"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("void main() {}"))
+
+        assertEquals(1, openCalls.size)
+        assertEquals(0, changeCalls.size)
+    }
+
+    @Test
+    fun `RemoveContentOverlay sends didClose`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("void main() {}"))
+        manager.applyOverlay("file:///test.dart", RemoveContentOverlay())
+
+        assertEquals(1, openCalls.size)
+        assertEquals(1, closeCalls.size)
+        assertEquals("file:///test.dart", closeCalls[0].textDocument.uri)
+    }
+
+    @Test
+    fun `RemoveContentOverlay for unknown file is no-op`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///unknown.dart", RemoveContentOverlay())
+
+        assertEquals(0, openCalls.size)
+        assertEquals(0, changeCalls.size)
+        assertEquals(0, closeCalls.size)
+    }
+
+    @Test
+    fun `version increments across multiple changes`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("v1"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("v2"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("v3"))
+
+        assertEquals(1, openCalls[0].textDocument.version)
+        assertEquals(2, changeCalls[0].textDocument.version)
+        assertEquals(3, changeCalls[1].textDocument.version)
+    }
+
+    @Test
+    fun `reopen after close starts fresh version`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("v1"))
+        manager.applyOverlay("file:///test.dart", RemoveContentOverlay())
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("v2"))
+
+        assertEquals(2, openCalls.size)
+        assertEquals(1, openCalls[0].textDocument.version)
+        assertEquals(1, openCalls[1].textDocument.version)
+    }
+
+    @Test
+    fun `multiple files are tracked independently`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///a.dart", AddContentOverlay("a1"))
+        manager.applyOverlay("file:///b.dart", AddContentOverlay("b1"))
+        manager.applyOverlay("file:///a.dart", AddContentOverlay("a2"))
+
+        assertEquals(2, openCalls.size)
+        assertEquals(1, changeCalls.size)
+        assertEquals("file:///a.dart", changeCalls[0].textDocument.uri)
+    }
+
+    @Test
+    fun `clear resets all state`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///a.dart", AddContentOverlay("a1"))
+        manager.clear()
+
+        openCalls.clear()
+        changeCalls.clear()
+
+        manager.applyOverlay("file:///a.dart", AddContentOverlay("a1"))
+
+        assertEquals(1, openCalls.size)
+        assertEquals(0, changeCalls.size)
+    }
+
+    @Test
+    fun `full sync sends content without range`() {
+        val manager = createManager(TextDocumentSyncKind.Full)
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("old"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("new"))
+
+        val changeEvent = changeCalls[0].contentChanges[0]
+        assertNull(changeEvent.range)
+        assertEquals("new", changeEvent.text)
+    }
+
+    @Test
+    fun `incremental sync sends content with full document range`() {
+        val manager = createManager(TextDocumentSyncKind.Incremental)
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("line1\nline2"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("replaced"))
+
+        val changeEvent = changeCalls[0].contentChanges[0]
+        assertNotNull(changeEvent.range)
+        assertEquals(Position(0, 0), changeEvent.range.start)
+        assertEquals(Position(1, 5), changeEvent.range.end)
+        assertEquals("replaced", changeEvent.text)
+    }
+
+    @Test
+    fun `end position handles CRLF`() {
+        val manager = createManager(TextDocumentSyncKind.Incremental)
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("a\r\nb\r\nc"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("replaced"))
+
+        val changeEvent = changeCalls[0].contentChanges[0]
+        assertEquals(Position(2, 1), changeEvent.range.end)
+    }
+
+    @Test
+    fun `end position handles lone CR`() {
+        val manager = createManager(TextDocumentSyncKind.Incremental)
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("a\rb\rc"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("replaced"))
+
+        val changeEvent = changeCalls[0].contentChanges[0]
+        assertEquals(Position(2, 1), changeEvent.range.end)
+    }
+
+    @Test
+    fun `end position for empty string`() {
+        val manager = createManager(TextDocumentSyncKind.Incremental)
+        manager.applyOverlay("file:///test.dart", AddContentOverlay(""))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("x"))
+
+        val changeEvent = changeCalls[0].contentChanges[0]
+        assertEquals(Position(0, 0), changeEvent.range.end)
+    }
+
+    @Test
+    fun `end position for trailing newline`() {
+        val manager = createManager(TextDocumentSyncKind.Incremental)
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("line1\n"))
+        manager.applyOverlay("file:///test.dart", AddContentOverlay("x"))
+
+        val changeEvent = changeCalls[0].contentChanges[0]
+        assertEquals(Position(1, 0), changeEvent.range.end)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `unsupported overlay type throws`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///test.dart", "not an overlay")
+    }
+
+    @Test
+    fun `closing one file does not affect the other`() {
+        val manager = createManager()
+        manager.applyOverlay("file:///a.dart", AddContentOverlay("a"))
+        manager.applyOverlay("file:///b.dart", AddContentOverlay("b"))
+        manager.applyOverlay("file:///a.dart", RemoveContentOverlay())
+
+        assertEquals(1, closeCalls.size)
+        assertEquals("file:///a.dart", closeCalls[0].textDocument.uri)
+
+        changeCalls.clear()
+        manager.applyOverlay("file:///b.dart", AddContentOverlay("b2"))
+        assertEquals(1, changeCalls.size)
+        assertEquals("file:///b.dart", changeCalls[0].textDocument.uri)
+        assertEquals(2, changeCalls[0].textDocument.version)
+    }
+}

--- a/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/lsp/LspSnippetTextEditDecoderTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/lsp/LspSnippetTextEditDecoderTest.kt
@@ -1,0 +1,63 @@
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.analyzer.lsp
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LspSnippetTextEditDecoderTest {
+    @Test
+    fun `test returns null for plain text edits`() {
+        assertNull(LspSnippetTextEditDecoder.decode("var value = 1;"))
+    }
+
+    @Test
+    fun `test decodes final selection placeholder`() {
+        val decoded = LspSnippetTextEditDecoder.decode("var ${'$'}{0:i} = ")!!
+
+        assertEquals("var i = ", decoded.text)
+        assertEquals(listOf(DecodedSnippetPlaceholder(0, 4, 1, null)), decoded.placeholders)
+    }
+
+    @Test
+    fun `test decodes plain tab stop placeholder`() {
+        val decoded = LspSnippetTextEditDecoder.decode("return ${'$'}0;")!!
+
+        assertEquals("return ;", decoded.text)
+        assertEquals(listOf(DecodedSnippetPlaceholder(0, 7, 0, null)), decoded.placeholders)
+    }
+
+    @Test
+    fun `test decodes linked edit placeholders and choices`() {
+        val decoded =
+            LspSnippetTextEditDecoder.decode(
+                "try {${'$'}0} on ${'$'}{1|Exception,Object|} catch (" +
+                    "${'$'}{2:e}) {}",
+            )!!
+
+        assertEquals("try {} on Exception catch (e) {}", decoded.text)
+        assertEquals(
+            listOf(
+                DecodedSnippetPlaceholder(0, 5, 0, null),
+                DecodedSnippetPlaceholder(1, 10, 9, listOf("Exception", "Object")),
+                DecodedSnippetPlaceholder(2, 27, 1, null),
+            ),
+            decoded.placeholders,
+        )
+    }
+
+    @Test
+    fun `test decodes escaped snippet characters as plain text`() {
+        val decoded = LspSnippetTextEditDecoder.decode("""\$\\""")!!
+
+        assertEquals("$\\", decoded.text)
+        assertEquals(emptyList<DecodedSnippetPlaceholder>(), decoded.placeholders)
+    }
+
+    @Test
+    fun `test returns null for malformed snippets`() {
+        assertNull(LspSnippetTextEditDecoder.decode("${'$'}{0"))
+        assertNull(LspSnippetTextEditDecoder.decode("${'$'}{1|Exception,Object}"))
+        assertNull(LspSnippetTextEditDecoder.decode("\\"))
+    }
+}


### PR DESCRIPTION
 Translated/scaffolded

  - Cluster 1, server lifecycle: mostly done behind the existing DartClient abstraction. LSP startup, shutdown, status listeners, workspace capability negotiation,
    and connection management are in place, but several legacy-facing methods are still no-ops.
  - Cluster 2, document sync and analysis configuration: partially done. File overlay sync is implemented through LSP document sync, and analysis roots are mapped to
    workspace folders. Priority files, subscriptions, reanalyze, and options updates are still stubbed/no-op.
  - Cluster 3, diagnostics/push: partially done. LSP publishDiagnostics is converted back into legacy AnalysisError objects so existing highlighting/problems-view
    plumbing still works. Other push-style notifications are still not migrated.
  - Cluster 7, code actions and refactoring: this branch now has broad translation coverage here.
      - Assists are translated from textDocument/codeAction into legacy SourceChange.
      - Fixes are translated from textDocument/codeAction into legacy SourceChange.
      - Rename is translated through LSP prepareRename / rename, but the result is converted back into legacy rename feedback and SourceChange, and still uses the
        old refactoring UI/contracts.
      - Move file is translated through workspace/willRenameFiles, then converted back into SourceChange.
      - Extract method / extract local / inline method / inline local are translated through command-based LSP refactoring (refactor.validate / refactor.perform),
        with the resulting edits converted back into SourceChange.
  - Cluster 12, extensions/raw: partially done. Diagnostic server port and UUID generation are implemented. The branch also has infrastructure for workspace/
    applyEdit handling to support command-backed refactorings. Raw request passthrough, dart/textDocumentContent, and DTD connection are still stubbed.