### PR TITLE
[build] [kokoro] fix gradlew path

### DIFF
--- a/third_party/tool/kokoro/setup.sh
+++ b/third_party/tool/kokoro/setup.sh
@@ -9,5 +9,5 @@ setup() {
   # Enable verbose output for Gradle
   export JAVA_OPTS=" -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
 
-  ./gradlew --version
+  ./third_party/gradlew --version
 }


### PR DESCRIPTION
Path fix for kokoro failure:

``` ./third_party/tool/kokoro/setup.sh: line 12: ./gradlew: No such file or directory```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
