### PR TITLE
[perf] background cache invalidation

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Removed
 
 ### Fixed
+- Avoid UI thread freezes during 'Invalidate Caches' by performing dartServer cache deletion asynchronously (#106)
 - Avoid UI thread freezes by moving DTD process creation to a pooled thread (#437)
 - Avoid UI thread freezes during project startup by batch-updating module root directory exclusions for `pubspec.yaml` files (#149)
 - Avoid AssertionErrors / UI crashes when navigating subclasses, superclasses, or overriding methods by migrating from deprecated `PsiElementListNavigator` to modern `PsiTargetNavigator`.

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DASSCacheInvalidator.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DASSCacheInvalidator.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.caches.CachesInvalidator
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.SystemInfoRt
 import com.jetbrains.lang.dart.DartBundle
+import com.intellij.openapi.util.io.FileUtil
 import java.io.File
 
 /**
@@ -26,7 +27,7 @@ private class DASSCacheInvalidator : CachesInvalidator() {
         }
         val dartServerCacheDirectory = getDartServerCacheDirectory()
         if (dartServerCacheDirectory != null && dartServerCacheDirectory.exists()) {
-            dartServerCacheDirectory.deleteRecursively()
+            FileUtil.asyncDelete(dartServerCacheDirectory)
         }
     }
 


### PR DESCRIPTION
Cache invalidation was causing UI freezes thanks to a synchronous `deleteRecursively()` call in `DASSCacheInvalidator`. This fixes that.

**Details:**  Previously, deleting the large `~/.dartServer` directory synchronously during the "Invalidate and Restart" action would completely freeze the IDE's UI thread. Using `asyncDelete` instantly renames the directory out of the way and schedules the heavy I/O deletion on a background thread, preventing the UI lock-up.

Fixes: #106

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
