### PR TITLE
[infra] build against community

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -112,9 +112,7 @@ java {
 
 dependencies {
     intellijPlatform {
-        // intellijIdea can be found here:
-        // https://www.jetbrains.com/idea/download/other.html
-        intellijIdea(ideaVersion)
+        intellijIdeaCommunity(ideaVersion)
 
         testFramework(TestFrameworkType.Platform)
 


### PR DESCRIPTION
Work towards: #311 

The dev channel build is failing with a timeout downloading ultimate. Community is smaller:

<img width="263" height="108" alt="image" src="https://github.com/user-attachments/assets/419a458f-9da4-4032-957c-60339bbabca5" />

(But still big 😬.)


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
