### PR TITLE
Fix virtual LSP analysis server stream dying after period of inactivity

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartMessageProducer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartMessageProducer.kt
@@ -53,7 +53,11 @@ class DartMessageProducer(val jsonHandler: MessageJsonHandler) : MessageProducer
             try {
                 val message = jsonHandler.parseMessage(json)
                 if (message != null) {
-                    messageConsumer.consume(message)
+                    try {
+                        messageConsumer.consume(message)
+                    } catch (t: Throwable) {
+                        logger.error("Error consuming parsed LSP message: $json", t)
+                    }
                 } else {
                     logger.warn("Parsed message is null for JSON: $json")
                 }
@@ -63,6 +67,8 @@ class DartMessageProducer(val jsonHandler: MessageJsonHandler) : MessageProducer
                 logger.warn("Error sending message to lsp4ij: $json", ex)
             } catch(ex: JsonRpcException) {
                 logger.warn("Error sending message to lsp4ij: $json", ex)
+            } catch(t: Throwable) {
+                logger.error("Unexpected error in message producer loop for JSON: $json", t)
             }
         }
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartMessageProducer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartMessageProducer.kt
@@ -55,8 +55,8 @@ class DartMessageProducer(val jsonHandler: MessageJsonHandler) : MessageProducer
                 if (message != null) {
                     try {
                         messageConsumer.consume(message)
-                    } catch (t: Throwable) {
-                        logger.error("Error consuming parsed LSP message: $json", t)
+                    } catch (e: Exception) {
+                        logger.error("Error consuming parsed LSP message: $json", e)
                     }
                 } else {
                     logger.warn("Parsed message is null for JSON: $json")
@@ -67,8 +67,8 @@ class DartMessageProducer(val jsonHandler: MessageJsonHandler) : MessageProducer
                 logger.warn("Error sending message to lsp4ij: $json", ex)
             } catch(ex: JsonRpcException) {
                 logger.warn("Error sending message to lsp4ij: $json", ex)
-            } catch(t: Throwable) {
-                logger.error("Unexpected error in message producer loop for JSON: $json", t)
+            } catch(e: Exception) {
+                logger.error("Unexpected error in message producer loop for JSON: $json", e)
             }
         }
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -5,6 +5,7 @@
  */
 package com.jetbrains.lang.dart.lsp
 
+import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.intellij.openapi.Disposable
@@ -26,8 +27,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
-import java.io.PipedInputStream
-import java.io.PipedOutputStream
+import java.util.concurrent.ConcurrentHashMap
 import org.eclipse.lsp4j.jsonrpc.JsonRpcException
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
@@ -57,7 +57,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     // This stores IDs that have been used by lsp4ij for LSP-over-legacy requests to DAS.
     // There are non-lsp4ij requests that are sent as LSP-over-legacy, but we don't need to forward responses for those
     // requests to lsp4ij since lsp4ij was not the originator.
-    private val pendingLegacyIds = java.util.concurrent.ConcurrentHashMap<String, com.google.gson.JsonElement>()
+    private val pendingLegacyIds = ConcurrentHashMap<String, JsonElement>()
     private var responseListener: ResponseListener? = null
     @Volatile private var isStopping = false
     private var clientMessageFuture: java.util.concurrent.Future<*>? = null

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -57,7 +57,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     // This stores IDs that have been used by lsp4ij for LSP-over-legacy requests to DAS.
     // There are non-lsp4ij requests that are sent as LSP-over-legacy, but we don't need to forward responses for those
     // requests to lsp4ij since lsp4ij was not the originator.
-    private val pendingLegacyIds = java.util.concurrent.ConcurrentHashMap<String, String>()
+    private val pendingLegacyIds = java.util.concurrent.ConcurrentHashMap<String, com.google.gson.JsonElement>()
     private var responseListener: ResponseListener? = null
     @Volatile private var isStopping = false
     private var clientMessageFuture: java.util.concurrent.Future<*>? = null
@@ -82,7 +82,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
                 return@ResponseListener
             }
 
-            logger.info("Response received from DAS: $response")
+            logger.debug("Response received from DAS: $response")
             val jsonObject = JsonParser.parseString(response).asJsonObject
             val lspPayload = extractLspPayload(jsonObject)
 
