### PR TITLE
Supports configuring Dart SDK as a folder path within the WSL

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -69,6 +69,7 @@ import com.jetbrains.lang.dart.logging.PluginLogger;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkUpdateChecker;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
@@ -2112,28 +2113,37 @@ public final class DartAnalysisServerService implements Disposable {
     synchronized (myLock) {
       mySdkHome = sdk.getHomePath();
 
-      final String runtimePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk));
+      final boolean isWslSdk = DartWslUtil.isWslSdkPath(mySdkHome);
+      final String runtimePath = isWslSdk
+        ? DartWslUtil.getLinuxDartExePath(mySdkHome)
+        : FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk));
 
       // If true, then the DAS will be started via `dart language-server`, instead of `dart .../analysis_server.dart.snapshot`
       final boolean useDartLangServerCall = isDartSdkVersionSufficientForDartLangServer(sdk);
 
-      String analysisServerPath = FileUtil.toSystemDependentName(mySdkHome + "/bin/snapshots/analysis_server.dart.snapshot");
+      String linuxSdkHome = isWslSdk ? DartWslUtil.toLinuxPath(mySdkHome) : null;
+      String analysisServerPath = isWslSdk && linuxSdkHome != null
+        ? linuxSdkHome + "/bin/snapshots/analysis_server.dart.snapshot"
+        : FileUtil.toSystemDependentName(mySdkHome + "/bin/snapshots/analysis_server.dart.snapshot");
       analysisServerPath = System.getProperty("dart.server.path", analysisServerPath);
 
       String dasStartupErrorMessage = "";
