### PR TITLE
Add test for WebSocket behavior in DTDProcess

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,4 +1,4 @@
-name: das tests
+name: integration tests
 
 on:
   pull_request:
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  dart-analysis-server-tests:
-    name: DAS Tests (${{ matrix.os }})
+  integration-tests:
+    name: Integration Tests (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -37,15 +37,15 @@ jobs:
         with:
           sdk: ${{ matrix.dart-version }}
 
-      - name: Run Dart Analysis Server Tests
-        run: ./gradlew :test --tests "com.jetbrains.dart.analysisServer.*"
+      - name: Run Integration Tests
+        run: ./gradlew :test --tests "com.jetbrains.dart.*"
         working-directory: third_party
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: das-test-results
+          name: integration-test-results
           path: |
             **/build/reports/
             **/build/test-results/

--- a/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DTDProcessTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DTDProcessTest.kt
@@ -1,13 +1,9 @@
-/*
- * Copyright 2026 The Chromium Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-package com.jetbrains.lang.dart.dtd
+package com.jetbrains.dart.dartToolingDaemon
 
 import com.google.gson.JsonObject
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.lang.dart.dtd.DTDProcess
+import com.jetbrains.lang.dart.dtd.DTDProcessListener
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.util.DartTestUtils
 import java.util.UUID

--- a/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DTDProcessTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DTDProcessTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 package com.jetbrains.dart.dartToolingDaemon
 
 import com.google.gson.JsonObject

--- a/third_party/src/test/java/com/jetbrains/lang/dart/dtd/DTDProcessTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/dtd/DTDProcessTest.kt
@@ -1,0 +1,127 @@
+package com.jetbrains.lang.dart.dtd
+
+import com.google.gson.JsonObject
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.lang.dart.sdk.DartSdk
+import com.jetbrains.lang.dart.util.DartTestUtils
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class DTDProcessTest : BasePlatformTestCase() {
+
+  private companion object {
+    const val STARTUP_TIMEOUT_SECONDS = 5L
+    const val RESPONSE_TIMEOUT_SECONDS = 2L
+    const val CONCURRENT_REQUESTS_TIMEOUT_SECONDS = 5L
+    const val CONCURRENT_REQUESTS_COUNT = 10
+  }
+
+  private lateinit var dtdProcess: DTDProcess
+
+  override fun setUp() {
+    super.setUp()
+    DartTestUtils.configureDartSdk(module, myFixture.projectDisposable, true)
+  }
+
+  override fun tearDown() {
+    try {
+      if (::dtdProcess.isInitialized) {
+        dtdProcess.terminate()
+      }
+    }
+    finally {
+      super.tearDown()
+    }
+  }
+
+  fun testRoundTripRequest() {
+    startDtdProcessAndAwaitSocketOpen()
+
+    val responseRef = AtomicReference<JsonObject?>() //AtomicReference is not really necessary
+    val responseReceived = CountDownLatch(1)
+
+    val params = JsonObject().apply { addProperty("streamId", "Service") }
+    dtdProcess.sendRequest("streamListen", params, includeSecret = true) { response ->
+      responseRef.set(response)
+      responseReceived.countDown()
+    }
+
+    assertTrue(
+      "No response from streamListen within ${RESPONSE_TIMEOUT_SECONDS}s",
+      responseReceived.await(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    )
+
+    val response = responseRef.get()
+    assertNotNull("Response should not be null", response)
+    response!!
+
+    assertNotNull("Response should carry an id", response["id"])
+
+    val result = response["result"]
+    assertNotNull("Response should carry a result", result)
+    assertTrue("Result should be a JSON object", result.isJsonObject)
+
+    val type = result.asJsonObject["type"]?.asString
+    assertEquals("streamListen result type", "Success", type)
+  }
+
+  fun testConcurrentRequests() {
+    startDtdProcessAndAwaitSocketOpen()
+
+    val n = CONCURRENT_REQUESTS_COUNT
+    val streamPrefix = "DTDProcessTest_${UUID.randomUUID()}"
+    val responses = ConcurrentHashMap<Int, JsonObject>()
+    val allReceived = CountDownLatch(n)
+
+    for (i in 0 until n) {
+      val params = JsonObject().apply { addProperty("streamId", "${streamPrefix}_$i") }
+      dtdProcess.sendRequest("streamListen", params, includeSecret = true) { response ->
+        responses[i] = response
+        allReceived.countDown()
+      }
+    }
+
+    assertTrue(
+      "Did not receive all $n responses within ${CONCURRENT_REQUESTS_TIMEOUT_SECONDS}s " +
+      "(received ${n - allReceived.count})",
+      allReceived.await(CONCURRENT_REQUESTS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    )
+
+    assertEquals("Each request should produce exactly one response", n, responses.size)
+    for (i in 0 until n) {
+      val response = responses[i]
+      assertNotNull("Missing response for request $i", response)
+      response!!
+
+      val result = response["result"]
+      assertNotNull("Response $i missing result", result)
+      assertTrue("Response $i result should be a JSON object", result.isJsonObject)
+
+      val type = result.asJsonObject["type"]?.asString
+      assertEquals("Response $i streamListen result type", "Success", type)
+    }
+  }
+
+  private fun startDtdProcessAndAwaitSocketOpen() {
+    val sdk = DartSdk.getDartSdk(project)
+      ?: error("Dart SDK is not configured for the test project")
+
+    dtdProcess = DTDProcess()
+
+    val socketReady = CountDownLatch(1)
+    dtdProcess.listener = object : DTDProcessListener {
+      override fun onWebSocketOpen() {
+        socketReady.countDown()
+      }
+    }
+
+    dtdProcess.start(sdk)
+    assertTrue(
+      "WebSocket did not open within ${STARTUP_TIMEOUT_SECONDS}s",
+      socketReady.await(STARTUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    )
+  }
+}

--- a/third_party/src/test/java/com/jetbrains/lang/dart/dtd/DTDProcessTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/dtd/DTDProcessTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 package com.jetbrains.lang.dart.dtd
 
 import com.google.gson.JsonObject

--- a/third_party/src/test/java/com/jetbrains/lang/dart/dtd/DTDProcessTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/dtd/DTDProcessTest.kt
@@ -12,116 +12,111 @@ import java.util.concurrent.atomic.AtomicReference
 
 class DTDProcessTest : BasePlatformTestCase() {
 
-  private companion object {
-    const val STARTUP_TIMEOUT_SECONDS = 5L
-    const val RESPONSE_TIMEOUT_SECONDS = 2L
-    const val CONCURRENT_REQUESTS_TIMEOUT_SECONDS = 5L
-    const val CONCURRENT_REQUESTS_COUNT = 10
-  }
-
-  private lateinit var dtdProcess: DTDProcess
-
-  override fun setUp() {
-    super.setUp()
-    DartTestUtils.configureDartSdk(module, myFixture.projectDisposable, true)
-  }
-
-  override fun tearDown() {
-    try {
-      if (::dtdProcess.isInitialized) {
-        dtdProcess.terminate()
-      }
-    }
-    finally {
-      super.tearDown()
-    }
-  }
-
-  fun testRoundTripRequest() {
-    startDtdProcessAndAwaitSocketOpen()
-
-    val responseRef = AtomicReference<JsonObject?>() //AtomicReference is not really necessary
-    val responseReceived = CountDownLatch(1)
-
-    val params = JsonObject().apply { addProperty("streamId", "Service") }
-    dtdProcess.sendRequest("streamListen", params, includeSecret = true) { response ->
-      responseRef.set(response)
-      responseReceived.countDown()
+    private companion object {
+        const val STARTUP_TIMEOUT_SECONDS = 5L
+        const val RESPONSE_TIMEOUT_SECONDS = 2L
+        const val CONCURRENT_REQUESTS_TIMEOUT_SECONDS = 5L
+        const val CONCURRENT_REQUESTS_COUNT = 100
     }
 
-    assertTrue(
-      "No response from streamListen within ${RESPONSE_TIMEOUT_SECONDS}s",
-      responseReceived.await(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-    )
+    private lateinit var dtdProcess: DTDProcess
 
-    val response = responseRef.get()
-    assertNotNull("Response should not be null", response)
-    response!!
-
-    assertNotNull("Response should carry an id", response["id"])
-
-    val result = response["result"]
-    assertNotNull("Response should carry a result", result)
-    assertTrue("Result should be a JSON object", result.isJsonObject)
-
-    val type = result.asJsonObject["type"]?.asString
-    assertEquals("streamListen result type", "Success", type)
-  }
-
-  fun testConcurrentRequests() {
-    startDtdProcessAndAwaitSocketOpen()
-
-    val n = CONCURRENT_REQUESTS_COUNT
-    val streamPrefix = "DTDProcessTest_${UUID.randomUUID()}"
-    val responses = ConcurrentHashMap<Int, JsonObject>()
-    val allReceived = CountDownLatch(n)
-
-    for (i in 0 until n) {
-      val params = JsonObject().apply { addProperty("streamId", "${streamPrefix}_$i") }
-      dtdProcess.sendRequest("streamListen", params, includeSecret = true) { response ->
-        responses[i] = response
-        allReceived.countDown()
-      }
+    override fun setUp() {
+        super.setUp()
+        DartTestUtils.configureDartSdk(module, myFixture.projectDisposable, true)
     }
 
-    assertTrue(
-      "Did not receive all $n responses within ${CONCURRENT_REQUESTS_TIMEOUT_SECONDS}s " +
-      "(received ${n - allReceived.count})",
-      allReceived.await(CONCURRENT_REQUESTS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-    )
-
-    assertEquals("Each request should produce exactly one response", n, responses.size)
-    for (i in 0 until n) {
-      val response = responses[i]
-      assertNotNull("Missing response for request $i", response)
-      response!!
-
-      val result = response["result"]
-      assertNotNull("Response $i missing result", result)
-      assertTrue("Response $i result should be a JSON object", result.isJsonObject)
-
-      val type = result.asJsonObject["type"]?.asString
-      assertEquals("Response $i streamListen result type", "Success", type)
-    }
-  }
-
-  private fun startDtdProcessAndAwaitSocketOpen() {
-    val sdk = DartSdk.getDartSdk(project)
-      ?: error("Dart SDK is not configured for the test project")
-
-    dtdProcess = DTDProcess()
-
-    val socketReady = CountDownLatch(1)
-    dtdProcess.listener = object : DTDProcessListener {
-      override fun onWebSocketOpen() {
-        socketReady.countDown()
-      }
+    override fun tearDown() {
+        try {
+            if (::dtdProcess.isInitialized) {
+                dtdProcess.terminate()
+            }
+        } finally {
+            super.tearDown()
+        }
     }
 
-    dtdProcess.start(sdk)
-    assertTrue(
-      "WebSocket did not open within ${STARTUP_TIMEOUT_SECONDS}s",
-      socketReady.await(STARTUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-    )
-  }
+    fun testRoundTripRequest() {
+        startDtdProcessAndAwaitSocketOpen()
+
+        val responseRef = AtomicReference<JsonObject?>() //AtomicReference is not really necessary
+        val responseReceived = CountDownLatch(1)
+
+        val params = JsonObject().apply { addProperty("streamId", "Service") }
+        dtdProcess.sendRequest("streamListen", params, includeSecret = true) { response ->
+            responseRef.set(response)
+            responseReceived.countDown()
+        }
+
+        assertTrue(
+            "No response from streamListen within ${RESPONSE_TIMEOUT_SECONDS}s",
+            responseReceived.await(RESPONSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        )
+
+        val response = requireNotNull(responseRef.get()) { "Response should not be null" }
+
+        assertNotNull("Response should carry an id", response["id"])
+
+        val result = response["result"]
+        assertNotNull("Response should carry a result", result)
+        assertTrue("Result should be a JSON object", result.isJsonObject)
+
+        val type = result.asJsonObject["type"]?.asString
+        assertEquals("streamListen result type", "Success", type)
+    }
+
+    fun testConcurrentRequests() {
+        startDtdProcessAndAwaitSocketOpen()
+
+        val n = CONCURRENT_REQUESTS_COUNT
+        val streamPrefix = "DTDProcessTest_${UUID.randomUUID()}"
+        val responses = ConcurrentHashMap<Int, JsonObject>()
+        val allReceived = CountDownLatch(n)
+
+        for (i in 0 until n) {
+            val params = JsonObject().apply { addProperty("streamId", "${streamPrefix}_$i") }
+            dtdProcess.sendRequest("streamListen", params, includeSecret = true) { response ->
+                responses[i] = response
+                allReceived.countDown()
+            }
+        }
+
+        assertTrue(
+            "Did not receive all $n responses within ${CONCURRENT_REQUESTS_TIMEOUT_SECONDS}s " +
+                    "(received ${n - allReceived.count})",
+            allReceived.await(CONCURRENT_REQUESTS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        )
+
+        assertEquals("Each request should produce exactly one response", n, responses.size)
+        for (i in 0 until n) {
+            val response = requireNotNull(responses[i]) { "Missing response for request $i" }
+
+            val result = response["result"]
+            assertNotNull("Response $i missing result", result)
+            assertTrue("Response $i result should be a JSON object", result.isJsonObject)
+
+            val type = result.asJsonObject["type"]?.asString
+            assertEquals("Response $i streamListen result type", "Success", type)
+        }
+    }
+
+    private fun startDtdProcessAndAwaitSocketOpen() {
+        val sdk = DartSdk.getDartSdk(project)
+            ?: error("Dart SDK is not configured for the test project")
+
+        dtdProcess = DTDProcess()
+
+        val socketReady = CountDownLatch(1)
+        dtdProcess.listener = object : DTDProcessListener {
+            override fun onWebSocketOpen() {
+                socketReady.countDown()
+            }
+        }
+
+        dtdProcess.start(sdk)
+        assertTrue(
+            "WebSocket did not open within ${STARTUP_TIMEOUT_SECONDS}s",
+            socketReady.await(STARTUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        )
+    }
 }


### PR DESCRIPTION
Related to #423 

## Summary                                                                                                                                                                                      
                                                                    
  Adds `DTDProcessTest`, an integration test that boots a real Dart Tooling Daemon process and exercises `DTDProcess`'s websocket request/response plumbing.                                      
   
  ## What the tests do                                                                                                                                                                            
                                                                    
  Both tests share `startDtdProcessAndAwaitSocketOpen()`, which launches a real `dart tooling-daemon --machine` process via `DTDProcess.start(sdk)` and waits up to 5s for `onWebSocketOpen` to   
  fire.
                                                                                                                                                                                                  
  - **`testRoundTripRequest`** — sends a single `streamListen` request (with the trusted-client secret) and asserts that:
    - a response arrives within 2s,
    - it carries an `id` and a JSON-object `result`,
    - `result.type == "Success"`.

  - **`testConcurrentRequests`** — fires 100 `streamListen` requests in a tight loop, each with a unique `streamId` (`DTDProcessTest_<uuid>_<i>`), and asserts that:                           
    - all 100 responses arrive within 5s,
    - each request produces exactly one response (verified via a `ConcurrentHashMap` keyed by request index),                                                                                     
    - every response has `result.type == "Success"`.                                                                                                                                              
                                                                                                                                                                                                  
    This exercises that `DTDProcess.consumerMap` correctly routes each response back to its caller under load.                                                                                    
                                                                    
  ## How to run                                                                                                                                                                                   
                                                                    
  The tests need a `DART_HOME` environment variable pointing at a Dart SDK (same prerequisite as the analysis-server tests — see `.github/workflows/presubmit.yaml`).                             
   
  From the command line:                                                                                                                                                                          
                                                                    
  ```
  ./gradlew test --tests "com.jetbrains.lang.dart.dtd.DTDProcessTest"
  ```                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                
  In the IDE, the class can be run directly as a JUnit test once `DART_HOME` is configured in the run configuration's environment variables. 
