### PR TITLE
Add logs to integration_tests.yaml

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -38,7 +38,7 @@ jobs:
           sdk: ${{ matrix.dart-version }}
 
       - name: Run Integration Tests
-        run: ./gradlew :test --tests "com.jetbrains.dart.*"
+        run: ./gradlew :test --tests "com.jetbrains.dart.*" -PverboseTests
         working-directory: third_party
 
       - name: Upload test results

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
@@ -209,12 +211,12 @@ tasks {
         if (providers.gradleProperty("verboseTests").isPresent) {
             testLogging {
                 events(
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED,
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED,
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED,
+                    TestLogEvent.STARTED,
+                    TestLogEvent.PASSED,
+                    TestLogEvent.FAILED,
+                    TestLogEvent.SKIPPED,
                 )
-                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+                exceptionFormat = TestExceptionFormat.FULL
                 showExceptions = true
                 showCauses = true
                 showStackTraces = true

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -206,6 +206,21 @@ tasks.named("runTarget") {
 tasks {
 
     test {
+        if (providers.gradleProperty("verboseTests").isPresent) {
+            testLogging {
+                events(
+                    org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED,
+                    org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED,
+                    org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,
+                    org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED,
+                )
+                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+                showExceptions = true
+                showCauses = true
+                showStackTraces = true
+            }
+        }
+
         var showDartHomeWarning = false
         val dartSdkPath = System.getenv("DART_HOME")
         if (dartSdkPath != null) {


### PR DESCRIPTION
## Summary

- The changes in build.gradle causes showing more logs if the -verboseTests is present in the command. It shows START when the tests start and will show the result afterwards. In the case of Failure it will also show the exception.
- Add `-PverboseTests` to enable the verbose test.
- The default -i argument only shows SKIPPED tests. (Not STARTED)