-      final File runtimePathFile = new File(runtimePath);
-      final File dasSnapshotFile = new File(analysisServerPath);
-      if (!runtimePathFile.exists()) {
-        dasStartupErrorMessage = DartBundle.message("dart.vm.file.does.not.exist.at.0", runtimePath);
-      }
-      else if (!useDartLangServerCall && !dasSnapshotFile.exists()) {
-        dasStartupErrorMessage = DartBundle.message("analysis.server.snapshot.file.does.not.exist.at.0", analysisServerPath);
-      }
-      else if (!runtimePathFile.canExecute()) {
-        dasStartupErrorMessage = DartBundle.message("dart.vm.file.is.not.executable.at.0", runtimePath);
-      }
-      else if (!useDartLangServerCall && !dasSnapshotFile.canRead()) {
-        dasStartupErrorMessage = DartBundle.message("analysis.server.snapshot.file.is.not.readable.at.0", analysisServerPath);
+      // For WSL SDKs, skip local file system checks - the binary runs inside WSL
+      if (!isWslSdk) {
+        final File runtimePathFile = new File(runtimePath);
+        final File dasSnapshotFile = new File(analysisServerPath);
+        if (!runtimePathFile.exists()) {
+          dasStartupErrorMessage = DartBundle.message("dart.vm.file.does.not.exist.at.0", runtimePath);
+        }
+        else if (!useDartLangServerCall && !dasSnapshotFile.exists()) {
+          dasStartupErrorMessage = DartBundle.message("analysis.server.snapshot.file.does.not.exist.at.0", analysisServerPath);
+        }
+        else if (!runtimePathFile.canExecute()) {
+          dasStartupErrorMessage = DartBundle.message("dart.vm.file.is.not.executable.at.0", runtimePath);
+        }
+        else if (!useDartLangServerCall && !dasSnapshotFile.canRead()) {
+          dasStartupErrorMessage = DartBundle.message("analysis.server.snapshot.file.is.not.readable.at.0", analysisServerPath);
+        }
       }
 
       if (!dasStartupErrorMessage.isEmpty()) {
@@ -2178,9 +2188,27 @@ public final class DartAnalysisServerService implements Disposable {
       }
 
       String firstArgument = useDartLangServerCall ? "language-server" : analysisServerPath;
-      myServerSocket =
-        new StdioServerSocket(runtimePath, StringUtil.split(vmArgsRaw, " "), firstArgument, StringUtil.split(serverArgsRaw, " "),
-                              debugStream);
+      if (isWslSdk) {
+        // For WSL, launch via wsl.exe with the Linux dart binary
+        String wslRuntimePath = "wsl";
+        List<String> wslArgs = new ArrayList<>();
+        wslArgs.add(runtimePath); // e.g., /usr/lib/dart/bin/dart
+        if (!vmArgsRaw.isEmpty()) {
+          wslArgs.addAll(StringUtil.split(vmArgsRaw, " "));
+        }
+        wslArgs.add(firstArgument);
+        if (!serverArgsRaw.isEmpty()) {
+          wslArgs.addAll(StringUtil.split(serverArgsRaw, " "));
+        }
+        myServerSocket =
+          new StdioServerSocket(wslRuntimePath, Collections.emptyList(), wslArgs.get(0),
+                                wslArgs.subList(1, wslArgs.size()), debugStream);
+      }
+      else {
+        myServerSocket =
+          new StdioServerSocket(runtimePath, StringUtil.split(vmArgsRaw, " "), firstArgument, StringUtil.split(serverArgsRaw, " "),
+                                debugStream);
+      }
       myServerSocket.setClientId(getClientId());
       myServerSocket.setClientVersion(getClientVersion());
 
@@ -2659,10 +2687,22 @@ public final class DartAnalysisServerService implements Disposable {
   public String getLocalFileUri(@NotNull String localFilePath) {
     if (!isDartSdkVersionSufficientForFileUri(mySdkVersion)) {
       // prior to Dart SDK 3.4, the protocol required file paths instead of URIs
+      if (DartWslUtil.isWslSdkPath(mySdkHome)) {
+        // For WSL SDKs, return Linux-style paths for older SDK versions
+        String linuxPath = DartWslUtil.toLinuxPath(localFilePath);
+        return linuxPath != null ? linuxPath : localFilePath;
+      }
       return FileUtil.toSystemDependentName(localFilePath);
     }
 
-    String escapedPath = URLUtil.encodePath(FileUtil.toSystemIndependentName(localFilePath));
+    // For WSL SDKs, convert Windows paths to Linux paths before creating the URI
+    String pathForUri = localFilePath;
+    if (DartWslUtil.isWslSdkPath(mySdkHome)) {
+      String linuxPath = DartWslUtil.toLinuxPathFromWindows(localFilePath);
+      if (linuxPath != null) pathForUri = linuxPath;
+    }
+
+    String escapedPath = URLUtil.encodePath(FileUtil.toSystemIndependentName(pathForUri));
     String url = VirtualFileManager.constructUrl(URLUtil.FILE_PROTOCOL, escapedPath);
     URI uri = VfsUtil.toUri(url);
     return uri != null ? uri.toString() : url;

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
@@ -8,6 +8,8 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.io.OSAgnosticPathUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.lang.dart.sdk.DartSdk
+import com.jetbrains.lang.dart.sdk.DartWslUtil
 import java.net.URI
 import java.net.URISyntaxException
 
@@ -34,6 +36,14 @@ fun getDartFileInfo(project: Project, filePathOrUri: String): DartFileInfo = whe
     var path = URI(filePathOrUri).path
     if (SystemInfo.isWindows && path.length >= 3 && path[0] == '/' && OSAgnosticPathUtil.startsWithWindowsDrive(path.substring(1))) {
       path = path.substring(1)
+    }
+    // When DAS runs in WSL, file URIs contain Linux paths even on Windows host.
+    // Convert Linux paths to UNC WSL paths so LocalFileSystem can find them.
+    if (SystemInfo.isWindows && path.startsWith("/") && DartWslUtil.isWslAvailable()) {
+      val sdk = DartSdk.getDartSdk(project)
+      val distroName = sdk?.homePath?.let { DartWslUtil.getWslDistroName(it) }
+      val uncPath = DartWslUtil.toWindowsUncPath(path, distroName)
+      if (uncPath != null) path = uncPath
     }
     DartLocalFileInfo(path)
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartServerRootsHandler.java
@@ -20,6 +20,7 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.io.URLUtil;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import com.jetbrains.lang.dart.util.DartBuildFileUtil;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.jetbrains.annotations.NotNull;
@@ -85,15 +86,28 @@ public class DartServerRootsHandler {
       newExcludedRootPaths.add(dotIdeaPath);
     }
 
+    final boolean isWslSdk = DartWslUtil.isWslSdkPath(sdk.getHomePath());
+
     for (Module module : DartSdkLibUtil.getModulesWithDartSdkEnabled(myProject)) {
       for (ContentEntry contentEntry : ModuleRootManager.getInstance(module).getContentEntries()) {
         final String contentEntryUrl = contentEntry.getUrl();
         if (contentEntryUrl.startsWith(URLUtil.FILE_PROTOCOL + URLUtil.SCHEME_SEPARATOR)) {
-          newIncludedRootPaths.add(VfsUtilCore.urlToPath(contentEntryUrl));
+          String rootPath = VfsUtilCore.urlToPath(contentEntryUrl);
+          // When running DAS in WSL, convert paths to Linux format
+          if (isWslSdk) {
+            String linuxPath = DartWslUtil.toLinuxPathFromWindows(rootPath);
+            if (linuxPath != null) rootPath = linuxPath;
+          }
+          newIncludedRootPaths.add(rootPath);
           for (String excludedUrl : contentEntry.getExcludeFolderUrls()) {
             // Analysis Server knows about special 'packages' folders, IDE doesn't need to explicitly list them as excluded.
             if (excludedUrl.startsWith(contentEntryUrl) && !excludedUrl.endsWith("/packages")) {
-              newExcludedRootPaths.add(VfsUtilCore.urlToPath(excludedUrl));
+              String excludedPath = VfsUtilCore.urlToPath(excludedUrl);
+              if (isWslSdk) {
+                String linuxPath = DartWslUtil.toLinuxPathFromWindows(excludedPath);
+                if (linuxPath != null) excludedPath = linuxPath;
+              }
+              newExcludedRootPaths.add(excludedPath);
             }
           }
         }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
@@ -25,6 +25,7 @@ import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonRequestHandler
 import com.jetbrains.lang.dart.logging.PluginLogger
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
+import com.jetbrains.lang.dart.sdk.DartWslUtil
 import com.jetbrains.lang.dart.websocket.WebSocketEventHandler
 import com.jetbrains.lang.dart.websocket.WebSocketException
 import com.jetbrains.lang.dart.websocket.WebSocketMessage
@@ -126,10 +127,16 @@ class DTDProcess {
 
   fun start(sdk: DartSdk) {
     val commandLine = GeneralCommandLine().withWorkDirectory(sdk.homePath)
-    commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
-    commandLine.charset = StandardCharsets.UTF_8
-    commandLine.addParameter("tooling-daemon")
-    commandLine.addParameter("--machine")
+    if (DartWslUtil.isWslSdkPath(sdk.homePath)) {
+      val linuxExePath = DartWslUtil.getLinuxDartExePath(sdk.homePath)
+      DartWslUtil.configureWslExecution(commandLine, linuxExePath, "tooling-daemon", "--machine")
+    }
+    else {
+      commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+      commandLine.charset = StandardCharsets.UTF_8
+      commandLine.addParameter("tooling-daemon")
+      commandLine.addParameter("--machine")
+    }
     Analytics.updateEnvironment(commandLine)
 
     osProcessHandler = object : KillableProcessHandler(commandLine) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.kt
@@ -55,6 +55,7 @@ import com.jetbrains.lang.dart.sdk.DartConfigurable
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
+import com.jetbrains.lang.dart.sdk.DartWslUtil
 import com.jetbrains.lang.dart.util.ProcessAdapter
 import com.jetbrains.lang.dart.util.PubspecYamlUtil
 import kotlinx.coroutines.CoroutineScope
@@ -107,20 +108,23 @@ abstract class DartPubActionBase : AnAction(), DumbAware {
 
     if (sdk == null) return
 
-    val exeFile = File(DartSdkUtil.getDartExePath(sdk))
+    // For WSL SDKs, we skip the local file existence check since the binary runs inside WSL
+    if (!DartWslUtil.isWslSdkPath(sdk.homePath)) {
+      val exeFile = File(DartSdkUtil.getDartExePath(sdk))
 
-    if (!exeFile.isFile) {
-      if (allowModalDialogs) {
-        val answer = Messages.showDialog(module.project,
-                                         DartBundle.message("dart.sdk.bad.dartpub.path", exeFile.path),
-                                         getTitle(pubspecYamlFile),
-                                         arrayOf(DartBundle.message("setup.dart.sdk"), CommonBundle.getCancelButtonText()),
-                                         Messages.OK,
-                                         Messages.getErrorIcon())
-        if (answer == Messages.OK) DartConfigurable.openDartSettings(module.project)
+      if (!exeFile.isFile) {
+        if (allowModalDialogs) {
+          val answer = Messages.showDialog(module.project,
+                                           DartBundle.message("dart.sdk.bad.dartpub.path", exeFile.path),
+                                           getTitle(pubspecYamlFile),
+                                           arrayOf(DartBundle.message("setup.dart.sdk"), CommonBundle.getCancelButtonText()),
+                                           Messages.OK,
+                                           Messages.getErrorIcon())
+          if (answer == Messages.OK) DartConfigurable.openDartSettings(module.project)
+        }
+
+        return
       }
-
-      return
     }
 
     val pubParameters = calculatePubParameters(module.project, pubspecYamlFile)
@@ -192,8 +196,14 @@ abstract class DartPubActionBase : AnAction(), DumbAware {
 
     @JvmStatic
     fun setupPubExePath(commandLine: GeneralCommandLine, dartSdk: DartSdk) {
-      commandLine.withExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(dartSdk)))
-      commandLine.addParameter("pub")
+      if (DartWslUtil.isWslSdkPath(dartSdk.homePath)) {
+        val linuxExePath = DartWslUtil.getLinuxDartExePath(dartSdk.homePath)
+        DartWslUtil.configureWslExecution(commandLine, linuxExePath, "pub")
+      }
+      else {
+        commandLine.withExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(dartSdk)))
+        commandLine.addParameter("pub")
+      }
     }
 
     @JvmStatic

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/devtools/DartDevToolsService.kt
@@ -20,6 +20,7 @@ import com.jetbrains.lang.dart.analytics.Analytics
 import com.jetbrains.lang.dart.logging.PluginLogger
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
+import com.jetbrains.lang.dart.sdk.DartWslUtil
 import java.nio.charset.StandardCharsets
 
 @Service(Service.Level.PROJECT)
@@ -40,11 +41,18 @@ class DartDevToolsService(private val myProject: Project) : Disposable {
     val sdk = DartSdk.getDartSdk(myProject)?.takeIf { isDartSdkVersionSufficient(it) } ?: return
 
     val commandLine = GeneralCommandLine().withWorkDirectory(sdk.homePath)
-    commandLine.charset = StandardCharsets.UTF_8
-    commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
-    commandLine.addParameter("devtools")
-    commandLine.addParameter("--machine")
-    dtdUri?.let { commandLine.addParameter("--dtd-uri=$it") }
+    if (DartWslUtil.isWslSdkPath(sdk.homePath)) {
+      val linuxExePath = DartWslUtil.getLinuxDartExePath(sdk.homePath)
+      DartWslUtil.configureWslExecution(commandLine, linuxExePath, "devtools", "--machine")
+      dtdUri?.let { commandLine.addParameter("--dtd-uri=$it") }
+    }
+    else {
+      commandLine.charset = StandardCharsets.UTF_8
+      commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+      commandLine.addParameter("devtools")
+      commandLine.addParameter("--machine")
+      dtdUri?.let { commandLine.addParameter("--dtd-uri=$it") }
+    }
 
     Analytics.updateEnvironment(commandLine)
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartConsoleFilter.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartConsoleFilter.java
@@ -14,6 +14,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.io.URLUtil;
 import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,7 +57,14 @@ public class DartConsoleFilter implements Filter {
     final VirtualFile file = switch (info.type) {
       case FILE -> {
         String path = URLUtil.unescapePercentSequences(info.path);
-        if (SystemInfo.isWindows) {
+        // When Dart runs in WSL, file paths are Linux-style even on Windows
+        if (mySdk != null && DartWslUtil.isWslSdkPath(mySdk.getHomePath())) {
+          String distroName = DartWslUtil.getWslDistroName(mySdk.getHomePath());
+          String uncPath = DartWslUtil.toWindowsUncPath(path, distroName);
+          yield uncPath != null ? LocalFileSystem.getInstance().findFileByPath(uncPath)
+                                : LocalFileSystem.getInstance().findFileByPath(path);
+        }
+        else if (SystemInfo.isWindows) {
           path = StringUtil.trimLeading(path, '/');
         }
         yield LocalFileSystem.getInstance().findFileByPath(path);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartPositionInfo.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartPositionInfo.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -219,12 +220,15 @@ public class DartPositionInfo {
   }
 
   // trim all leading slashes on windows or all except one on Mac/Linux
+  // When running Dart in WSL, paths are Linux-style even on Windows
   private static int getPathStartIndex(final @NotNull String text) {
     if (text.isEmpty() || text.charAt(0) != '/') return 0;
 
     int index = 0;
     while (index < text.length() && text.charAt(index) == '/') index++;
 
+    // In WSL mode, keep one leading slash (Linux path)
+    if (SystemInfo.isWindows && DartWslUtil.isWslAvailable()) return index - 1;
     return SystemInfo.isWindows ? index : index - 1;
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunnerParameters.java
@@ -15,6 +15,7 @@ import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -131,7 +132,22 @@ public class DartCommandLineRunnerParameters implements Cloneable {
       throw new RuntimeConfigurationError(DartBundle.message("path.to.dart.file.not.set"));
     }
 
-    final VirtualFile dartFile = LocalFileSystem.getInstance().findFileByPath(myFilePath);
+    VirtualFile dartFile = LocalFileSystem.getInstance().findFileByPath(myFilePath);
+    // For WSL paths, try converting to UNC path if not found directly
+    if (dartFile == null && DartWslUtil.isWslAvailable()) {
+      String linuxPath = DartWslUtil.toLinuxPath(myFilePath);
+      if (linuxPath != null) {
+        // Already a UNC WSL path, should work
+      }
+      else {
+        // Try converting a Linux-style path to UNC
+        String uncPath = DartWslUtil.toWindowsUncPath(myFilePath);
+        if (uncPath != null) {
+          dartFile = LocalFileSystem.getInstance().findFileByPath(uncPath);
+        }
+      }
+    }
+
     if (dartFile == null) {
       throw new RuntimeConfigurationError(DartBundle.message("dart.file.not.found", FileUtil.toSystemDependentName(myFilePath)));
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunningState.java
@@ -34,6 +34,7 @@ import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.base.DartRunConfiguration;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -171,6 +172,11 @@ public class DartCommandLineRunningState extends CommandLineState {
   }
 
   protected void setupExePath(@NotNull GeneralCommandLine commandLine, @NotNull DartSdk sdk) {
+    if (DartWslUtil.isWslSdkPath(sdk.getHomePath())) {
+      final String linuxExePath = DartWslUtil.getLinuxDartExePath(sdk.getHomePath());
+      DartWslUtil.configureWslExecution(commandLine, linuxExePath);
+      return;
+    }
     commandLine.setExePath(DartSdkUtil.getDartExePath(sdk));
   }
 
@@ -241,7 +247,14 @@ public class DartCommandLineRunningState extends CommandLineState {
       throw new ExecutionException(e);
     }
 
-    commandLine.addParameter(FileUtil.toSystemDependentName(dartFile.getPath()));
+    final DartSdk sdk = DartSdk.getDartSdk(getEnvironment().getProject());
+    if (sdk != null && DartWslUtil.isWslSdkPath(sdk.getHomePath())) {
+      String linuxPath = DartWslUtil.toLinuxPathFromWindows(dartFile.getPath());
+      commandLine.addParameter(linuxPath != null ? linuxPath : dartFile.getPath());
+    }
+    else {
+      commandLine.addParameter(FileUtil.toSystemDependentName(dartFile.getPath()));
+    }
   }
 
   protected void addVmOption(@NotNull DartSdk sdk, @NotNull GeneralCommandLine commandLine, @NotNull String option) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartConsoleFolding.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartConsoleFolding.java
@@ -18,10 +18,13 @@ import java.util.List;
 public final class DartConsoleFolding extends ConsoleFolding {
 
   private static final String DART_MARKER = SystemInfo.isWindows ? "\\bin\\dart.exe " : "/bin/dart ";
+  private static final String DART_MARKER_LINUX = "/bin/dart ";
   private static final String WEBDEV_RUNNER_MARKER = SystemInfo.isWindows
                                                      ? "\\bin\\pub.bat global run webdev daemon " : "/bin/pub global run webdev daemon ";
+  private static final String WEBDEV_RUNNER_MARKER_LINUX = "/bin/pub global run webdev daemon ";
   private static final String TEST_RUNNER_MARKER = SystemInfo.isWindows
                                                    ? "\\bin\\pub.bat run test -r json " : "/bin/pub run test -r json ";
+  private static final String TEST_RUNNER_MARKER_LINUX = "/bin/pub run test -r json ";
   private static final int MIN_FRAME_DISPLAY_COUNT = 8;
 
   private int myFrameCount = 0;
@@ -47,8 +50,11 @@ public final class DartConsoleFolding extends ConsoleFolding {
     if (line.startsWith(DartConsoleFilter.OBSERVATORY_LISTENING_ON) || line.startsWith(DartConsoleFilter.DART_VM_LISTENING_ON)) return true;
 
     int index = line.indexOf(DART_MARKER);
+    if (index < 0) index = line.indexOf(DART_MARKER_LINUX);
     if (index < 0) index = line.indexOf(TEST_RUNNER_MARKER);
+    if (index < 0) index = line.indexOf(TEST_RUNNER_MARKER_LINUX);
     if (index < 0) index = line.indexOf(WEBDEV_RUNNER_MARKER);
+    if (index < 0) index = line.indexOf(WEBDEV_RUNNER_MARKER_LINUX);
     if (index < 0) return false;
 
     final String probablySdkPath = line.substring(0, index);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -47,6 +47,7 @@ import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceEv
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceStackFrame;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceSuspendContext;
 import com.jetbrains.lang.dart.ide.runner.server.webdev.DartDaemonParserUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import com.jetbrains.lang.dart.util.DartBazelFileUtil;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
@@ -568,6 +569,17 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     else {
       result.add(uriByIde);
       result.add(threeSlashize(new File(filePath).toURI().toString()));
+    }
+
+    // WSL: also add a Linux-style file URI for Dart running in WSL
+    if (uriByIde.startsWith(DartUrlResolver.FILE_PREFIX) && myCurrentWorkingDirectory != null) {
+      com.jetbrains.lang.dart.sdk.DartSdk dartSdk = com.jetbrains.lang.dart.sdk.DartSdk.getDartSdk(getSession().getProject());
+      if (dartSdk != null && DartWslUtil.isWslSdkPath(dartSdk.getHomePath())) {
+        String linuxPath = DartWslUtil.toLinuxPath(filePath);
+        if (linuxPath != null) {
+          result.add("file:///" + linuxPath);
+        }
+      }
     }
 
     // package: (if applicable)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/VmServiceWrapper.java
@@ -455,7 +455,13 @@ public final class VmServiceWrapper implements Disposable {
     String url = file.getUrl();
     LOG.info("in getResolvedUri. url: " + url);
 
+    // When Dart runs in WSL, file URIs use Linux paths (file:///home/...)
+    // which already have three slashes, so we should not modify them
     if (SystemInfo.isWindows) {
+      if (url.startsWith("file:///") && url.length() > 10 && url.charAt(9) == '/') {
+        // Likely a WSL Linux path like file:///home/user/...
+        return url;
+      }
       // Dart and the VM service use three /'s in file URIs: https://api.dart.dev/stable/2.16.1/dart-core/Uri-class.html.
       return url.replace("file://", "file:///");
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevRunningState.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevRunningState.java
@@ -21,6 +21,7 @@ import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.pubServer.DartWebdev;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.charset.StandardCharsets;

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunningState.java
@@ -36,6 +36,7 @@ import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunningState;
 import com.jetbrains.lang.dart.ide.runner.util.DartTestLocationProvider;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -156,6 +157,11 @@ public class DartTestRunningState extends DartCommandLineRunningState {
 
   @Override
   protected void setupExePath(@NotNull GeneralCommandLine commandLine, @NotNull DartSdk sdk) {
+    if (DartWslUtil.isWslSdkPath(sdk.getHomePath())) {
+      final String linuxExePath = DartWslUtil.getLinuxDartExePath(sdk.getHomePath());
+      DartWslUtil.configureWslExecution(commandLine, linuxExePath);
+      return;
+    }
     commandLine.setExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk)));
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -35,6 +35,7 @@ import com.jetbrains.lang.dart.ide.devtools.DartDevToolsService
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
+import com.jetbrains.lang.dart.sdk.DartWslUtil
 import de.roderick.weberknecht.WebSocket
 import de.roderick.weberknecht.WebSocketEventHandler
 import de.roderick.weberknecht.WebSocketException
@@ -85,10 +86,16 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
     activeLocationChangeEventSupported = DartAnalysisServerService.isDartSdkVersionSufficientForWorkspaceApplyEdits(sdk.version)
 
     val commandLine = GeneralCommandLine().withWorkDirectory(sdk.homePath)
-    commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
-    commandLine.charset = StandardCharsets.UTF_8
-    commandLine.addParameter("tooling-daemon")
-    commandLine.addParameter("--machine")
+    if (DartWslUtil.isWslSdkPath(sdk.homePath)) {
+      val linuxExePath = DartWslUtil.getLinuxDartExePath(sdk.homePath)
+      DartWslUtil.configureWslExecution(commandLine, linuxExePath, "tooling-daemon", "--machine")
+    }
+    else {
+      commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
+      commandLine.charset = StandardCharsets.UTF_8
+      commandLine.addParameter("tooling-daemon")
+      commandLine.addParameter("--machine")
+    }
     Analytics.updateEnvironment(commandLine)
 
     logger.info("Starting Dart Tooling Daemon, sdk ${sdk.version}")

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreate.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartCreate.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -60,11 +61,21 @@ public class DartCreate {
                                              @Nullable String workingDirectory,
                                              int timeoutInSeconds,
                                              String... parameters) throws ExecutionException {
-    final GeneralCommandLine command = new GeneralCommandLine()
-      .withExePath(DartSdkUtil.getDartExePath(sdkRoot))
-      .withWorkDirectory(workingDirectory);
+    final GeneralCommandLine command = new GeneralCommandLine();
 
-    command.addParameter("create");
+    if (DartWslUtil.isWslSdkPath(sdkRoot)) {
+      String linuxExePath = DartWslUtil.getLinuxDartExePath(sdkRoot);
+      DartWslUtil.configureWslExecution(command, linuxExePath, "create");
+    }
+    else {
+      command.setExePath(DartSdkUtil.getDartExePath(sdkRoot));
+      command.addParameter("create");
+    }
+
+    if (workingDirectory != null) {
+      command.withWorkDirectory(workingDirectory);
+    }
+
     command.addParameters(parameters);
 
     Analytics.updateEnvironment(command);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartConfigurable.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartConfigurable.java
@@ -41,6 +41,7 @@ import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.flutter.FlutterUtil;
 import com.jetbrains.lang.dart.lsp.LspMethod;
 import com.jetbrains.lang.dart.ui.BasicComboBoxWithBrowseButton;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -271,7 +272,12 @@ public final class DartConfigurable implements SearchableConfigurable, NoScroll,
   }
 
   private static @NotNull String getTextFromCombo(final @NotNull ComboBox<?> combo) {
-    return FileUtilRt.toSystemIndependentName(combo.getEditor().getItem().toString().trim());
+    String path = combo.getEditor().getItem().toString().trim();
+    // WSL paths use backslashes in Windows but are Linux paths internally
+    if (DartWslUtil.isWslSdkPath(path)) {
+      return path; // Keep WSL UNC paths as-is
+    }
+    return FileUtilRt.toSystemIndependentName(path);
   }
 
   @Override
@@ -288,7 +294,11 @@ public final class DartConfigurable implements SearchableConfigurable, NoScroll,
 
     // reset UI
     myEnableDartSupportCheckBox.setSelected(myDartSupportEnabledInitial);
-    @NlsSafe String sdkInitialPath = mySdkInitial == null ? "" : FileUtilRt.toSystemDependentName(mySdkInitial.getHomePath());
+    @NlsSafe String sdkInitialPath = mySdkInitial == null ? "" : (
+      DartWslUtil.isWslSdkPath(mySdkInitial.getHomePath())
+        ? mySdkInitial.getHomePath()
+        : FileUtilRt.toSystemDependentName(mySdkInitial.getHomePath())
+    );
     mySdkPathComboWithBrowse.getEditor().setItem(sdkInitialPath);
     if (!sdkInitialPath.isEmpty()) {
       ensureComboModelContainsCurrentItem(mySdkPathComboWithBrowse);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartSdkUtil.java
@@ -90,8 +90,12 @@ public final class DartSdkUtil {
       // Suggest default path according to https://dart.dev/get-dart.
       // No need to check folder presence here; even if it doesn't exist - that's the best we can suggest
       @NlsSafe String path = SystemInfo.isMac ? CpuArch.isArm64() ? "/opt/homebrew/opt/dart/libexec"
-                                                                  : "/usr/local/opt/dart/libexec"
-                                              : SystemInfo.isWindows ? "C:\\tools\\dart-sdk"
+                                                                   : "/usr/local/opt/dart/libexec"
+                                              : SystemInfo.isWindows ? (
+                                                DartWslUtil.isWslAvailable()
+                                                  ? DartWslUtil.toWindowsUncPath("/usr/lib/dart")
+                                                  : "C:\\tools\\dart-sdk"
+                                              )
                                                                      : SystemInfo.isLinux ? "/usr/lib/dart"
                                                                                           : null;
       if (path != null) {
@@ -180,6 +184,7 @@ public final class DartSdkUtil {
   public static @Nullable @NlsContexts.Label String getErrorMessageIfWrongSdkRootPath(final @NotNull String sdkRootPath) {
     if (sdkRootPath.isEmpty()) return DartBundle.message("error.path.to.sdk.not.specified");
 
+    // For WSL SDK paths, java.io.File can access \\wsl.localhost\... UNC paths on Windows
     final File sdkRoot = new File(sdkRootPath);
     if (!sdkRoot.isDirectory()) return DartBundle.message("error.folder.specified.as.sdk.not.exists");
 
@@ -193,6 +198,9 @@ public final class DartSdkUtil {
   }
 
   public static @NotNull String getDartExePath(@NotNull String sdkRoot) {
+    if (DartWslUtil.isWslSdkPath(sdkRoot)) {
+      return DartWslUtil.getLinuxDartExePath(sdkRoot);
+    }
     return sdkRoot + (SystemInfo.isWindows ? "/bin/dart.exe" : "/bin/dart");
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartWslUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/sdk/DartWslUtil.java
@@ -1,0 +1,231 @@
+// Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+package com.jetbrains.lang.dart.sdk;
+
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.util.SystemInfo;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Utility class for WSL (Windows Subsystem for Linux) support in the Dart IntelliJ plugin.
+ * <p>
+ * WSL allows running Linux binaries on Windows. When a Dart SDK is installed inside WSL,
+ * the plugin needs to launch processes via WSL and handle path translation between
+ * Windows host paths and Linux guest paths.
+ */
+public final class DartWslUtil {
+
+  private static final String WSL_PATH_PREFIX = "\\\\wsl.localhost\\";
+  private static final String WSL_PATH_PREFIX_LEGACY = "\\\\wsl$\\";
+
+  private static volatile Boolean ourWslAvailable;
+  private static volatile String ourDefaultWslDistro;
+
+  private DartWslUtil() {
+  }
+
+  /**
+   * Returns {@code true} if the given SDK home path is located inside a WSL distribution.
+   * This is determined by checking for the {@code \\\\wsl.localhost\\} or {@code \\\\$\\} UNC path prefix.
+   */
+  public static boolean isWslSdkPath(@Nullable String sdkPath) {
+    if (sdkPath == null || !SystemInfo.isWindows) return false;
+    String normalized = sdkPath.replace('/', '\\');
+    return normalized.startsWith(WSL_PATH_PREFIX) || normalized.startsWith(WSL_PATH_PREFIX_LEGACY);
+  }
+
+  /**
+   * Returns {@code true} if WSL is available on this Windows system.
+   * Checks for the existence of {@code wsl.exe} in the system PATH.
+   */
+  public static boolean isWslAvailable() {
+    if (!SystemInfo.isWindows) return false;
+    Boolean available = ourWslAvailable;
+    if (available == null) {
+      synchronized (DartWslUtil.class) {
+        available = ourWslAvailable;
+        if (available == null) {
+          try {
+            Process process = new ProcessBuilder("wsl", "--status")
+              .redirectErrorStream(true)
+              .start();
+            int exitCode = process.waitFor();
+            process.destroy();
+            available = (exitCode == 0);
+          }
+          catch (Exception e) {
+            available = false;
+          }
+          ourWslAvailable = available;
+        }
+      }
+    }
+    return available;
+  }
+
+  /**
+   * Converts a Windows UNC WSL path (e.g. {@code \\\\wsl.localhost\\Ubuntu\\usr\\lib\\dart})
+   * to the Linux guest path (e.g. {@code /usr/lib/dart}).
+   *
+   * @return the Linux path, or {@code null} if the input is not a WSL UNC path
+   */
+  public static @Nullable String toLinuxPath(@NotNull String wslUncPath) {
+    String normalized = wslUncPath.replace('/', '\\');
+    if (normalized.startsWith(WSL_PATH_PREFIX)) {
+      String remainder = normalized.substring(WSL_PATH_PREFIX.length());
+      int firstSlash = remainder.indexOf('\\');
+      if (firstSlash >= 0) {
+        return "/" + remainder.substring(firstSlash + 1).replace('\\', '/');
+      }
+    }
+    else if (normalized.startsWith(WSL_PATH_PREFIX_LEGACY)) {
+      String remainder = normalized.substring(WSL_PATH_PREFIX_LEGACY.length());
+      int firstSlash = remainder.indexOf('\\');
+      if (firstSlash >= 0) {
+        return "/" + remainder.substring(firstSlash + 1).replace('\\', '/');
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Converts a Linux guest path (e.g. {@code /usr/lib/dart}) to a Windows UNC WSL path
+   * using the default WSL distribution.
+   *
+   * @return the Windows UNC path, or {@code null} if conversion fails
+   */
+  public static @Nullable String toWindowsUncPath(@NotNull String linuxPath) {
+    return toWindowsUncPath(linuxPath, (String)null);
+  }
+
+  public static @Nullable String toWindowsUncPath(@NotNull String linuxPath, @Nullable String distroName) {
+    if (!SystemInfo.isWindows) return null;
+    String distro = distroName != null ? distroName : getDefaultWslDistro();
+    if (distro == null) return null;
+    return "\\\\wsl.localhost\\" + distro + (linuxPath.startsWith("/") ? linuxPath : "/" + linuxPath);
+  }
+
+  /**
+   * Returns the default WSL distribution name, or {@code null} if unavailable.
+   */
+  public static @Nullable String getDefaultWslDistro() {
+    if (!SystemInfo.isWindows) return null;
+    String distro = ourDefaultWslDistro;
+    if (distro == null) {
+      synchronized (DartWslUtil.class) {
+        distro = ourDefaultWslDistro;
+        if (distro == null) {
+          try {
+            Process process = new ProcessBuilder("wsl", "-l", "-v")
+              .redirectErrorStream(true)
+              .start();
+            try (java.io.BufferedReader reader = new java.io.BufferedReader(
+              new java.io.InputStreamReader(process.getInputStream()))) {
+              String line;
+              boolean headerSkipped = false;
+              while ((line = reader.readLine()) != null) {
+                if (!headerSkipped) {
+                  headerSkipped = true;
+                  continue;
+                }
+                // Lines are like: "  Ubuntu           Running         2"
+                // The current default has a star: "* Ubuntu           Running         2"
+                line = line.replace('\u0000', ' ').trim();
+                if (line.startsWith("*")) {
+                  line = line.substring(1).trim();
+                }
+                // The distribution name is the first whitespace-separated token
+                String[] parts = line.split("\\s+");
+                if (parts.length > 0 && !parts[0].isEmpty()) {
+                  distro = parts[0];
+                  break;
+                }
+              }
+            }
+            process.destroy();
+          }
+          catch (Exception e) {
+            // WSL not available or command failed
+          }
+          if (distro == null) {
+            distro = "";
+          }
+          ourDefaultWslDistro = distro;
+        }
+      }
+    }
+    return distro.isEmpty() ? null : distro;
+  }
+
+  /**
+   * Converts a Windows path to the corresponding Linux path inside WSL, if applicable.
+   * If the path is already a Linux path or a UNC WSL path, it is handled accordingly.
+   *
+   * @return the Linux guest path, or {@code null} if the path cannot be converted
+   */
+  public static @Nullable String toLinuxPathFromWindows(@NotNull String windowsPath) {
+    if (!SystemInfo.isWindows) return windowsPath;
+
+    // Already a UNC WSL path
+    String linuxPath = toLinuxPath(windowsPath);
+    if (linuxPath != null) return linuxPath;
+
+    // Already a Linux path
+    if (windowsPath.startsWith("/")) return windowsPath;
+
+    // Standard Windows path like C:\Users\...
+    // WSL mounts Windows drives under /mnt/c, /mnt/d, etc.
+    String normalized = windowsPath.replace('/', '\\');
+    if (normalized.length() >= 2 && normalized.charAt(1) == ':') {
+      char driveLetter = Character.toLowerCase(normalized.charAt(0));
+      if (driveLetter >= 'a' && driveLetter <= 'z') {
+        String rest = normalized.substring(2).replace('\\', '/');
+        return "/mnt/" + driveLetter + rest;
+      }
+    }
+    return null;
+  }
+
+  public static @Nullable String getWslDistroName(@Nullable String path) {
+    if (path == null || !SystemInfo.isWindows) return null;
+    String normalized = path.replace('/', '\\');
+    if (normalized.startsWith(WSL_PATH_PREFIX)) {
+      String remainder = normalized.substring(WSL_PATH_PREFIX.length());
+      int firstSlash = remainder.indexOf('\\');
+      return firstSlash >= 0 ? remainder.substring(0, firstSlash) : remainder;
+    }
+    else if (normalized.startsWith(WSL_PATH_PREFIX_LEGACY)) {
+      String remainder = normalized.substring(WSL_PATH_PREFIX_LEGACY.length());
+      int firstSlash = remainder.indexOf('\\');
+      return firstSlash >= 0 ? remainder.substring(0, firstSlash) : remainder;
+    }
+    return null;
+  }
+
+  /**
+   * Configures a {@link GeneralCommandLine} to execute via WSL.
+   * This sets the exe path to {@code wsl.exe} and prepends the Linux executable path as an argument.
+   */
+  public static void configureWslExecution(@NotNull GeneralCommandLine commandLine,
+                                           @NotNull String linuxExePath,
+                                           @NotNull String... additionalArgs) {
+    commandLine.setExePath("wsl");
+    commandLine.addParameter(linuxExePath);
+    for (String arg : additionalArgs) {
+      commandLine.addParameter(arg);
+    }
+  }
+
+  /**
+   * Returns the Linux-style dart executable path for a WSL SDK.
+   * For a WSL SDK at {@code /usr/lib/dart}, this returns {@code /usr/lib/dart/bin/dart}.
+   */
+  public static @NotNull String getLinuxDartExePath(@NotNull String wslSdkPath) {
+    String linuxPath = toLinuxPath(wslSdkPath);
+    if (linuxPath == null) {
+      // Assume the path is already a Linux path
+      linuxPath = wslSdkPath;
+    }
+    return linuxPath + "/bin/dart";
+  }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/DartUrlResolverImpl.java
@@ -21,6 +21,7 @@ import com.jetbrains.lang.dart.ide.index.DartLibraryIndex;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryProperties;
 import com.jetbrains.lang.dart.sdk.DartPackagesLibraryType;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -126,6 +127,10 @@ public final class DartUrlResolverImpl extends DartUrlResolver {
 
     if (url.startsWith(FILE_PREFIX)) {
       final String path = StringUtil.trimLeading(url.substring(FILE_PREFIX.length()), '/');
+      // When running Dart in WSL, file URIs contain Linux paths even on Windows host
+      if (SystemInfo.isWindows && myDartSdk != null && DartWslUtil.isWslSdkPath(myDartSdk.getHomePath())) {
+        return LocalFileSystem.getInstance().findFileByPath("/" + path);
+      }
       return LocalFileSystem.getInstance().findFileByPath(SystemInfo.isWindows ? path : ("/" + path));
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/PackageConfigFileUtil.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.io.URLUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -179,8 +180,14 @@ public final class PackageConfigFileUtil {
     if (uri.startsWith("file:/")) {
       final String pathAfterSlashes = StringUtil.trimEnd(StringUtil.trimLeading(StringUtil.trimStart(uri, "file:/"), '/'), "/");
       if (SystemInfo.isWindows && !ApplicationManager.getApplication().isUnitTestMode()) {
+        // Check if this is a Linux path from WSL (no Windows drive letter)
         if (pathAfterSlashes.length() > 2 && OSAgnosticPathUtil.startsWithWindowsDrive(pathAfterSlashes)) {
           return pathAfterSlashes;
+        }
+        // WSL: when DAS runs inside WSL, it produces Linux-style file URIs
+        // Convert them to UNC WSL paths that the Windows host can access
+        if (DartWslUtil.isWslAvailable() && pathAfterSlashes.startsWith("/")) {
+          return DartWslUtil.toWindowsUncPath(pathAfterSlashes);
         }
       }
       else {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/PathUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/PathUtil.java
@@ -2,6 +2,7 @@ package com.jetbrains.lang.dart.util;
 
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.OSAgnosticPathUtil;
+import com.jetbrains.lang.dart.sdk.DartWslUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class PathUtil {
@@ -9,6 +10,10 @@ public class PathUtil {
     }
 
     public static boolean isAbsolutePlatformIndependent(@NotNull String path) {
+        // On Windows with WSL, Linux-style absolute paths (starting with /) should also be recognized
+        if (SystemInfo.isWindows && DartWslUtil.isWslAvailable()) {
+            return PathUtil.isWindowsAbsolutePath(path) || PathUtil.isUnixAbsolutePath(path);
+        }
         return (SystemInfo.isWindows && PathUtil.isWindowsAbsolutePath(path))
                 || (!SystemInfo.isWindows && PathUtil.isUnixAbsolutePath(path));
     }


### PR DESCRIPTION
- Fixes https://github.com/flutter/dart-intellij-third-party/issues/243 .
- Supports configuring Dart SDK as a folder path within the WSL.
- The current PR will not break the scenario of launching IntelliJ IDEA via WSLg using WSL and then using Dart plugins within IntelliJ IDEA.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