@@ -101,36 +101,35 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             if (params.has(LSP_MESSAGE_KEY)) {
                 val msgObj = params.get(LSP_MESSAGE_KEY).asJsonObject
                 if (msgObj.getAsJsonPrimitive("method")?.asString == "workspace/applyEdit") {
-                    logger.info("Ignored workspace/applyEdit message from DAS (handled by legacy bridge)")
+                    logger.debug("Ignored workspace/applyEdit message from DAS (handled by legacy bridge)")
                     return null
                 }
-                logger.info("extractLspPayload: Extracted LSP notification/message from DAS: $msgObj")
+                logger.debug("extractLspPayload: Extracted LSP notification/message from DAS: $msgObj")
                 return msgObj
             }
         }
 
         val topLevelId = if (jsonObject.has("id")) jsonObject.get("id").asString else null
         if (topLevelId != null) {
-            val lspId = pendingLegacyIds[topLevelId]
-            if (lspId != null) {
+            val lspIdElement = pendingLegacyIds[topLevelId]
+            if (lspIdElement != null) {
                 if (jsonObject.has("result")) {
                     pendingLegacyIds.remove(topLevelId)
                     val result = jsonObject.get("result").asJsonObject
                     if (result.has(LSP_RESPONSE_KEY)) {
                         val resultPayload = result.get(LSP_RESPONSE_KEY).asJsonObject
-                        logger.info("extractLspPayload: Extracted successful LSP response for legacyId=$topLevelId (lspId=$lspId): $resultPayload")
+                        logger.debug("extractLspPayload: Extracted successful LSP response for legacyId=$topLevelId (lspId=$lspIdElement): $resultPayload")
                         return resultPayload
                     } else {
-                        logger.info("extractLspPayload: DAS response has result but is missing '$LSP_RESPONSE_KEY': $jsonObject")
+                        logger.debug("extractLspPayload: DAS response has result but is missing '$LSP_RESPONSE_KEY': $jsonObject")
                     }
                 } else if (jsonObject.has("error")) {
                     pendingLegacyIds.remove(topLevelId)
                     val error = jsonObject.get("error").asJsonObject
-                    logger.warn("Received legacy error from DAS for legacyId=$topLevelId (lspId=$lspId): $error")
+                    logger.warn("Received legacy error from DAS for legacyId=$topLevelId (lspId=$lspIdElement): $error")
                     val lspErrorResponse = JsonObject()
                     lspErrorResponse.addProperty("jsonrpc", JSONRPC_VERSION)
-                    val idElement = JsonParser.parseString(lspId)
-                    lspErrorResponse.add("id", idElement)
+                    lspErrorResponse.add("id", lspIdElement)
                     
                     val lspError = JsonObject()
                     lspError.addProperty("code", error.get("code")?.asInt ?: -32603)
@@ -139,14 +138,14 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
                         lspError.add("data", error.get("data"))
                     }
                     lspErrorResponse.add("error", lspError)
-                    logger.info("extractLspPayload: Created LSP error response for legacyId=$topLevelId (lspId=$lspId): $lspErrorResponse")
+                    logger.debug("extractLspPayload: Created LSP error response for legacyId=$topLevelId (lspId=$lspIdElement): $lspErrorResponse")
                     return lspErrorResponse
                 }
             } else {
-                logger.info("extractLspPayload: Ignored DAS response for legacyId=$topLevelId because it is not in pendingLegacyIds")
+                logger.debug("extractLspPayload: Ignored DAS response for legacyId=$topLevelId because it is not in pendingLegacyIds")
             }
         } else {
-            logger.info("extractLspPayload: Ignored DAS message without top-level id: $jsonObject")
+            logger.debug("extractLspPayload: Ignored DAS message without top-level id: $jsonObject")
         }
 
         return null
@@ -157,14 +156,14 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         try {
             requestReader.listen { message ->
                 try {
-                    logger.info("LSP message from lsp4ij: $message")
+                    logger.debug("LSP message from lsp4ij: $message")
                     when (message) {
                         is RequestMessage -> handleRequestMessage(message)
                         is NotificationMessage -> handleNotificationMessage(message)
-                        else -> logger.info("Ignored unrecognized message type from lsp4ij request: $message")
+                        else -> logger.debug("Ignored unrecognized message type from lsp4ij request: $message")
                     }
-                } catch (t: Throwable) {
-                    logger.error("Error processing LSP message from lsp4ij: $message", t)
+                } catch (e: Exception) {
+                    logger.error("Error processing LSP message from lsp4ij: $message", e)
                 }
             }
         } catch (e: JsonRpcException) {
@@ -178,8 +177,8 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             } else {
                 logger.error("Error listening for lsp4ij messages", e)
             }
-        } catch (t: Throwable) {
-            logger.error("Unexpected error in LSP message listener loop", t)
+        } catch (e: Exception) {
+            logger.error("Unexpected error in LSP message listener loop", e)
         }
     }
 
