### PR TITLE
[analytics] improve initialization timing

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
@@ -145,6 +145,8 @@ private object AnalyticsConfigurationManager {
   private const val INITIALIZATION_TIMEOUT_IN_MS: Long = 700
   lateinit var data: AnalyticsConfiguration
   private val initLatch = CountDownLatch(1)
+  
+  @Volatile
   private var isInitializing = false
 
   fun getConfiguration(sdk: DartSdk, project: Project, logger: Logger): AnalyticsConfiguration {
@@ -153,8 +155,15 @@ private object AnalyticsConfigurationManager {
     if (::data.isInitialized && initLatch.count == 0L) return data
 
     // TODO (pq): capture timing info and report (if analytics are enabled)
-    if (!isInitializing) {
-      isInitializing = true
+    var shouldInitialize = false
+    synchronized(this) {
+      if (!isInitializing) {
+        isInitializing = true
+        shouldInitialize = true
+      }
+    }
+
+    if (shouldInitialize) {
       data = AnalyticsConfiguration()
 
       // Return a default configuration (that suppresses analytics) when running tests.


### PR DESCRIPTION
This addresses some initializing timing issues and adds some thread synchronization logic. (The latter was pointed out by Gemini -- interestingly, I don't think this is a practical issue today but it could definitely become one if we shard DAS access, and with it initialization, across more threads so I think the change is sound.)

The concern about blocking the EDT is a good one and I'm aware of it.  I'm not sure if there's an easy way around it but will continue to explore. I bet we can make this better but I take this to be a good step forward.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
