### PR TITLE
Keep name Dart.zip for dev build

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -301,7 +301,9 @@ tasks.register<PrintVersionTask>("printVersion") {
 tasks.named<Zip>("buildPlugin") {
     val v = intellijPlatform.pluginConfiguration.version
     archiveFileName.set(v.map { versionStr ->
-        if (commitHash.isNotEmpty() && !versionStr.contains(commitHash)) {
+        if (project.hasProperty("dev")) {
+            "Dart.zip"
+        } else if (commitHash.isNotEmpty() && !versionStr.contains(commitHash)) {
             "Dart-$versionStr-$commitHash.zip"
         } else {
             "Dart-$versionStr.zip"

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -301,12 +301,14 @@ tasks.register<PrintVersionTask>("printVersion") {
 tasks.named<Zip>("buildPlugin") {
     val v = intellijPlatform.pluginConfiguration.version
     archiveFileName.set(v.map { versionStr ->
-        if (project.hasProperty("dev")) {
-            "Dart.zip"
-        } else if (commitHash.isNotEmpty() && !versionStr.contains(commitHash)) {
-            "Dart-$versionStr-$commitHash.zip"
+        if (project.hasProperty("versionedName")) {
+            if (commitHash.isNotEmpty() && !versionStr.contains(commitHash)) {
+                "Dart-$versionStr-$commitHash.zip"
+            } else {
+                "Dart-$versionStr.zip"
+            }
         } else {
-            "Dart-$versionStr.zip"
+            "Dart.zip"
         }
     })
 }


### PR DESCRIPTION
This was breaking dev build because the dev build looks for `Dart.zip` during the release process. We could change the release process to look for a versioned plugin, but making the default `Dart.zip` is simpler. This way we can also build the plugin locally and not need to worry about deleting old versions ourselves (as it will be replaced).

### Build Instructions

*   **Default Build**
    *   **Command:** `./gradlew buildPlugin`
    *   **Output File:** `build/distributions/Dart.zip`
    *   **Plugin Version:** `506.0.0` (example)
    *   **Description:** Builds the plugin with the release version and the default filename.

*   **Dev Build (Default filename)**
    *   **Command:** `./gradlew buildPlugin -Pdev`
    *   **Output File:** `build/distributions/Dart.zip`
    *   **Plugin Version:** `507.0.0-dev.20260604-ba2510d` (example)
    *   **Description:** Builds the plugin with a development version (including timestamp and commit hash) but keeps the default filename.

*   **Default Build with Versioned Filename**
    *   **Command:** `./gradlew buildPlugin -PversionedName`
    *   **Output File:** `build/distributions/Dart-506.0.0-ba2510d.zip` (example)
    *   **Plugin Version:** `506.0.0` (example)
    *   **Description:** Builds the plugin with the release version and includes the version and commit hash in the filename.

*   **Dev Build with Versioned Filename**
    *   **Command:** `./gradlew buildPlugin -Pdev -PversionedName`
    *   **Output File:** `build/distributions/Dart-507.0.0-dev.20260604-ba2510d.zip` (example)
    *   **Plugin Version:** `507.0.0-dev.20260604-ba2510d` (example)
    *   **Description:** Builds the plugin with a development version and includes that version info in the filename.