### PR TITLE
[maintenance] centralize gradle deps in libs.versions

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -18,11 +18,11 @@ allprojects {
 
 // Plugins - must be first
 plugins {
-    id("java") // Java support
-    id("org.jetbrains.kotlin.jvm") version "2.2.21" // Kotlin support
-    id("org.jetbrains.intellij.platform") version "2.10.5" // IntelliJ Platform Gradle Plugin
-    id("org.jetbrains.changelog") version "2.2.0" // Gradle Changelog Plugin
-    id("org.jetbrains.kotlinx.kover") version "0.9.4" // Kover Code Coverage Plugin
+    id("java")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.intellij.platform)
+    alias(libs.plugins.changelog)
+    alias(libs.plugins.kover)
 }
 
 // Read ideaVersion from gradle.properties
@@ -133,7 +133,7 @@ dependencies {
 
     implementation(fileTree("lib") { include("*.jar") })
 
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.junit)
 }
 
 intellijPlatformTesting {

--- a/third_party/gradle/libs.versions.toml
+++ b/third_party/gradle/libs.versions.toml
@@ -4,7 +4,17 @@
 [versions]
 guava = "33.3.1-jre"
 junit = "4.13.2"
+kotlin = "2.2.21"
+intellijPlatform = "2.10.5"
+changelog = "2.2.0"
+kover = "0.9.4"
 
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit = { module = "junit:junit", version.ref = "junit" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+intellij-platform = { id = "org.jetbrains.intellij.platform", version.ref = "intellijPlatform" }
+changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
Introduces Gradle Version Catalog for dependency management.

#### Changes:
*   **Gradle Version Catalog**: Updates `third_party/gradle/libs.versions.toml` to manage versions for Kotlin, IntelliJ Platform plugin, Changelog plugin, Kover, and JUnit.
*   **Build Script Updates**: Refactors `third_party/build.gradle.kts` to use type-safe accessors from the version catalog for plugins and dependencies.

#### Verification:
*   Verified that the project still builds successfully with `./gradlew build` after these changes.


Fixes: #334 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
