### PR TITLE
[build] de-noise output: defer `DART_HOME` check until test execution

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -137,6 +137,7 @@ tasks {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
     }
     test {
+        var showDartHomeWarning = false
         val dartSdkPath = System.getenv("DART_HOME")
         if (dartSdkPath != null) {
             val versionFile = file("${dartSdkPath}/version")
@@ -149,7 +150,13 @@ tasks {
                 )
             }
         } else {
-            logger.error("DART_HOME environment variable is not set. Dart Analysis Server tests will fail.")
+            showDartHomeWarning = true
+        }
+
+        doFirst {
+            if (showDartHomeWarning) {
+                logger.error("DART_HOME environment variable is not set. Dart Analysis Server tests will fail.")
+            }
         }
     }
 }


### PR DESCRIPTION
The `DART_HOME` check was happening eagerly during the configuration step which produces a spam warning when building the plugin. This fixes that.


### Warning for Tests
```
☁  third_party [main] ⚡  ./gradlew :test --tests "com.jetbrains.dart.analysisServer.*"
Calculating task graph as no cached configuration is available for tasks: :test --tests com.jetbrains.dart.analysisServer.*

> Configure project :
plugin version: valueof(GradlePropertyValueSource)
ideaVersion: extension 'ideaVersion'
Following 1 plugins could not be created: plugins/fullLine/lib/modules/intellij.fullLine.yaml.jar

> Task :compileTestJava
Note: /Users/pquitslund/src/repos/dart-intellij-third-party/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerHighlightingTest.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /Users/pquitslund/src/repos/dart-intellij-third-party/third_party/src/test/java/com/jetbrains/lang/dart/highlighting/DartHighlightingTest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :test
DART_HOME environment variable is not set. Dart Analysis Server tests will fail.
```

### Not for Buiilds

```
☁  third_party [build_fixProdVersion] ⚡  ./gradlew buildPlugin -Pdev
Calculating task graph as configuration cache cannot be reused because the set of Gradle properties has changed: 'dev' was added.

> Configure project :
plugin version: 504.0.0-dev.20260331
ideaVersion: extension 'ideaVersion'
Following 1 plugins could not be created: plugins/fullLine/lib/modules/intellij.fullLine.yaml.jar

BUILD SUCCESSFUL in 5s
15 actionable tasks: 8 executed, 3 from cache, 4 up-to-date
Configuration cache entry stored.
```


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
