### PR TITLE
[build] bump to latest stable (2026.1.2)

### DIFF
--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -16,7 +16,7 @@ pluginId = Dart
 pluginSinceBuild = 251
 pluginUntilBuild = 261.*
 
-ideaVersion = 2026.1.1
+ideaVersion = 2026.1.2
 
 javaVersion = 21
 


### PR DESCRIPTION
2026.1.1 is failing to resolve locally. 2026.1.2 seems to fix it.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
