### PR TITLE
Filter out workspace/applyEdit messages in lsp4ij

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -96,7 +96,12 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             if (jsonObject.has("params")) {
                 val params = jsonObject.get("params").asJsonObject
                 if (params.has(LSP_MESSAGE_KEY)) {
-                    lspPayload = params.get(LSP_MESSAGE_KEY).asJsonObject
+                    val msgObj = params.get(LSP_MESSAGE_KEY).asJsonObject
+                    if (msgObj.has("method") && msgObj.get("method").asString == "workspace/applyEdit") {
+                        logger.debug("Ignored workspace/applyEdit message from DAS on main branch (handled by legacy bridge)")
+                    } else {
+                        lspPayload = msgObj
+                    }
                 }
             }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -90,30 +90,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
             logger.debug("Response received from DAS: $response")
             val jsonObject = JsonParser.parseString(response).asJsonObject
-
-            var lspPayload: JsonObject? = null
-
-            if (jsonObject.has("params")) {
-                val params = jsonObject.get("params").asJsonObject
-                if (params.has(LSP_MESSAGE_KEY)) {
-                    val msgObj = params.get(LSP_MESSAGE_KEY).asJsonObject
-                    if (msgObj.has("method") && msgObj.get("method").asString == "workspace/applyEdit") {
-                        logger.debug("Ignored workspace/applyEdit message from DAS on main branch (handled by legacy bridge)")
-                    } else {
-                        lspPayload = msgObj
-                    }
-                }
-            }
-
-            if (lspPayload == null && jsonObject.has("result")) {
-                val topLevelId = if (jsonObject.has("id")) jsonObject.get("id").asString else null
-                if (topLevelId != null && pendingLegacyIds.remove(topLevelId)) {
-                    val result = jsonObject.get("result").asJsonObject
-                    if (result.has(LSP_RESPONSE_KEY)) {
-                        lspPayload = result.get(LSP_RESPONSE_KEY).asJsonObject
-                    }
-                }
-            }
+            val lspPayload = extractLspPayload(jsonObject)
 
             if (lspPayload != null) {
                 enqueueResponse(lspPayload.toString())
@@ -122,6 +99,32 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         this.responseListener = listener
         dartAnalysisService.addResponseListener(listener)
         logger.info("Finished setting up DAS listening for lsp4ij")
+    }
+
+    private fun extractLspPayload(jsonObject: JsonObject): JsonObject? {
+        if (jsonObject.has("params")) {
+            val params = jsonObject.get("params").asJsonObject
+            if (params.has(LSP_MESSAGE_KEY)) {
+                val msgObj = params.get(LSP_MESSAGE_KEY).asJsonObject
+                if (msgObj.getAsJsonPrimitive("method")?.asString == "workspace/applyEdit") {
+                    logger.debug("Ignored workspace/applyEdit message from DAS (handled by legacy bridge)")
+                    return null
+                }
+                return msgObj
+            }
+        }
+
+        if (jsonObject.has("result")) {
+            val topLevelId = if (jsonObject.has("id")) jsonObject.get("id").asString else null
+            if (topLevelId != null && pendingLegacyIds.remove(topLevelId)) {
+                val result = jsonObject.get("result").asJsonObject
+                if (result.has(LSP_RESPONSE_KEY)) {
+                    return result.get(LSP_RESPONSE_KEY).asJsonObject
+                }
+            }
+        }
+
+        return null
     }
 
     private fun processLspClientMessages() {


### PR DESCRIPTION
This was causing edits to be applied twice once lsp4ij is enabled, for instance while making changes in the property editor:

Initial state:
<img width="1085" height="610" alt="Screenshot 2026-05-15 at 8 21 38 AM" src="https://github.com/user-attachments/assets/ea35069c-ddf3-4c3c-b90f-d926365fd053" />

After edits applied:
<img width="1040" height="350" alt="Screenshot 2026-05-15 at 8 22 04 AM" src="https://github.com/user-attachments/assets/799947ce-9f9b-4b15-a1e7-abbb2d78bcb9" />

lsp4ij shows it applied `workspace/applyEdit` requests:
<img width="899" height="326" alt="Screenshot 2026-05-15 at 8 35 55 AM" src="https://github.com/user-attachments/assets/0d6c80f7-a635-4459-8d1f-6fcf6228ad33" />

To test this change, make sure that making changes in the property editor doesn't cause `workspace/applyEdit` requests to show up in the lsp4ij interface and the final code produced is reasonable.
