### PR TITLE
[build] kokoro deploy script fixes

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -187,6 +187,6 @@ tasks.register("printCompileClasspath") {
 
 tasks.register("printVersion") {
     doLast {
-        println(version)
+        println(intellijPlatform.pluginConfiguration.version.get())
     }
 }

--- a/third_party/tool/kokoro/deploy.sh
+++ b/third_party/tool/kokoro/deploy.sh
@@ -8,7 +8,6 @@ echo "kokoro build start"
 cd third_party
 
 VERSION=$(./gradlew -q printVersion -Pdev --no-configuration-cache | tail -n 1)
-echo "version: $VERSION"
 
 ./gradlew buildPlugin -Pdev
 

--- a/third_party/tool/kokoro/deploy.sh
+++ b/third_party/tool/kokoro/deploy.sh
@@ -35,7 +35,7 @@ echo "Uploading $ZIP_FILE to JetBrains Marketplace..."
 curl -i \
   --header "Authorization: Bearer $TOKEN" \
   -F pluginId=6351 \
-  -F file=@$ZIP_FILE \
+  -F file=@"$ZIP_FILE" \
   -F channel=dev \
   https://plugins.jetbrains.com/plugin/uploadPlugin
 

--- a/third_party/tool/kokoro/deploy.sh
+++ b/third_party/tool/kokoro/deploy.sh
@@ -7,7 +7,9 @@ echo "kokoro build start"
 
 cd third_party
 
-VERSION=$(./gradlew -q printVersion --no-configuration-cache)
+VERSION=$(./gradlew -q printVersion -Pdev --no-configuration-cache | tail -n 1)
+echo "version: $VERSION"
+
 ./gradlew buildPlugin -Pdev
 
 echo "kokoro build finished"
@@ -24,7 +26,7 @@ if [ ! -f "$KOKORO_TOKEN_FILE" ]; then
 fi
 TOKEN=$(cat "$KOKORO_TOKEN_FILE")
 
-ZIP_FILE="build/distributions/Dart-$VERSION.zip"
+ZIP_FILE="build/distributions/Dart.zip"
 if [ ! -f "$ZIP_FILE" ]; then
   echo "Error: Zip file not found at $ZIP_FILE"
   exit 1

--- a/third_party/tool/kokoro/deploy.sh
+++ b/third_party/tool/kokoro/deploy.sh
@@ -36,6 +36,7 @@ curl -i \
   --header "Authorization: Bearer $TOKEN" \
   -F pluginId=6351 \
   -F file=@$ZIP_FILE \
+  -F channel=dev \
   https://plugins.jetbrains.com/plugin/uploadPlugin
 
 echo "kokoro deploy finished"

--- a/third_party/tool/kokoro/deploy.sh
+++ b/third_party/tool/kokoro/deploy.sh
@@ -7,7 +7,7 @@ echo "kokoro build start"
 
 cd third_party
 
-VERSION=$(./gradlew -q printVersion)
+VERSION=$(./gradlew -q printVersion --no-configuration-cache)
 ./gradlew buildPlugin -Pdev
 
 echo "kokoro build finished"


### PR DESCRIPTION
A host of deploy script fixes.

1. disabled config caching for `printVersion`: Turns out you can't reference script variables directly in a task action as it causes the task to capture non-serializable script references, breaking configuration cache requirements. In this case the fix is easy since we can safely disable the config cache for the run of `printVersion`.
2. fixed `ZIP` file: Updated the artifact path in `deploy.sh` to expect `Dart.zip` instead of `Dart-$VERSION.zip` to match the IntelliJ platform plugin naming convention.
3. fixed `printVersion` version string: Added the `-Pdev` flag to the call to `printVersion` so we get the right dev version, and used `tail -n 1` to extract only the clean version string from the output.
4. fixed `version` property source: Switched from printing the unset project-level `version` to `intellijPlatform.pluginConfiguration.version.get()`, which is where the plugin's _actual_ version is stored.
5. added miss `dev` flag to upload: Not sure how this got missed. Also to be safe I wrapped the `ZIP_FILE` reference in the `curl` call with quotes to be identical with the Flutter plugin.

This should complete #247.

### Sample run:

```
☁  dart-intellij-third-party [build_fixConfigCache] ⚡  ./third_party/tool/kokoro/deploy.sh
openjdk 23.0.2 2025-01-21
OpenJDK Runtime Environment Zulu23.32+11-CA (build 23.0.2+7)
OpenJDK 64-Bit Server VM Zulu23.32+11-CA (build 23.0.2+7, mixed mode, sharing)

------------------------------------------------------------
Gradle 8.13
------------------------------------------------------------

Build time:    2025-02-25 09:22:14 UTC
Revision:      073314332697ba45c16c0a0ce1891fa6794179ff

Kotlin:        2.0.21
Groovy:        3.0.22
Ant:           Apache Ant(TM) version 1.10.15 compiled on August 25 2024
Launcher JVM:  23.0.2 (Azul Systems, Inc. 23.0.2+7)
Daemon JVM:    /Library/Java/JavaVirtualMachines/zulu-23.jdk/Contents/Home (no JDK specified, using current Java home)
OS:            Mac OS X 26.4 aarch64

kokoro build start
version: 505.0.0-dev.20260405
Calculating task graph as configuration cache cannot be reused because a build logic input of type 'JavaRuntimeMetadataValueSource' has changed.

> Configure project :
plugin version: 505.0.0-dev.20260405
ideaVersion: 251 to 261.*
Following 1 plugins could not be created: plugins/fullLine/lib/modules/intellij.fullLine.yaml.jar

BUILD SUCCESSFUL in 3s
15 actionable tasks: 1 executed, 14 up-to-date
Configuration cache entry stored.
kokoro build finished
kokoro deploy start
Uploading build/distributions/Dart.zip to JetBrains Marketplace...
kokoro deploy finished
```


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
