### PR TITLE
[build] fix non-dev plugin version setting

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -37,19 +37,13 @@ repositories {
 intellijPlatform {
     pluginConfiguration {
         if (project.hasProperty("dev")) {
-            var pluginVersion: String?
             val latestVersion = changelog.getLatest().version
-            val majorVersion = latestVersion.substringBefore('.').toInt()
-            val nextMajorVersion = majorVersion + 1
+            val nextMajorVersion = latestVersion.substringBefore('.').toInt() + 1
             val datestamp = DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now())
-            pluginVersion = "$nextMajorVersion.0.0-dev.$datestamp"
+            val baseVersion = "$nextMajorVersion.0.0-dev.$datestamp"
 
             val commitHash = System.getenv("KOKORO_GIT_COMMIT")
-            if (commitHash is String) {
-                val shortCommitHash = commitHash.take(7)
-                pluginVersion = "$pluginVersion-$shortCommitHash"
-            }
-            version = pluginVersion
+            version = if (commitHash != null) "$baseVersion-${commitHash.take(7)}" else baseVersion
         } else {
             version = providers.gradleProperty("pluginVersion")
         }


### PR DESCRIPTION
Fixes borked version setting for non-dev builds.

```
☁  third_party [build_fixProdVersion] ⚡  ./gradlew buildPlugin -Pdev
Calculating task graph as configuration cache cannot be reused because the set of Gradle properties has changed: 'dev' was added.

> Configure project :
plugin version: 504.0.0-dev.20260331
ideaVersion: 251 to 261.*
DART_HOME environment variable is not set. Dart Analysis Server tests will fail.
Following 1 plugins could not be created: plugins/fullLine/lib/modules/intellij.fullLine.yaml.jar

BUILD SUCCESSFUL in 4s
15 actionable tasks: 8 executed, 3 from cache, 4 up-to-date
Configuration cache entry stored.

☁  third_party [build_fixProdVersion] ⚡  ./gradlew buildPlugin      
Calculating task graph as configuration cache cannot be reused because the set of Gradle properties has changed: 'dev' was removed.

> Configure project :
plugin version: 503.0.0
ideaVersion: 251 to 261.*
DART_HOME environment variable is not set. Dart Analysis Server tests will fail.
Following 1 plugins could not be created: plugins/fullLine/lib/modules/intellij.fullLine.yaml.jar

BUILD SUCCESSFUL in 4s
15 actionable tasks: 8 executed, 3 from cache, 4 up-to-date
Configuration cache entry stored.

```


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
