### PR TITLE
[perf] background DTD process creation

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Removed
 
 ### Fixed
+- Avoid UI thread freezes by moving DTD process creation to a pooled thread (#437)
 - Avoid UI thread freezes during project startup by batch-updating module root directory exclusions for `pubspec.yaml` files (#149)
 - Avoid AssertionErrors / UI crashes when navigating subclasses, superclasses, or overriding methods by migrating from deprecated `PsiElementListNavigator` to modern `PsiTargetNavigator`.
 - Avoid potential NullPointerExceptions in the indexer when recovering from malformed class declarations (#375)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
@@ -226,7 +226,14 @@ private object AnalyticsConfigurationManager {
           }
         }
       }
-      dtdProcess.start(sdk)
+      ApplicationManager.getApplication().executeOnPooledThread {
+        try {
+          dtdProcess.start(sdk)
+        } catch (e: Exception) {
+          logger.warn("Failed to start DTD process", e)
+          initLatch.countDown()
+        }
+      }
     }
 
     try {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
@@ -229,8 +229,8 @@ private object AnalyticsConfigurationManager {
       ApplicationManager.getApplication().executeOnPooledThread {
         try {
           dtdProcess.start(sdk)
-        } catch (e: Exception) {
-          logger.warn("Failed to start DTD process", e)
+        } catch (t: Throwable) {
+          logger.warn("Failed to start DTD process", t)
           initLatch.countDown()
         }
       }


### PR DESCRIPTION
The rub is we're seeing UI freezes thanks to synchronous DTD process creation. This fixes that by moving the `DTDProcess.start(sdk)` call to a background pooled thread. 

**Details:** Previously, starting the OS process synchronously during `Analytics.getConfiguration` could hold up a Read Action if the process took a long time to start (e.g. 55s as reported in #437), which completely froze the UI thread. Offloading process creation allows the calling thread to safely hit the 700ms timeout and fallback if the process is slow.

Fixes: #437

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
