### PR TITLE
[denoise] suppress `DART_HOME` warnings for non-DAS tests

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -224,7 +224,25 @@ tasks {
         }
 
         doFirst {
-            if (showDartHomeWarning) {
+            val isRunningAnalysisServerTests = try {
+                // --tests command-line filters are internal to Gradle. We retrieve them
+                // via reflection to avoid compiling against internal Gradle classes.
+                val cmdLinePatternsMethod = filter.javaClass.getMethod("getCommandLineIncludePatterns")
+                val cmdLinePatterns = cmdLinePatternsMethod.invoke(filter) as? Set<*>
+                val allPatterns = filter.includePatterns + (cmdLinePatterns?.filterIsInstance<String>() ?: emptySet())
+
+                // If filters are specified, check if they target DAS tests. Otherwise, default to true.
+                if (allPatterns.isNotEmpty()) {
+                    allPatterns.any { it.contains("analysisServer") }
+                } else {
+                    true
+                }
+            } catch (_: Exception) {
+                // Fallback: assume DAS tests might run if reflection fails.
+                true
+            }
+
+            if (showDartHomeWarning && isRunningAnalysisServerTests) {
                 logger.error("DART_HOME environment variable is not set. Dart Analysis Server tests will fail.")
             }
         }

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -233,7 +233,7 @@ tasks {
 
                 // If filters are specified, check if they target DAS tests. Otherwise, default to true.
                 if (allPatterns.isNotEmpty()) {
-                    allPatterns.any { it.contains("analysisServer") }
+                    allPatterns.any { allPatterns.any { it.contains("analysisServer") || it.contains("com.jetbrains.dart") } }
                 } else {
                     true
                 }


### PR DESCRIPTION
When running standard Dart plugin unit tests (e.g., `com.jetbrains.lang.dart.*` package) in CI or local environments without a configured Dart SDK, Gradle logged a spurious error warning:

 `DART_HOME environment variable is not set. Dart Analysis Server tests will fail.`

Since the standard unit tests run against a mocked SDK and do not require `DART_HOME`, this warning is only applicable when Dart Analysis Server (DAS) tests (`com.jetbrains.dart.analysisServer.*`) are executing.


This PR updates the `test` task configuration in `third_party/build.gradle.kts` to only log the `DART_HOME` warning if:
1. No test filter is specified (meaning all tests, including DAS tests, are run).
2. The active test filters explicitly target DAS tests (containing the string `analysisServer`).
Since command-line filters supplied via `--tests` are stored within Gradle's internal `DefaultTestFilter` class and not exposed via the public `TestFilter` API, we retrieve them dynamically using reflection to prevent coupling to compiler-internal Gradle classes. If reflection fails, the logic falls back safely to assuming DAS tests may run.
---
#### Verification & Sample Output

##### Scenario A: Running standard unit tests (warning is bypassed)
```bash
$ ./gradlew test --tests com.jetbrains.lang.dart.parser.DartParsingTest.testPrimaryConstructors

> Task :test
[0.006s] ...
BUILD SUCCESSFUL in 4s
```

##### Scenario B: Running Analysis Server tests (warning is printed as expected)

```
$ ./gradlew test --tests com.jetbrains.dart.analysisServer.DartServerGotoSuperHandlerTest

> Task :test
DART_HOME environment variable is not set. Dart Analysis Server tests will fail.
[0.006s]...
DartServerGotoSuperHandlerTest > testSuperOperator FAILED
    java.lang.AssertionError at DartServerGotoSuperHandlerTest.java:14
...
BUILD FAILED in 7s

```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
