### PR TITLE
[fix] primary constructor go to decl / symbol resolution

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Removed
 
 ### Fixed
-- Fix Go to Declaration and symbol resolution for `new` constructor syntax (#450)
+- Support Go to Declaration and symbol resolution for 'new' constructor syntax (#63510)
 
 ## 506.0.0
 

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 
 ### Fixed
+- Fix Go to Declaration and symbol resolution for `new` constructor syntax (#63510)
 
 ## 506.0.0
 

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Removed
 
 ### Fixed
-- Fix Go to Declaration and symbol resolution for `new` constructor syntax (#63510)
+- Fix Go to Declaration and symbol resolution for `new` constructor syntax (#450)
 
 ## 506.0.0
 

--- a/third_party/gen/com/jetbrains/lang/dart/psi/DartNewConstructorDeclaration.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/DartNewConstructorDeclaration.java
@@ -5,7 +5,10 @@ import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
-public interface DartNewConstructorDeclaration extends DartPsiCompositeElement {
+public interface DartNewConstructorDeclaration extends DartComponent {
+
+  @NotNull
+  List<DartComponentName> getComponentNameList();
 
   @Nullable
   DartComponentName getComponentName();

--- a/third_party/gen/com/jetbrains/lang/dart/psi/impl/DartNewConstructorDeclarationImpl.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/impl/DartNewConstructorDeclarationImpl.java
@@ -11,7 +11,7 @@ import static com.jetbrains.lang.dart.DartTokenTypes.*;
 import com.jetbrains.lang.dart.psi.*;
 import com.jetbrains.lang.dart.util.DartPsiImplUtil;
 
-public class DartNewConstructorDeclarationImpl extends DartPsiCompositeElementImpl implements DartNewConstructorDeclaration {
+public class DartNewConstructorDeclarationImpl extends AbstractDartComponentImpl implements DartNewConstructorDeclaration {
 
   public DartNewConstructorDeclarationImpl(@NotNull ASTNode node) {
     super(node);
@@ -28,9 +28,15 @@ public class DartNewConstructorDeclarationImpl extends DartPsiCompositeElementIm
   }
 
   @Override
+  @NotNull
+  public List<DartComponentName> getComponentNameList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, DartComponentName.class);
+  }
+
+  @Override
   @Nullable
   public DartComponentName getComponentName() {
-    return findChildByClass(DartComponentName.class);
+    return DartPsiImplUtil.getComponentName(this);
   }
 
   @Override

--- a/third_party/src/main/java/com/jetbrains/lang/dart/Dart.bnf
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/Dart.bnf
@@ -334,7 +334,9 @@ private classMemberDefinition ::= thisDeclaration
                                 | incompleteDeclaration // not valid according to spec, but we'd like it to be parsed in order to have completion
                                 {recoverWhile="class_member_recover"}
 
-newConstructorDeclaration ::= metadata* 'augment'? ('external' | 'const')* 'new' componentName? formalParameterList initializers? (';' | functionBodyOrNative | redirection)? {pin=4}
+newAsComponentName ::= 'new' {elementType="componentName"}
+newConstructorDeclaration ::= metadata* 'augment'? ('external' | 'const')* newAsComponentName componentName? formalParameterList initializers? (';' | functionBodyOrNative | redirection)?
+{pin=4 mixin="com.jetbrains.lang.dart.psi.impl.AbstractDartComponentImpl" implements="com.jetbrains.lang.dart.psi.DartComponent" methods = [getComponentName]}
 
 thisDeclaration ::= 'this' initializers? (';' | block) {pin=1}
 private class_member_recover ::= !(<<nonStrictID>> | 'this' | 'operator' | '(' | '@' | 'abstract' | 'base' | 'class' | 'const' | 'covariant' |
@@ -351,7 +353,7 @@ methodDeclaration ::= metadata* 'augment'? ('external' | 'static' | 'const')* me
 {pin=4 mixin="com.jetbrains.lang.dart.psi.impl.AbstractDartMethodDeclarationImpl" implements="com.jetbrains.lang.dart.psi.DartComponent"}
 private methodDeclarationPrivate ::= returnType <<methodNameWrapper>> typeParameters? formalParameterList | !untypedFunctionType <<methodNameWrapper>> typeParameters? formalParameterList // todo remove, use functionSignature as in spec
 
-namedConstructorDeclaration ::= metadata* 'augment'? ('external' | 'const')* componentName '.' (componentName | 'new') formalParameterList initializers? (';' | functionBodyOrNative | redirection)?
+namedConstructorDeclaration ::= metadata* 'augment'? ('external' | 'const')* componentName '.' (componentName | newAsComponentName) formalParameterList initializers? (';' | functionBodyOrNative | redirection)?
 {pin=7 mixin="com.jetbrains.lang.dart.psi.impl.AbstractDartComponentImpl" implements="com.jetbrains.lang.dart.psi.DartComponent" methods = [getComponentName]}
 
 initializers ::= ':' superCallOrFieldInitializer (',' superCallOrFieldInitializer)*

--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartComponentType.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartComponentType.java
@@ -101,7 +101,8 @@ public enum DartComponentType {
       return TYPEDEF;
     }
     if (element instanceof DartNamedConstructorDeclaration
-        || element instanceof DartFactoryConstructorDeclaration) {
+        || element instanceof DartFactoryConstructorDeclaration
+        || element instanceof DartNewConstructorDeclaration) {
       return CONSTRUCTOR;
     }
     if (element instanceof DartFunctionFormalParameter

--- a/third_party/src/main/java/com/jetbrains/lang/dart/util/DartPsiImplUtil.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/util/DartPsiImplUtil.java
@@ -160,6 +160,11 @@ public final class DartPsiImplUtil {
     return list.size() == 2 ? list.get(1) : list.size() == 1 ? list.get(0) : null;
   }
 
+  public static @Nullable DartComponentName getComponentName(@NotNull DartNewConstructorDeclaration element) {
+    final List<DartComponentName> list = element.getComponentNameList();
+    return list.size() == 2 ? list.get(1) : list.size() == 1 ? list.get(0) : null;
+  }
+
   public static @Nullable DartReferenceExpression getReferenceExpression(final @NotNull DartType dartType) {
     final DartSimpleType simpleType = dartType.getSimpleType();
     return simpleType == null ? null : simpleType.getReferenceExpression();

--- a/third_party/src/test/java/com/jetbrains/lang/dart/navigation/DartGoToSymbolTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/navigation/DartGoToSymbolTest.java
@@ -70,4 +70,26 @@ public class DartGoToSymbolTest extends DartCodeInsightFixtureTestCase {
     contributor.processNames(names::add, GlobalSearchScope.allScope(getProject()), null);
     assertTrue(names.contains("Foo"));
   }
+
+  public void testGoToSymbolPrimaryConstructors() {
+    myFixture.addFileToProject("constructors.dart",
+                               """
+                               class Foo1 {
+                                 new();
+                               }
+                               class Foo2 {
+                                 Foo2.new();
+                               }
+                               class Foo3 {
+                                 new named();
+                               }
+                               """);
+
+    DartSymbolContributor contributor = new DartSymbolContributor();
+    List<String> names = new ArrayList<>();
+    contributor.processNames(names::add, GlobalSearchScope.allScope(getProject()), null);
+    assertTrue(names.contains("Foo1"));
+    assertTrue(names.contains("Foo2"));
+    assertTrue(names.contains("named"));
+  }
 }


### PR DESCRIPTION
"Go to Declaration" and symbol resolution for `new` constructor declarations weren't working. This fixes that.

Fixes: https://github.com/flutter/dart-intellij-third-party/issues/450

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
