### PR TITLE
Reduce logging of location changes

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartActiveLocationChangeHandler.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartActiveLocationChangeHandler.kt
@@ -67,7 +67,7 @@ internal class DartActiveLocationChangeHandler(private val dtdService: DartTooli
     val activeLocationNull = paramsObject.getAsJsonObject("eventData")?.getAsJsonObject("textDocument") == null
     if (!activeLocationNull || !activeLocationNullSent) {
       activeLocationNullSent = activeLocationNull
-      logger.info("Sending active location change event: $paramsObject")
+      logger.debug("Sending active location change event: $paramsObject")
       dtdService.sendRequest("postEvent", paramsObject, false) { }
     }
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartActiveLocationChangeHandler.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartActiveLocationChangeHandler.kt
@@ -67,7 +67,6 @@ internal class DartActiveLocationChangeHandler(private val dtdService: DartTooli
     val activeLocationNull = paramsObject.getAsJsonObject("eventData")?.getAsJsonObject("textDocument") == null
     if (!activeLocationNull || !activeLocationNullSent) {
       activeLocationNullSent = activeLocationNull
-      logger.debug("Sending active location change event: $paramsObject")
       dtdService.sendRequest("postEvent", paramsObject, false) { }
     }
   }


### PR DESCRIPTION
This file sends a request to DTD anytime the cursor location changes, so it makes our log much too noisy. DTD requests are already logged as debug messages anyway.