### PR TITLE
[build] downgrade kotlin to be compatible w/`ideaVersion`

### DIFF
--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -18,7 +18,7 @@ pluginVersion = 504.0.0
 pluginSinceBuild = 251
 pluginUntilBuild = 261.*
 
-# Bumping to 2025.2.6.1 will require significant changes: https://github.com/flutter/dart-intellij-third-party/issues/352
+# Tracking issue for changes required to bumpt to 2025.2.6.1: https://github.com/flutter/dart-intellij-third-party/issues/352
 ideaVersion = 2025.1.7
 
 javaVersion = 21

--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -18,6 +18,7 @@ pluginVersion = 504.0.0
 pluginSinceBuild = 251
 pluginUntilBuild = 261.*
 
+# Bumping to 2025.2.6.1 will require significant changes: https://github.com/flutter/dart-intellij-third-party/issues/352
 ideaVersion = 2025.1.7
 
 javaVersion = 21

--- a/third_party/gradle/libs.versions.toml
+++ b/third_party/gradle/libs.versions.toml
@@ -4,7 +4,9 @@
 [versions]
 guava = "33.6.0-jre"
 junit = "4.13.2"
-kotlin = "2.3.21"
+# Bumping to 2.3.21 is blocked on an `ideaVersion` update: 
+# https://github.com/flutter/dart-intellij-third-party/issues/352
+kotlin = "2.2.21"
 intellijPlatform = "2.10.5"
 changelog = "2.5.0"
 kover = "0.9.8"


### PR DESCRIPTION
### Downgrade Kotlin to Restore Compatibility with IntelliJ 2025.1.7

To fix `runIde` which is borked and avoid compilation errors and configuration cache issues encountered when running with newer versions, this commit downgrades Kotlin.

We want to get to a new `ideaVersion` but that'll be a bit of work (see: #352).

#### Changes:
*   **`libs.versions.toml`**: Downgraded Kotlin from `2.3.21` back to `2.2.21`. Added a comment noting that bumping to `2.3.21` is blocked on an `ideaVersion` update.
*   **`gradle.properties`**: Kept `ideaVersion` at `2025.1.7` (and added a comment noting that bumping to `2025.2.6.1` will require significant refactoring).

Note that this essentially reverts #343.



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