@@ -208,7 +207,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             val lspIdToCancel = if (cancelParamsObj.has("id")) cancelParamsObj.get("id").asString else null
             if (lspIdToCancel == null) return
 
-            val entry = pendingLegacyIds.entries.firstOrNull { it.value == lspIdToCancel } ?: return
+            val entry = pendingLegacyIds.entries.firstOrNull { it.value.asString == lspIdToCancel } ?: return
             val legacyIdToCancel = entry.key
             pendingLegacyIds.remove(legacyIdToCancel)
 
@@ -223,8 +222,8 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
             try {
                 DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
-            } catch (t: Throwable) {
-                logger.error("Failed to send cancelRequest to DAS: $cancelReq", t)
+            } catch (e: Exception) {
+                logger.error("Failed to send cancelRequest to DAS: $cancelReq", e)
             }
         } else if (message.method == "exit") {
             logger.info("Received exit notification from lsp4ij, stopping connection provider")
@@ -252,7 +251,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
     private fun forwardLspRequestToDas(message: RequestMessage, dartAnalysisService: DartAnalysisServerService) {
         val rawId = message.id ?: return
-        val lspId = JSON_HANDLER.gson.toJsonTree(rawId).asString
+        val lspIdElement = JSON_HANDLER.gson.toJsonTree(rawId)
 
         if (!dartAnalysisService.isServerProcessActive) {
             logger.warn("Cannot forward LSP request to DAS because DAS process is not active: $message")
@@ -262,7 +261,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
 
         val legacyRequest = JsonObject()
         val legacyId = dartAnalysisService.generateUniqueId()
-        pendingLegacyIds[legacyId] = lspId
+        pendingLegacyIds[legacyId] = lspIdElement
         legacyRequest.addProperty("id", legacyId)
         legacyRequest.addProperty("method", "lsp.handle")
 
@@ -273,10 +272,10 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         try {
             // Forward to DAS.
             dartAnalysisService.sendRequest(legacyId, legacyRequest)
-        } catch (t: Throwable) {
-            logger.error("Failed to send request to DAS: $legacyRequest", t)
+        } catch (e: Exception) {
+            logger.error("Failed to send request to DAS: $legacyRequest", e)
             pendingLegacyIds.remove(legacyId)
-            sendErrorResponse(message.id, ResponseErrorCode.InternalError, "Failed to send request to Dart Analysis Server: ${t.message}")
+            sendErrorResponse(message.id, ResponseErrorCode.InternalError, "Failed to send request to Dart Analysis Server: ${e.message}")
         }
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -49,18 +49,10 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     }
 
     // Stream for writing LSP responses from the virtual server to the lsp4ij client.
-    // I'm not even sure we need this at all.
-    val clientLspInputStream = PipedInputStream(1024 * 1024)
-    val virtualServerLspOutputStream = PipedOutputStream()
+    val responseStream = VirtualStream()
 
     // Stream for the lsp4ij client to write requests to the virtual server.
-    val virtualServerLspInputStream = PipedInputStream(1024 * 1024)
-    val clientLspOutputStream = PipedOutputStream()
-
-    init {
-        clientLspInputStream.connect(virtualServerLspOutputStream)
-        virtualServerLspInputStream.connect(clientLspOutputStream)
-    }
+    val requestStream = VirtualStream()
 
     // This stores IDs that have been used by lsp4ij for LSP-over-legacy requests to DAS.
     // There are non-lsp4ij requests that are sent as LSP-over-legacy, but we don't need to forward responses for those
@@ -90,7 +82,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
                 return@ResponseListener
             }
 
-            logger.debug("Response received from DAS: $response")
+            logger.info("Response received from DAS: $response")
             val jsonObject = JsonParser.parseString(response).asJsonObject
             val lspPayload = extractLspPayload(jsonObject)
 
@@ -109,32 +101,63 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             if (params.has(LSP_MESSAGE_KEY)) {
                 val msgObj = params.get(LSP_MESSAGE_KEY).asJsonObject
                 if (msgObj.getAsJsonPrimitive("method")?.asString == "workspace/applyEdit") {
-                    logger.debug("Ignored workspace/applyEdit message from DAS (handled by legacy bridge)")
+                    logger.info("Ignored workspace/applyEdit message from DAS (handled by legacy bridge)")
                     return null
                 }
+                logger.info("extractLspPayload: Extracted LSP notification/message from DAS: $msgObj")
                 return msgObj
             }
         }
 
