### PR TITLE
Handle cancelRequest from lsp4ij

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Fixed
 - Avoid AssertionErrors / UI crashes when navigating subclasses, superclasses, or overriding methods by migrating from deprecated `PsiElementListNavigator` to modern `PsiTargetNavigator`.
 - Avoid potential NullPointerExceptions in the indexer when recovering from malformed class declarations (#375)
+- Prevent duplicate application of `workspace/applyEdit` messages not from lsp4ij  (#409)
+- Forward cancelRequest for LSP-over-legacy requests (#410)
 
 ## 505.0.0
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -63,7 +63,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     // This stores IDs that have been used by lsp4ij for LSP-over-legacy requests to DAS.
     // There are non-lsp4ij requests that are sent as LSP-over-legacy, but we don't need to forward responses for those
     // requests to lsp4ij since lsp4ij was not the originator.
-    private val pendingLegacyIds = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+    private val pendingLegacyIds = java.util.concurrent.ConcurrentHashMap<String, String>()
     private var responseListener: ResponseListener? = null
     private var isStopping = false
     private var clientMessageFuture: java.util.concurrent.Future<*>? = null
@@ -116,7 +116,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
         if (jsonObject.has("result")) {
             val topLevelId = if (jsonObject.has("id")) jsonObject.get("id").asString else null
-            if (topLevelId != null && pendingLegacyIds.remove(topLevelId)) {
+            if (topLevelId != null && pendingLegacyIds.values.remove(topLevelId)) {
                 val result = jsonObject.get("result").asJsonObject
                 if (result.has(LSP_RESPONSE_KEY)) {
                     return result.get(LSP_RESPONSE_KEY).asJsonObject
@@ -169,6 +169,25 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     }
 
     private fun handleNotificationMessage(message: NotificationMessage) {
+        if (message.method == "$/cancelRequest") {
+            val cancelParamsObj = JSON_HANDLER.gson.toJsonTree(message.params).asJsonObject
+            val lspIdToCancel = if (cancelParamsObj.has("id")) cancelParamsObj.get("id").asString else null
+            if (lspIdToCancel != null) {
+                val legacyIdToCancel = pendingLegacyIds.remove(lspIdToCancel)
+                if (legacyIdToCancel != null) {
+                    logger.info("Forwarding $/cancelRequest for lspId=$lspIdToCancel as legacy server.cancelRequest for legacyId=$legacyIdToCancel")
+                    val cancelReqId = DartAnalysisServerService.getInstance(project).generateUniqueId()
+                    val cancelReq = JsonObject()
+                    cancelReq.addProperty("id", cancelReqId)
+                    cancelReq.addProperty("method", "server.cancelRequest")
+                    val paramsObj = JsonObject()
+                    paramsObj.addProperty("id", legacyIdToCancel)
+                    cancelReq.add("params", paramsObj)
+                    DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
+                }
+            }
+            return
+        }
         logger.info("Ignored unimplemented method from lsp4ij notification: ${message.method}")
     }
 
@@ -186,9 +205,11 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
 
     private fun forwardLspRequestToDas(message: RequestMessage, dartAnalysisService: DartAnalysisServerService) {
+        val rawId = message.id ?: return
+        val lspId = rawId.toString()
         val legacyRequest = JsonObject()
         val legacyId = dartAnalysisService.generateUniqueId()
-        pendingLegacyIds.add(legacyId)
+        pendingLegacyIds.put(lspId, legacyId)
         legacyRequest.addProperty("id", legacyId)
         legacyRequest.addProperty("method", "lsp.handle")
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -172,21 +172,19 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         if (message.method == "$/cancelRequest") {
             val cancelParamsObj = JSON_HANDLER.gson.toJsonTree(message.params).asJsonObject
             val lspIdToCancel = if (cancelParamsObj.has("id")) cancelParamsObj.get("id").asString else null
-            if (lspIdToCancel != null) {
-                val legacyIdToCancel = pendingLegacyIds.remove(lspIdToCancel)
-                if (legacyIdToCancel != null) {
-                    logger.info("Forwarding $/cancelRequest for lspId=$lspIdToCancel as legacy server.cancelRequest for legacyId=$legacyIdToCancel")
-                    val cancelReqId = DartAnalysisServerService.getInstance(project).generateUniqueId()
-                    val cancelReq = JsonObject()
-                    cancelReq.addProperty("id", cancelReqId)
-                    cancelReq.addProperty("method", "server.cancelRequest")
-                    val paramsObj = JsonObject()
-                    paramsObj.addProperty("id", legacyIdToCancel)
-                    cancelReq.add("params", paramsObj)
-                    DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
-                }
-            }
-            return
+            if (lspIdToCancel == null) return
+
+            val legacyIdToCancel = pendingLegacyIds.remove(lspIdToCancel) ?: return
+
+            logger.info("Forwarding $/cancelRequest for lspId=$lspIdToCancel as legacy server.cancelRequest for legacyId=$legacyIdToCancel")
+            val cancelReqId = DartAnalysisServerService.getInstance(project).generateUniqueId()
+            val cancelReq = JsonObject()
+            cancelReq.addProperty("id", cancelReqId)
+            cancelReq.addProperty("method", "server.cancelRequest")
+            val paramsObj = JsonObject()
+            paramsObj.addProperty("id", legacyIdToCancel)
+            cancelReq.add("params", paramsObj)
+            DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
         }
         logger.info("Ignored unimplemented method from lsp4ij notification: ${message.method}")
     }
@@ -209,7 +207,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         val lspId = rawId.toString()
         val legacyRequest = JsonObject()
         val legacyId = dartAnalysisService.generateUniqueId()
-        pendingLegacyIds.put(lspId, legacyId)
+        pendingLegacyIds[lspId] = legacyId
         legacyRequest.addProperty("id", legacyId)
         legacyRequest.addProperty("method", "lsp.handle")
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -170,7 +170,10 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
     private fun handleNotificationMessage(message: NotificationMessage) {
         if (message.method == "$/cancelRequest") {
-            val cancelParamsObj = JSON_HANDLER.gson.toJsonTree(message.params).asJsonObject
+            val params = message.params ?: return
+            val jsonElement = JSON_HANDLER.gson.toJsonTree(params)
+            if (!jsonElement.isJsonObject) return
+            val cancelParamsObj = jsonElement.asJsonObject
             val lspIdToCancel = if (cancelParamsObj.has("id")) cancelParamsObj.get("id").asString else null
             if (lspIdToCancel == null) return
 
@@ -185,8 +188,9 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             paramsObj.addProperty("id", legacyIdToCancel)
             cancelReq.add("params", paramsObj)
             DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
+        } else {
+            logger.info("Ignored unimplemented method from lsp4ij notification: ${message.method}")
         }
-        logger.info("Ignored unimplemented method from lsp4ij notification: ${message.method}")
     }
 
     private fun handleInitializeRequest(message: RequestMessage) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -210,7 +210,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
     private fun forwardLspRequestToDas(message: RequestMessage, dartAnalysisService: DartAnalysisServerService) {
         val rawId = message.id ?: return
-        val lspId = rawId.toString()
+        val lspId = JSON_HANDLER.gson.toJsonTree(rawId).asString
         val legacyRequest = JsonObject()
         val legacyId = dartAnalysisService.generateUniqueId()
         pendingLegacyIds[legacyId] = lspId

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -116,7 +116,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
         if (jsonObject.has("result")) {
             val topLevelId = if (jsonObject.has("id")) jsonObject.get("id").asString else null
-            if (topLevelId != null && pendingLegacyIds.values.remove(topLevelId)) {
+            if (topLevelId != null && pendingLegacyIds.remove(topLevelId) != null) {
                 val result = jsonObject.get("result").asJsonObject
                 if (result.has(LSP_RESPONSE_KEY)) {
                     return result.get(LSP_RESPONSE_KEY).asJsonObject
@@ -177,7 +177,9 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             val lspIdToCancel = if (cancelParamsObj.has("id")) cancelParamsObj.get("id").asString else null
             if (lspIdToCancel == null) return
 
-            val legacyIdToCancel = pendingLegacyIds.remove(lspIdToCancel) ?: return
+            val entry = pendingLegacyIds.entries.firstOrNull { it.value == lspIdToCancel } ?: return
+            val legacyIdToCancel = entry.key
+            pendingLegacyIds.remove(legacyIdToCancel)
 
             logger.info("Forwarding $/cancelRequest for lspId=$lspIdToCancel as legacy server.cancelRequest for legacyId=$legacyIdToCancel")
             val cancelReqId = DartAnalysisServerService.getInstance(project).generateUniqueId()
@@ -211,7 +213,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         val lspId = rawId.toString()
         val legacyRequest = JsonObject()
         val legacyId = dartAnalysisService.generateUniqueId()
-        pendingLegacyIds[lspId] = legacyId
+        pendingLegacyIds[legacyId] = lspId
         legacyRequest.addProperty("id", legacyId)
         legacyRequest.addProperty("method", "lsp.handle")
 


### PR DESCRIPTION
Not having cancelRequest forward to the DAS was causing problems as I was working on `codeAction` because it can cause DAS to crash when there are many requests. However, `cancelRequest` is independent from `codeAction` and makes sense to have first.

Note that this is sending a legacy `cancelRequest`, not LSP-over-legacy.