### PR TITLE
[infra] add `runTarget`

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -25,6 +25,9 @@ plugins {
     id("org.jetbrains.kotlinx.kover") version "0.9.4" // Kover Code Coverage Plugin
 }
 
+// Read ideaVersion from gradle.properties
+val ideaVersion = providers.gradleProperty("ideaVersion").get()
+
 // Configure project's dependencies
 repositories {
     mavenCentral()
@@ -111,7 +114,7 @@ dependencies {
     intellijPlatform {
         // intellijIdea can be found here:
         // https://www.jetbrains.com/idea/download/other.html
-        intellijIdea("2025.3.1.1")
+        intellijIdea(ideaVersion)
 
         testFramework(TestFrameworkType.Platform)
 
@@ -131,6 +134,66 @@ dependencies {
     implementation(fileTree("lib") { include("*.jar") })
 
     testImplementation("junit:junit:4.13.2")
+}
+
+intellijPlatformTesting {
+  runIde {
+    register("runTarget") {
+      val ideTarget = project.findProperty("ide") as? String
+      val ideV = project.findProperty("ideV") as? String
+      val idePath = project.findProperty("idePath") as? String
+      
+      if (idePath != null) {
+        localPath = file(idePath)
+      } else {
+        val actualTarget = ideTarget ?: "IntelliJ"
+        type = when (actualTarget) {
+          "IntelliJ" -> IntelliJPlatformType.IntellijIdeaCommunity
+          "Ultimate" -> IntelliJPlatformType.IntellijIdeaUltimate
+          "AndroidStudio" -> IntelliJPlatformType.AndroidStudio
+          else -> IntelliJPlatformType.IntellijIdeaCommunity
+        }
+        val fallbackVersion = if (actualTarget == "IntelliJ") "2024.2" else ideaVersion
+        this.version = ideV ?: fallbackVersion
+      }
+    }
+  }
+}
+
+tasks.named("runTarget") {
+  val ideTarget = project.findProperty("ide") as? String
+  val ideV = project.findProperty("ideV") as? String
+  val idePath = project.findProperty("idePath") as? String
+  
+  doFirst {
+    if (ideTarget == null && ideV == null && idePath == null) {
+      println("============================================================")
+      println("runTarget - Available Options")
+      println("============================================================")
+      println("Valid values for -Pide:")
+      println(" - IntelliJ (default, IntelliJ IDEA Community)")
+      println(" - Ultimate (IntelliJ IDEA Ultimate)")
+      println(" - AndroidStudio")
+      println()
+      println("Valid values for -PideV:")
+      println(" - Any valid version string for the selected IDE.")
+      println(" - Examples for IntelliJ/Ultimate: 2024.1, 2024.2, 2024.3, 2025.1")
+      println(" - Run './gradlew printProductsReleases' to see the full list.")
+      println()
+      println("Valid values for -PidePath:")
+      println(" - Path to a local installation of the IDE (e.g., Android Studio).")
+      println(" - Use this if Gradle resolution fails for Android Studio.")
+      println()
+      println("Examples:")
+      println(" ./gradlew runTarget -Pide=IntelliJ -PideV=2025.1")
+      println(" ./gradlew runTarget -Pide=Ultimate -PideV=2025.1")
+      println(" ./gradlew runTarget -PidePath=/Applications/Android\\ Studio.app")
+      println("============================================================")
+      println("Stopping execution. Please run with parameters to launch a specific IDE.")
+      
+      throw org.gradle.api.tasks.StopExecutionException()
+    }
+  }
 }
 
 tasks {
@@ -165,11 +228,16 @@ tasks {
 // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-faq.html#how-to-check-the-latest-available-eap-release
 tasks {
     printProductsReleases {
-        channels = listOf(ProductRelease.Channel.EAP)
-        types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
+        channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
+        types = listOf(IntelliJPlatformType.IntellijIdeaCommunity, IntelliJPlatformType.IntellijIdeaUltimate, IntelliJPlatformType.AndroidStudio)
         untilBuild = provider { null }
         doLast {
-            productsReleases.get().max()
+            println()
+            println("Mapping printProductsReleases output to ideV:")
+            println(" - The prefix (e.g., IU-, IC-, AI-) maps to -Pide (Ultimate, IntelliJ, AndroidStudio).")
+            println(" - The number part (e.g., 261.23567.71) maps to -PideV.")
+            println(" - Example: AI-2025.3.3.6 -> -Pide=AndroidStudio -PideV=2025.3.3.6")
+            println()
         }
     }
 }

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -153,6 +153,7 @@ intellijPlatformTesting {
           "AndroidStudio" -> IntelliJPlatformType.AndroidStudio
           else -> IntelliJPlatformType.IntellijIdeaCommunity
         }
+        // Fallback to 2024.2 for IntelliJ Community because 2025.3+ has publication changes that cause resolution errors.
         val fallbackVersion = if (actualTarget == "IntelliJ") "2024.2" else ideaVersion
         this.version = ideV ?: fallbackVersion
       }

--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -18,6 +18,8 @@ pluginVersion = 504.0.0
 pluginSinceBuild = 251
 pluginUntilBuild = 261.*
 
+ideaVersion = 2025.3.1.1
+
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 9.3.0
 


### PR DESCRIPTION
Adds a parameterized `runTarget` Gradle task letting us run and test the plugin against multiple IDE targets (IntelliJ IDEA Community, Ultimate, and Android Studio) without changing the primary compilation classpath.

This is modeled after the approach taken in `flutter-intellij` PR [#8910](https://github.com/flutter/flutter-intellij/pull/8910) with a few tweaks.

### Key Bits

-   **Centralized IDE Version**: Extracts the hardcoded IDE version to `gradle.properties` as `ideaVersion`.
-   **Parameterized `runTarget` Task**: Registered a custom `runTarget` task using the `intellijPlatformTesting` extension that accepts `-Pide` and `-PideV` parameters.
-   **Self-Documenting CLI**: Running `./gradlew runTarget` without parameters displays usage instructions and stops execution.
-   **Enhanced `printProductsReleases`**: Updates the task to include Android Studio releases and provided instructions for mapping the output to task parameters.

### Differences from `flutter-intellij/pull/8910`

-   **Fallback Version Adjustment**: For the default fallback (when no parameters are provided), we use IntelliJ Community `"2024.2"` instead of the project's compilation target `"2025.3.1.1"`. This avoids resolution errors caused by JetBrains changing the publication structure for Community editions starting with version 2025.3. (Note this is just for printing the help docs and not for actually running anything.)
-   **Local IDE Path Support (`-PidePath`)**: We added a new parameter `-PidePath` to allow running against a local IDE installation (e.g., `./gradlew runTarget -PidePath=/Applications/Android\ Studio.app`). This was added to bypass brittle automated resolution issues specifically associated with Android Studio releases in the new Gradle plugin.


Fixes: https://github.com/flutter/dart-intellij-third-party/issues/316


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
