### PR TITLE
[fix] async `killProcess` execution

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
@@ -19,7 +19,6 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.EventDispatcher
 import com.intellij.util.io.BaseOutputReader
 import com.jetbrains.lang.dart.analytics.Analytics
-import com.jetbrains.lang.dart.analytics.AnalyticsConfiguration
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonConsumer
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonListener
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonRequestHandler
@@ -142,7 +141,11 @@ class DTDProcess {
 
   fun terminate() {
     if (::osProcessHandler.isInitialized && !osProcessHandler.isProcessTerminated) {
-      osProcessHandler.killProcess()
+      ApplicationManager.getApplication().executeOnPooledThread {
+        if (!osProcessHandler.isProcessTerminated) {
+          osProcessHandler.killProcess()
+        }
+      }
     }
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessListener
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -57,7 +58,11 @@ class DartDevToolsService(private val myProject: Project) : Disposable {
 
   override fun dispose() {
     if (::processHandler.isInitialized && !processHandler.isProcessTerminated) {
-      processHandler.killProcess()
+      ApplicationManager.getApplication().executeOnPooledThread {
+        if (!processHandler.isProcessTerminated) {
+          processHandler.destroyProcess()
+        }
+      }
     }
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -241,7 +241,11 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
 
   override fun dispose() {
     if (::dtdProcessHandler.isInitialized && !dtdProcessHandler.isProcessTerminated) {
-      dtdProcessHandler.killProcess()
+      ApplicationManager.getApplication().executeOnPooledThread {
+        if (!dtdProcessHandler.isProcessTerminated) {
+          dtdProcessHandler.killProcess()
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Terminating the OS-level process tree via `killProcess()` can be slow. Since this has been happening on the EDT, some users have noticed UI freezing. The fix here is pretty simple, offloading `killProcess()` calls to IDEA's background thread pool.

Fixes: https://github.com/flutter/dart-intellij-third-party/issues/285 (and cleans up other calls too)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