-        if (jsonObject.has("result")) {
-            val topLevelId = if (jsonObject.has("id")) jsonObject.get("id").asString else null
-            if (topLevelId != null && pendingLegacyIds.remove(topLevelId) != null) {
-                val result = jsonObject.get("result").asJsonObject
-                if (result.has(LSP_RESPONSE_KEY)) {
-                    return result.get(LSP_RESPONSE_KEY).asJsonObject
+        val topLevelId = if (jsonObject.has("id")) jsonObject.get("id").asString else null
+        if (topLevelId != null) {
+            val lspId = pendingLegacyIds[topLevelId]
+            if (lspId != null) {
+                if (jsonObject.has("result")) {
+                    pendingLegacyIds.remove(topLevelId)
+                    val result = jsonObject.get("result").asJsonObject
+                    if (result.has(LSP_RESPONSE_KEY)) {
+                        val resultPayload = result.get(LSP_RESPONSE_KEY).asJsonObject
+                        logger.info("extractLspPayload: Extracted successful LSP response for legacyId=$topLevelId (lspId=$lspId): $resultPayload")
+                        return resultPayload
+                    } else {
+                        logger.info("extractLspPayload: DAS response has result but is missing '$LSP_RESPONSE_KEY': $jsonObject")
+                    }
+                } else if (jsonObject.has("error")) {
+                    pendingLegacyIds.remove(topLevelId)
+                    val error = jsonObject.get("error").asJsonObject
+                    logger.warn("Received legacy error from DAS for legacyId=$topLevelId (lspId=$lspId): $error")
+                    val lspErrorResponse = JsonObject()
+                    lspErrorResponse.addProperty("jsonrpc", JSONRPC_VERSION)
+                    val idElement = JsonParser.parseString(lspId)
+                    lspErrorResponse.add("id", idElement)
+                    
+                    val lspError = JsonObject()
+                    lspError.addProperty("code", error.get("code")?.asInt ?: -32603)
+                    lspError.addProperty("message", error.get("message")?.asString ?: "Unknown DAS error")
+                    if (error.has("data")) {
+                        lspError.add("data", error.get("data"))
+                    }
+                    lspErrorResponse.add("error", lspError)
+                    logger.info("extractLspPayload: Created LSP error response for legacyId=$topLevelId (lspId=$lspId): $lspErrorResponse")
+                    return lspErrorResponse
                 }
+            } else {
+                logger.info("extractLspPayload: Ignored DAS response for legacyId=$topLevelId because it is not in pendingLegacyIds")
             }
+        } else {
+            logger.info("extractLspPayload: Ignored DAS message without top-level id: $jsonObject")
         }
 
         return null
     }
 
     private fun processLspClientMessages() {
-        val requestReader = StreamMessageProducer(virtualServerLspInputStream, JSON_HANDLER)
+        val requestReader = StreamMessageProducer(requestStream, JSON_HANDLER)
         try {
             requestReader.listen { message ->
                 try {
-                    logger.debug("Message from lsp4ij: $message")
+                    logger.info("LSP message from lsp4ij: $message")
                     when (message) {
                         is RequestMessage -> handleRequestMessage(message)
                         is NotificationMessage -> handleNotificationMessage(message)
@@ -148,9 +171,9 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             val cause = e.cause
             if (cause is IOException) {
                 if (isStopping) {
-                    logger.info("Connection closed during shutdown: ${cause.message}")
+                    logger.info("Connection closed during shutdown: ${cause.message}", e)
                 } else {
-                    logger.warn("Connection closed unexpectedly: ${cause.message}")
+                    logger.warn("Connection closed unexpectedly: ${cause.message}", e)
                 }
             } else {
                 logger.error("Error listening for lsp4ij messages", e)
@@ -197,7 +220,12 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             val paramsObj = JsonObject()
             paramsObj.addProperty("id", legacyIdToCancel)
             cancelReq.add("params", paramsObj)
-            DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
+
+            try {
+                DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
+            } catch (t: Throwable) {
+                logger.error("Failed to send cancelRequest to DAS: $cancelReq", t)
+            }
         } else if (message.method == "exit") {
             logger.info("Received exit notification from lsp4ij, stopping connection provider")
             isStopping = true
@@ -216,6 +244,8 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     }
 
     private fun handleShutdownRequest(message: RequestMessage) {
+        logger.info("Received shutdown request from lsp4ij, transitioning to stopping state")
+        isStopping = true
         sendSuccessResponse(message.id, null)
     }
 
@@ -283,11 +313,11 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     }
 
     override fun getInputStream(): InputStream? {
-        return clientLspInputStream
+        return responseStream
     }
 
     override fun getOutputStream(): OutputStream? {
-        return clientLspOutputStream
+        return requestStream.outputStream
     }
 
     override fun stop() {
@@ -301,10 +331,8 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         service.producer?.stop()
         service.producer = null
 
-        clientLspInputStream.close()
-        virtualServerLspOutputStream.close()
-        virtualServerLspInputStream.close()
-        clientLspOutputStream.close()
+        responseStream.close()
+        requestStream.close()
 
         // Wait for the client message thread to terminate.
         // This is primarily needed for legacy unit tests to prevent ThreadLeakTracker from failing tests
@@ -322,3 +350,5 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         pendingLegacyIds.clear()
     }
 }
+
+

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProvider.kt
@@ -29,6 +29,8 @@ import java.io.OutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import org.eclipse.lsp4j.jsonrpc.JsonRpcException
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
 
 /**
  * This is essentially a virtual LSP language server.
@@ -65,7 +67,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     // requests to lsp4ij since lsp4ij was not the originator.
     private val pendingLegacyIds = java.util.concurrent.ConcurrentHashMap<String, String>()
     private var responseListener: ResponseListener? = null
-    private var isStopping = false
+    @Volatile private var isStopping = false
     private var clientMessageFuture: java.util.concurrent.Future<*>? = null
 
     override fun start() {
@@ -131,11 +133,15 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         val requestReader = StreamMessageProducer(virtualServerLspInputStream, JSON_HANDLER)
         try {
             requestReader.listen { message ->
-                logger.debug("Message from lsp4ij: $message")
-                when (message) {
-                    is RequestMessage -> handleRequestMessage(message)
-                    is NotificationMessage -> handleNotificationMessage(message)
-                    else -> logger.info("Ignored unrecognized message type from lsp4ij request: $message")
+                try {
+                    logger.debug("Message from lsp4ij: $message")
+                    when (message) {
+                        is RequestMessage -> handleRequestMessage(message)
+                        is NotificationMessage -> handleNotificationMessage(message)
+                        else -> logger.info("Ignored unrecognized message type from lsp4ij request: $message")
+                    }
+                } catch (t: Throwable) {
+                    logger.error("Error processing LSP message from lsp4ij: $message", t)
                 }
             }
         } catch (e: JsonRpcException) {
@@ -149,6 +155,8 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             } else {
                 logger.error("Error listening for lsp4ij messages", e)
             }
+        } catch (t: Throwable) {
+            logger.error("Unexpected error in LSP message listener loop", t)
         }
     }
 
@@ -192,6 +200,7 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
             DartAnalysisServerService.getInstance(project).sendRequest(cancelReqId, cancelReq)
         } else if (message.method == "exit") {
             logger.info("Received exit notification from lsp4ij, stopping connection provider")
+            isStopping = true
             ApplicationManager.getApplication().executeOnPooledThread { stop() }
         } else {
             logger.info("Ignored unimplemented method from lsp4ij notification: ${message.method}")
@@ -214,6 +223,13 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
     private fun forwardLspRequestToDas(message: RequestMessage, dartAnalysisService: DartAnalysisServerService) {
         val rawId = message.id ?: return
         val lspId = JSON_HANDLER.gson.toJsonTree(rawId).asString
+
+        if (!dartAnalysisService.isServerProcessActive) {
+            logger.warn("Cannot forward LSP request to DAS because DAS process is not active: $message")
+            sendErrorResponse(message.id, ResponseErrorCode.InternalError, "Dart Analysis Server is not active")
+            return
+        }
+
         val legacyRequest = JsonObject()
         val legacyId = dartAnalysisService.generateUniqueId()
         pendingLegacyIds[legacyId] = lspId
@@ -224,8 +240,14 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         params.add("lspMessage", JSON_HANDLER.gson.toJsonTree(message).asJsonObject)
         legacyRequest.add("params", params)
 
-        // Forward to DAS.
-        dartAnalysisService.sendRequest(legacyId, legacyRequest)
+        try {
+            // Forward to DAS.
+            dartAnalysisService.sendRequest(legacyId, legacyRequest)
+        } catch (t: Throwable) {
+            logger.error("Failed to send request to DAS: $legacyRequest", t)
+            pendingLegacyIds.remove(legacyId)
+            sendErrorResponse(message.id, ResponseErrorCode.InternalError, "Failed to send request to Dart Analysis Server: ${t.message}")
+        }
     }
 
     private fun sendResponseToClient(response: ResponseMessage) {
@@ -238,6 +260,14 @@ class DartVirtualStreamConnectionProvider(private val project: Project) : Stream
         response.jsonrpc = JSONRPC_VERSION
         response.id = messageId
         response.result = result
+        sendResponseToClient(response)
+    }
+
+    private fun sendErrorResponse(messageId: String?, errorCode: ResponseErrorCode, message: String) {
+        val response = ResponseMessage()
+        response.jsonrpc = JSONRPC_VERSION
+        response.id = messageId
+        response.error = ResponseError(errorCode, message, null)
         sendResponseToClient(response)
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/VirtualStream.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/VirtualStream.kt
@@ -11,63 +11,84 @@ import java.io.OutputStream
 import java.util.concurrent.LinkedBlockingQueue
 
 /**
- * A thread-safe circular byte queue that replaces standard PipedInputStream/PipedOutputStream.
+ * A high-performance thread-safe circular byte queue that replaces PipedInputStream/PipedOutputStream.
+ * Uses chunks of ByteArrays to prevent GC pressure and boxing overhead when handling large payloads.
  * This class is entirely thread-agnostic and is immune to thread pool worker thread terminations.
  */
 class VirtualStream : InputStream() {
-    private val queue = LinkedBlockingQueue<Int>()
+    companion object {
+        // Reference-identical poison pill to cleanly signal EOF
+        private val POISON_PILL = ByteArray(0)
+    }
+
+    private val queue = LinkedBlockingQueue<ByteArray>()
     @Volatile private var closed = false
+
+    // Buffer tracking state for the current chunk being read
+    private var currentBuffer: ByteArray? = null
+    private var currentPos = 0
 
     val outputStream = object : OutputStream() {
         override fun write(b: Int) {
             if (closed) throw IOException("Stream closed")
-            queue.put(b)
+            queue.put(byteArrayOf(b.toByte()))
         }
 
         override fun write(b: ByteArray, off: Int, len: Int) {
             if (closed) throw IOException("Stream closed")
-            for (i in 0 until len) {
-                queue.put(b[off + i].toInt() and 0xFF)
+            if (len > 0) {
+                queue.put(b.copyOfRange(off, off + len))
             }
         }
 
         override fun close() {
             closed = true
-            queue.put(-1) // EOF poison pill
+            queue.put(POISON_PILL)
         }
     }
 
     override fun read(): Int {
-        if (closed && queue.isEmpty()) return -1
-        val b = queue.take()
-        if (b == -1) {
-            closed = true
-            return -1
+        if (closed && currentBuffer == null) return -1
+        val buffer = getOrFetchBuffer() ?: return -1
+        val b = buffer[currentPos++].toInt() and 0xFF
+        if (currentPos >= buffer.size) {
+            currentBuffer = null
         }
         return b
     }
 
     override fun read(b: ByteArray, off: Int, len: Int): Int {
         if (len == 0) return 0
-        val first = read()
-        if (first == -1) return -1
-        b[off] = first.toByte()
-        var bytesRead = 1
-        while (bytesRead < len) {
-            val next = queue.poll() ?: break
-            if (next == -1) {
-                closed = true
-                queue.put(-1)
-                break
-            }
-            b[off + bytesRead] = next.toByte()
-            bytesRead++
+        if (closed && currentBuffer == null && queue.isEmpty()) return -1
+
+        val buffer = getOrFetchBuffer() ?: return -1
+        val available = buffer.size - currentPos
+        val bytesToCopy = Math.min(len, available)
+        System.arraycopy(buffer, currentPos, b, off, bytesToCopy)
+        currentPos += bytesToCopy
+        if (currentPos >= buffer.size) {
+            currentBuffer = null
         }
-        return bytesRead
+        return bytesToCopy
+    }
+
+    private fun getOrFetchBuffer(): ByteArray? {
+        var buffer = currentBuffer
+        if (buffer == null) {
+            val next = queue.take()
+            if (next === POISON_PILL || next.isEmpty()) {
+                closed = true
+                return null
+            }
+            buffer = next
+            currentBuffer = next
+            currentPos = 0
+        }
+        return buffer
     }
 
     override fun close() {
         closed = true
-        queue.put(-1)
+        queue.put(POISON_PILL)
     }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/VirtualStream.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/VirtualStream.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.lsp
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.LinkedBlockingQueue
+
+/**
+ * A thread-safe circular byte queue that replaces standard PipedInputStream/PipedOutputStream.
+ * This class is entirely thread-agnostic and is immune to thread pool worker thread terminations.
+ */
+class VirtualStream : InputStream() {
+    private val queue = LinkedBlockingQueue<Int>()
+    @Volatile private var closed = false
+
+    val outputStream = object : OutputStream() {
+        override fun write(b: Int) {
+            if (closed) throw IOException("Stream closed")
+            queue.put(b)
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            if (closed) throw IOException("Stream closed")
+            for (i in 0 until len) {
+                queue.put(b[off + i].toInt() and 0xFF)
+            }
+        }
+
+        override fun close() {
+            closed = true
+            queue.put(-1) // EOF poison pill
+        }
+    }
+
+    override fun read(): Int {
+        if (closed && queue.isEmpty()) return -1
+        val b = queue.take()
+        if (b == -1) {
+            closed = true
+            return -1
+        }
+        return b
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+        if (len == 0) return 0
+        val first = read()
+        if (first == -1) return -1
+        b[off] = first.toByte()
+        var bytesRead = 1
+        while (bytesRead < len) {
+            val next = queue.poll() ?: break
+            if (next == -1) {
+                closed = true
+                queue.put(-1)
+                break
+            }
+            b[off + bytesRead] = next.toByte()
+            bytesRead++
+        }
+        return bytesRead
+    }
+
+    override fun close() {
+        closed = true
+        queue.put(-1)
+    }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/VirtualStream.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/VirtualStream.kt
@@ -22,7 +22,8 @@ class VirtualStream : InputStream() {
     }
 
     private val queue = LinkedBlockingQueue<ByteArray>()
-    @Volatile private var closed = false
+    @Volatile private var writeClosed = false
+    @Volatile private var readClosed = false
 
     // Buffer tracking state for the current chunk being read
     private var currentBuffer: ByteArray? = null
@@ -30,25 +31,27 @@ class VirtualStream : InputStream() {
 
     val outputStream = object : OutputStream() {
         override fun write(b: Int) {
-            if (closed) throw IOException("Stream closed")
+            if (writeClosed) throw IOException("Stream closed")
             queue.put(byteArrayOf(b.toByte()))
         }
 
         override fun write(b: ByteArray, off: Int, len: Int) {
-            if (closed) throw IOException("Stream closed")
+            if (writeClosed) throw IOException("Stream closed")
             if (len > 0) {
                 queue.put(b.copyOfRange(off, off + len))
             }
         }
 
         override fun close() {
-            closed = true
-            queue.put(POISON_PILL)
+            if (!writeClosed) {
+                writeClosed = true
+                queue.put(POISON_PILL)
+            }
         }
     }
 
     override fun read(): Int {
-        if (closed && currentBuffer == null) return -1
+        if (readClosed) return -1
         val buffer = getOrFetchBuffer() ?: return -1
         val b = buffer[currentPos++].toInt() and 0xFF
         if (currentPos >= buffer.size) {
@@ -59,7 +62,7 @@ class VirtualStream : InputStream() {
 
     override fun read(b: ByteArray, off: Int, len: Int): Int {
         if (len == 0) return 0
-        if (closed && currentBuffer == null && queue.isEmpty()) return -1
+        if (readClosed) return -1
 
         val buffer = getOrFetchBuffer() ?: return -1
         val available = buffer.size - currentPos
@@ -75,9 +78,12 @@ class VirtualStream : InputStream() {
     private fun getOrFetchBuffer(): ByteArray? {
         var buffer = currentBuffer
         if (buffer == null) {
+            if (readClosed) {
+                return null
+            }
             val next = queue.take()
-            if (next === POISON_PILL || next.isEmpty()) {
-                closed = true
+            if (next === POISON_PILL) {
+                readClosed = true
                 return null
             }
             buffer = next
@@ -88,7 +94,6 @@ class VirtualStream : InputStream() {
     }
 
     override fun close() {
-        closed = true
-        queue.put(POISON_PILL)
+        outputStream.close()
     }
 }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProviderTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartVirtualStreamConnectionProviderTest.kt
@@ -152,7 +152,7 @@ class DartVirtualStreamConnectionProviderTest : DartCodeInsightFixtureTestCase()
             override fun getErrorStream(): ByteLineReaderStream? = null
             override fun getRequestSink(): RequestSink? = null
             override fun getResponseStream(): ResponseStream? = null
-            override fun isOpen(): Boolean = false
+            override fun isOpen(): Boolean = true
             override fun start() {}
             override fun stop() {}
         }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/VirtualStreamTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/VirtualStreamTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.lsp
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Detailed unit tests for the VirtualStream circular queue byte stream.
+ * Verifies concurrency, block reads/writes, EOF handling, and edge conditions.
+ */
+class VirtualStreamTest {
+
+    @Test
+    fun testWriteAndReadSingleBytes() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+
+        out.write(10)
+        out.write(20)
+        out.write(30)
+
+        assertEquals(10, stream.read())
+        assertEquals(20, stream.read())
+        assertEquals(30, stream.read())
+    }
+
+    @Test
+    fun testWriteAndReadChunks() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+
+        val data = byteArrayOf(1, 2, 3, 4, 5)
+        out.write(data)
+
+        val buffer = ByteArray(5)
+        val readBytes = stream.read(buffer)
+
+        assertEquals(5, readBytes)
+        assertArrayEquals(data, buffer)
+    }
+
+    @Test
+    fun testPartialReads() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+
+        out.write(byteArrayOf(1, 2, 3))
+        out.write(byteArrayOf(4, 5, 6, 7))
+
+        val buffer = ByteArray(5)
+        // Should read first chunk (size 3)
+        val firstRead = stream.read(buffer, 0, 5)
+        assertEquals(3, firstRead)
+        assertEquals(1, buffer[0].toInt())
+        assertEquals(2, buffer[1].toInt())
+        assertEquals(3, buffer[2].toInt())
+
+        // Next read should fetch from second chunk
+        val secondRead = stream.read(buffer, 0, 5)
+        assertEquals(4, secondRead)
+        assertEquals(4, buffer[0].toInt())
+        assertEquals(5, buffer[1].toInt())
+        assertEquals(6, buffer[2].toInt())
+        assertEquals(7, buffer[3].toInt())
+    }
+
+    @Test
+    fun testEOFPoisonPill() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+
+        out.write(10)
+        out.close()
+
+        assertEquals(10, stream.read())
+        assertEquals(-1, stream.read())
+        assertEquals(-1, stream.read(ByteArray(5)))
+    }
+
+    @Test
+    fun testReadAfterClose() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+
+        out.write(byteArrayOf(1, 2, 3))
+        out.close()
+
+        val buffer = ByteArray(5)
+        val readBytes = stream.read(buffer)
+        assertEquals(3, readBytes)
+        assertEquals(1, buffer[0].toInt())
+
+        assertEquals(-1, stream.read())
+    }
+
+    @Test
+    fun testBlockingRead() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+        val latch = CountDownLatch(1)
+        val result = AtomicInteger(-1)
+
+        Thread {
+            result.set(stream.read())
+            latch.countDown()
+        }.start()
+
+        // Sleep to ensure the read thread blocks
+        Thread.sleep(200)
+        assertEquals(-1, result.get()) // Still blocked
+
+        out.write(42)
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertEquals(42, result.get())
+    }
+
+    @Test
+    fun testMultiThreadedWrites() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+        val numThreads = 5
+        val writesPerThread = 100
+        val latch = CountDownLatch(numThreads)
+
+        for (t in 0 until numThreads) {
+            Thread {
+                for (i in 0 until writesPerThread) {
+                    out.write(t)
+                }
+                latch.countDown()
+            }.start()
+        }
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS))
+        out.close()
+
+        val expectedTotal = numThreads * writesPerThread
+        var actualCount = 0
+        val counts = IntArray(numThreads)
+
+        while (true) {
+            val b = stream.read()
+            if (b == -1) break
+            counts[b]++
+            actualCount++
+        }
+
+        assertEquals(expectedTotal, actualCount)
+        for (t in 0 until numThreads) {
+            assertEquals(writesPerThread, counts[t])
+        }
+    }
+
+    @Test
+    fun testWriteToClosedStreamThrows() {
+        val stream = VirtualStream()
+        val out = stream.outputStream
+        out.close()
+
+        try {
+            out.write(10)
+            fail("Expected IOException")
+        } catch (e: IOException) {
+            assertEquals("Stream closed", e.message)
+        }
+    }
+}


### PR DESCRIPTION
I initially noticed the virtual server dying after a few minutes of idleness, with this kind of log:

```
com.jetbrains.lang.dart.lsp.DartVirtualStreamConnectionProvider [WARNING] Connection closed unexpectedly: Pipe broken
```

I was looking for whether there was any particular error from the analysis server or elsewhere causing the broken pipe, but adding logs didn't show anything. It turns out the problem is using `PipedInputStream`/`PipedOutputStream`, as those are not intended for a long-lived process. The threads writing to the streams can be killed, which causes the pipe to interpret that the stream is gone. Since lsp4ij probably has writing threads that get collected with some regular frequency (on the order of a few minutes of idleness), broken pipe was showing up consistently.

Gemini wrote me a `VirtualStream` that is queue-backed, so that messages can be written to the stream and the writer being canceled has no impact on the stream's state.

The rest of the changes are missing logs that were added while eliminating other sources of error, but I figured they could be nice to have in case errors do show up in those places later on.