### PR TITLE
Add timing for assists and fixes

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/assists/DartQuickAssistSet.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/assists/DartQuickAssistSet.java
@@ -42,13 +42,13 @@ public class DartQuickAssistSet {
       return lastSourceChanges;
     }
 
-    long startTime = System.currentTimeMillis();
+    long startTime = System.nanoTime();
 
     final DartAnalysisServerService service = DartAnalysisServerService.getInstance(psiFile.getProject());
     service.updateFilesContent();
     lastSourceChanges = service.edit_getAssists(psiFile.getVirtualFile(), offset, length);
 
-    long durationMs = System.currentTimeMillis() - startTime;
+    long durationMs = (System.nanoTime() - startTime) / 1_000_000;
 
     AssistData assistData = AnalyticsData.forAssist("dart.legacy_assist", psiFile.getProject());
     assistData.add(AnalyticsConstants.DURATION_MS, (int) durationMs);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/assists/DartQuickAssistSet.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/assists/DartQuickAssistSet.java
@@ -6,6 +6,10 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiFile;
+import com.jetbrains.lang.dart.analytics.Analytics;
+import com.jetbrains.lang.dart.analytics.AnalyticsConstants;
+import com.jetbrains.lang.dart.analytics.AnalyticsData;
+import com.jetbrains.lang.dart.analytics.AssistData;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import org.dartlang.analysis.server.protocol.SourceChange;
 import org.jetbrains.annotations.NotNull;
@@ -14,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DartQuickAssistSet {
+
   private List<SourceChange> lastSourceChanges = new ArrayList<>();
   private long lastPsiModificationCount;
   private String lastFilePath;
@@ -37,9 +42,17 @@ public class DartQuickAssistSet {
       return lastSourceChanges;
     }
 
+    long startTime = System.currentTimeMillis();
+
     final DartAnalysisServerService service = DartAnalysisServerService.getInstance(psiFile.getProject());
     service.updateFilesContent();
     lastSourceChanges = service.edit_getAssists(psiFile.getVirtualFile(), offset, length);
+
+    long durationMs = System.currentTimeMillis() - startTime;
+
+    AssistData assistData = AnalyticsData.forAssist("dart.legacy_assist", psiFile.getProject());
+    assistData.add(AnalyticsConstants.DURATION_MS, (int) durationMs);
+    Analytics.report(assistData);
 
     lastFilePath = filePath;
     lastOffset = offset;

--- a/third_party/src/main/java/com/jetbrains/lang/dart/fixes/DartQuickFixSet.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/fixes/DartQuickFixSet.java
@@ -76,10 +76,10 @@ public class DartQuickFixSet {
       fix.setSourceChange(null);
     }
 
-    long startTime = System.currentTimeMillis();
+    long startTime = System.nanoTime();
 
     final Consumer<List<AnalysisErrorFixes>> consumer = fixes -> {
-      long durationMs = System.currentTimeMillis() - startTime;
+      long durationMs = (System.nanoTime() - startTime) / 1_000_000;
 
       FixData fixData = AnalyticsData.forFix("dart.legacy_fix", myPsiManager.getProject());
       fixData.add(AnalyticsConstants.DURATION_MS, (int) durationMs);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/fixes/DartQuickFixSet.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/fixes/DartQuickFixSet.java
@@ -6,6 +6,10 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.PsiManager;
 import com.intellij.util.Consumer;
+import com.jetbrains.lang.dart.analytics.Analytics;
+import com.jetbrains.lang.dart.analytics.AnalyticsConstants;
+import com.jetbrains.lang.dart.analytics.AnalyticsData;
+import com.jetbrains.lang.dart.analytics.FixData;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.annotator.DartProblemGroup;
 import com.jetbrains.lang.dart.sdk.DartSdk;
@@ -20,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class DartQuickFixSet {
+
   private static final String MIN_SDK_VERSION_WITH_IGNORE_FIXES = "2.14";
   private static final String DART_FIX_IGNORE_PREFIX = "dart.fix.ignore";
   private static final int MAX_QUICK_FIXES = 5;
@@ -71,7 +76,15 @@ public class DartQuickFixSet {
       fix.setSourceChange(null);
     }
 
+    long startTime = System.currentTimeMillis();
+
     final Consumer<List<AnalysisErrorFixes>> consumer = fixes -> {
+      long durationMs = System.currentTimeMillis() - startTime;
+
+      FixData fixData = AnalyticsData.forFix("dart.legacy_fix", myPsiManager.getProject());
+      fixData.add(AnalyticsConstants.DURATION_MS, (int) durationMs);
+      Analytics.report(fixData);
+
       final long psiModCountWhenReceivedFixes = myPsiManager.getModificationTracker().getModificationCount();
       final long vfsModCountWhenReceivedFixes = VirtualFileManager.getInstance().getModificationCount();
 


### PR DESCRIPTION
Similar to https://github.com/flutter/dart-intellij-third-party/issues/289, we want to track how long legacy assists and fixes are taking end-to-end, so we have a benchmark for post-LSP migration.