### PR TITLE
Handle exit notification from lsp4ij

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -190,6 +190,9 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             paramsObj.addProperty("id", legacyIdToCancel)
             cancelReq.add("params", paramsObj)
             DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
+        } else if (message.method == "exit") {
+            logger.info("Received exit notification from lsp4ij, stopping connection provider")
+            stop()
         } else {
             logger.info("Ignored unimplemented method from lsp4ij notification: ${message.method}")
         }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -192,7 +192,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
         } else if (message.method == "exit") {
             logger.info("Received exit notification from lsp4ij, stopping connection provider")
-            stop()
+            ApplicationManager.getApplication().executeOnPooledThread { stop() }
         } else {
             logger.info("Ignored unimplemented method from lsp4ij notification: ${message.method}")
         }


### PR DESCRIPTION
Without this handling, stopping the server from the lsp4ij interface caused a timeout error because the exit notification (which comes after a shutdown request) was ignored. This fix properly closes the streams of the virtual server.