### PR TITLE
Set environment values for analytics logging in DAS

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartPluginId.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartPluginId.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 package com.jetbrains.lang.dart;
 
 import com.intellij.openapi.extensions.PluginId;

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
@@ -56,14 +56,19 @@ private object UnifiedAnalytics {
 
   /** Environment variables used by the unified analytics package. */
   object Env {
+    // For more context on these environment variables, see https://github.com/Dart-Code/Dart-Code/issues/5561.
+    // Environment variable used to specify the IDE name, e.g. IntelliJ IDEA.
+    const val IDE_NAME = "DASH__IDE_NAME"
+    // Environment variable used to specify the IDE platform version.
+    const val IDE_VERSION = "DASH__IDE_VERSION"
+    // Environment variable used to specify the plugin name, e.g. Dart.
+    const val PLUGIN_NAME = "DASH__PLUGIN_NAME"
+    // Environment variable used to specify the plugin version.
+    const val PLUGIN_VERSION = "DASH__PLUGIN_VERSION"
     // Environment variable used to suppress analytics.
     const val SUPPRESS_ANALYTICS = "DASH__SUPPRESS_ANALYTICS"
     // Environment variable used to specify the top-level tool.
     const val TOOL = "DASH__TOOL"
-    const val IDE_NAME = "DASH__IDE_NAME"
-    const val IDE_VERSION = "DASH__IDE_VERSION"
-    const val PLUGIN_NAME = "DASH__PLUGIN_NAME"
-    const val PLUGIN_VERSION = "DASH__PLUGIN_VERSION"
   }
 
   private val logger: Logger =


### PR DESCRIPTION
Addresses https://github.com/flutter/dart-intellij-third-party/issues/288

Example values logged:

```
2026-03-26 11:34:12 com.jetbrains.lang.dart.analytics.Analytics [INFO   ] DASH environment updated:  
2026-03-26 11:34:12 com.jetbrains.lang.dart.analytics.Analytics [INFO   ]   DASH__IDE_NAME=IntelliJ IDEA  
2026-03-26 11:34:12 com.jetbrains.lang.dart.analytics.Analytics [INFO   ]   DASH__IDE_VERSION=2025.3.1.1  
2026-03-26 11:34:12 com.jetbrains.lang.dart.analytics.Analytics [INFO   ]   DASH__PLUGIN_NAME=Dart  
2026-03-26 11:34:12 com.jetbrains.lang.dart.analytics.Analytics [INFO   ]   DASH__PLUGIN_VERSION=503.0.0  
```

Are there any consequences if we report these values from the Flutter plugin as well? I suppose since the Dart plugin starts services like DTD and analysis server, the analysis server will be reporting those, and the Flutter plugin values will probably be ignored most of the time?