### PR TITLE
[infra] report elapsed time for integration tests

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -1,3 +1,8 @@
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestDescriptor
 import org.gradle.api.tasks.testing.TestListener
 import org.gradle.api.tasks.testing.TestResult
@@ -8,8 +13,19 @@ import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
+
+class VerboseTestListener : TestListener, Serializable {
+    override fun beforeSuite(suite: TestDescriptor) {}
+    override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
+    override fun beforeTest(testDescriptor: TestDescriptor) {}
+    override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {
+        val elapsed = result.endTime - result.startTime
+        val testName = testDescriptor.className?.let { "$it.${testDescriptor.name}" }
+            ?: testDescriptor.parent?.name?.let { "$it.${testDescriptor.name}" }
+            ?: testDescriptor.name
+        Logging.getLogger(Test::class.java).lifecycle("Test $testName took ${elapsed}ms")
+    }
+}
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -19,18 +35,7 @@ allprojects {
     tasks.withType<Test> {
         systemProperty("file.encoding", "UTF-8")
         if (providers.gradleProperty("verboseTests").isPresent) {
-            addTestListener(object : TestListener {
-                override fun beforeSuite(suite: TestDescriptor) {}
-                override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
-                override fun beforeTest(testDescriptor: TestDescriptor) {}
-                override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {
-                    val elapsed = result.endTime - result.startTime
-                    val testName = testDescriptor.className?.let { "$it.${testDescriptor.name}" }
-                        ?: testDescriptor.parent?.name?.let { "$it.${testDescriptor.name}" }
-                        ?: testDescriptor.name
-                    logger.lifecycle("Test $testName took ${elapsed}ms")
-                }
-            })
+            addTestListener(VerboseTestListener())
         }
     }
 }

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestResult
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.changelog.Changelog
@@ -15,6 +18,20 @@ allprojects {
     }
     tasks.withType<Test> {
         systemProperty("file.encoding", "UTF-8")
+        if (providers.gradleProperty("verboseTests").isPresent) {
+            addTestListener(object : TestListener {
+                override fun beforeSuite(suite: TestDescriptor) {}
+                override fun afterSuite(suite: TestDescriptor, result: TestResult) {}
+                override fun beforeTest(testDescriptor: TestDescriptor) {}
+                override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {
+                    val elapsed = result.endTime - result.startTime
+                    val testName = testDescriptor.className?.let { "$it.${testDescriptor.name}" }
+                        ?: testDescriptor.parent?.name?.let { "$it.${testDescriptor.name}" }
+                        ?: testDescriptor.name
+                    logger.lifecycle("Test $testName took ${elapsed}ms")
+                }
+            })
+        }
     }
 }
 

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -20,10 +20,7 @@ class VerboseTestListener : TestListener, Serializable {
     override fun beforeTest(testDescriptor: TestDescriptor) {}
     override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) {
         val elapsed = result.endTime - result.startTime
-        val testName = testDescriptor.className?.let { "$it.${testDescriptor.name}" }
-            ?: testDescriptor.parent?.name?.let { "$it.${testDescriptor.name}" }
-            ?: testDescriptor.name
-        Logging.getLogger(Test::class.java).lifecycle("Test $testName took ${elapsed}ms")
+        Logging.getLogger(Test::class.java).lifecycle("took ${elapsed}ms")
     }
 }
 


### PR DESCRIPTION
The idea here is to add elapsed time reporting so that if a run is terminated and no report is uploaded we can look at the log to understand where the time went.

<img width="678" height="271" alt="image" src="https://github.com/user-attachments/assets/69983b03-678c-4bfc-acaf-ac87062210ad" />
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
