### PR TITLE
[maintenance] add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,3 @@
-# See Dependabot documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# See Dependabot documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "autosubmit"
+    # Updating patch versions for "github-actions" is too chatty.
+    # See https://github.com/flutter/flutter/issues/158350.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
+  - package-ecosystem: "gradle"
+    directory: "/third_party"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "autosubmit"

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -198,9 +198,7 @@ tasks.named("runTarget") {
 }
 
 tasks {
-    wrapper {
-        gradleVersion = providers.gradleProperty("gradleVersion").get()
-    }
+
     test {
         var showDartHomeWarning = false
         val dartSdkPath = System.getenv("DART_HOME")

--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -20,9 +20,6 @@ pluginUntilBuild = 261.*
 
 ideaVersion = 2025.1.7
 
-# Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 9.3.0
-
 javaVersion = 21
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib


### PR DESCRIPTION
#### Changes:
*   **Dependabot Configuration**: Adds `.github/dependabot.yml` to check for updates to GitHub Actions (root directory) and Gradle dependencies/plugins (in the `third_party` directory, where the actual Gradle project resides).
*   **Gradle Wrapper Management**: Removes the custom `gradleVersion` property from `gradle.properties` and the corresponding override in `build.gradle.kts`. This allows Dependabot to manage the Gradle wrapper version directly in `gradle-wrapper.properties` without causing out-of-sync states.

#### Verification:
*   Verified that the project still builds successfully with `./gradlew build` after these changes.



Fixes: #335 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
