### PR TITLE
[docs] fix integration test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Dev Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fplugins.jetbrains.com%2Fapi%2Fplugins%2F6351%2Fupdates%3Fchannel%3Ddev%26size%3D1&query=%24%5B0%5D.version&label=dev%20release&color=lightgrey)
 
 [![presubmit](https://github.com/flutter/dart-intellij-third-party/actions/workflows/presubmit.yaml/badge.svg)](https://github.com/flutter/dart-intellij-third-party/actions/workflows/presubmit.yaml)
-[![das tests](https://github.com/flutter/dart-intellij-third-party/actions/workflows/das_tests.yaml/badge.svg?label=das%20tests)](https://github.com/flutter/dart-intellij-third-party/actions/workflows/das_tests.yaml)
+[![integration tests](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml/badge.svg?label=das%20tests)](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml)
 
 
 ## Development setup

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Dev Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fplugins.jetbrains.com%2Fapi%2Fplugins%2F6351%2Fupdates%3Fchannel%3Ddev%26size%3D1&query=%24%5B0%5D.version&label=dev%20release&color=lightgrey)
 
 [![presubmit](https://github.com/flutter/dart-intellij-third-party/actions/workflows/presubmit.yaml/badge.svg)](https://github.com/flutter/dart-intellij-third-party/actions/workflows/presubmit.yaml)
-[![integration tests](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml/badge.svg?label=das%20tests)](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml)
+[![integration tests](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml/badge.svg?label=integration%20tests)](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml)
 
 
 ## Development setup


### PR DESCRIPTION
When we renamed `das_tests`, we missed the badge and so we have a broken link in the [README](https://github.com/flutter/dart-intellij-third-party):

<img width="884" height="171" alt="image" src="https://github.com/user-attachments/assets/469ef9d8-3c40-4ba5-9eca-2b5665016593" />

This fixes that.

<img width="974" height="177" alt="image" src="https://github.com/user-attachments/assets/9b765b48-5aea-4e3d-98a2-d733c5d9d071" />


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
