### PR TITLE
Add version and commit hash to generated zip file

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 // Read ideaVersion from gradle.properties
 val ideaVersion = providers.gradleProperty("ideaVersion").get()
 
-val commitHash = System.getenv("KOKORO_GIT_COMMIT")?.take(7) ?: try {
+val commitHash = System.getenv("KOKORO_GIT_COMMIT")?.takeIf { it.isNotBlank() }?.take(7) ?: try {
     providers.exec {
         commandLine("git", "rev-parse", "--short", "HEAD")
     }.standardOutput.asText.get().trim().take(7)

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -28,6 +28,14 @@ plugins {
 // Read ideaVersion from gradle.properties
 val ideaVersion = providers.gradleProperty("ideaVersion").get()
 
+val commitHash = System.getenv("KOKORO_GIT_COMMIT")?.take(7) ?: try {
+    providers.exec {
+        commandLine("git", "rev-parse", "--short", "HEAD")
+    }.standardOutput.asText.get().trim().take(7)
+} catch (e: Exception) {
+    ""
+}
+
 // Configure project's dependencies
 repositories {
     mavenCentral()
@@ -44,15 +52,7 @@ intellijPlatform {
             val nextMajorVersion = latestVersion.substringBefore('.').toInt() + 1
             val datestamp = DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now())
             val baseVersion = "$nextMajorVersion.0.0-dev.$datestamp"
-
-            val commitHash = System.getenv("KOKORO_GIT_COMMIT") ?: try {
-                providers.exec {
-                    commandLine("git", "rev-parse", "--short", "HEAD")
-                }.standardOutput.asText.get().trim()
-            } catch (e: Exception) {
-                ""
-            }
-            version = if (commitHash.isNotEmpty()) "$baseVersion-${commitHash.take(7)}" else baseVersion
+            version = if (commitHash.isNotEmpty()) "$baseVersion-$commitHash" else baseVersion
         } else {
             version = changelog.getLatest().version
         }
@@ -282,12 +282,29 @@ abstract class PrintVersionTask : org.gradle.api.DefaultTask() {
     @get:org.gradle.api.tasks.Input
     abstract val pluginVersion: org.gradle.api.provider.Property<String>
 
+    @get:org.gradle.api.tasks.Internal
+    abstract val archiveFileName: org.gradle.api.provider.Property<String>
+
     @org.gradle.api.tasks.TaskAction
     fun action() {
-        println(pluginVersion.get())
+        println("Plugin Version: ${pluginVersion.get()}")
+        println("Archive File Name: ${archiveFileName.get()}")
     }
 }
 
 tasks.register<PrintVersionTask>("printVersion") {
     pluginVersion.set(intellijPlatform.pluginConfiguration.version)
+    val buildPluginTask = tasks.named<Zip>("buildPlugin")
+    archiveFileName.set(buildPluginTask.flatMap { it.archiveFileName })
+}
+
+tasks.named<Zip>("buildPlugin") {
+    val v = intellijPlatform.pluginConfiguration.version
+    archiveFileName.set(v.map { versionStr ->
+        if (commitHash.isNotEmpty() && !versionStr.contains(commitHash)) {
+            "Dart-$versionStr-$commitHash.zip"
+        } else {
+            "Dart-$versionStr.zip"
+        }
+    })
 }


### PR DESCRIPTION
One annoying thing about preparing for release is my paranoia about whether I'm uploading the correct file to our drive for our own testing and to the jetbrains site. Many things could help here, but as a quick fix, here I'm adding the version and the last hash to the generated zip file name, so the resulting file is something like `Dart-506.0.0-8b1053e.zip`.