### PR TITLE
Initialize Dart Analysis Server early in tests using real SDK

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -2375,7 +2375,13 @@ public final class DartAnalysisServerService implements Disposable {
     assert ApplicationManager.getApplication().isUnitTestMode();
 
     long startTime = System.currentTimeMillis();
-    while (isServerProcessActive() && !myServerData.hasAllData_TESTS_ONLY(file)) {
+    // Wait for up to 300ms for the server to start background analysis/indexing if it hasn't yet.
+    while (isServerProcessActive() && !myAnalysisInProgress && !myServerData.hasAllData_TESTS_ONLY(file)) {
+      if (System.currentTimeMillis() > startTime + 300) break;
+      TimeoutUtil.sleep(20);
+    }
+
+    while (isServerProcessActive() && (!myServerData.hasAllData_TESTS_ONLY(file) || myAnalysisInProgress)) {
       if (System.currentTimeMillis() > startTime + ANALYSIS_IN_TESTS_TIMEOUT) return;
       TimeoutUtil.sleep(100);
     }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/util/DartTestUtils.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/util/DartTestUtils.java
@@ -17,6 +17,7 @@ import com.intellij.psi.PsiDocumentManager;
 import com.intellij.testFramework.IndexingTestUtil;
 import com.intellij.util.PathUtil;
 import com.intellij.util.SmartList;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
 import com.jetbrains.lang.dart.sdk.DartSdkUtil;
@@ -116,6 +117,11 @@ public final class DartTestUtils {
       Disposer.register(disposable, DartSdkLibUtil.enableDartSdkAndReturnUndoingDisposable(module));
     });
     IndexingTestUtil.waitUntilIndexesAreReady(module.getProject());
+    if (realSdk) {
+      ApplicationManager.getApplication().runReadAction(() -> {
+        DartAnalysisServerService.getInstance(module.getProject()).serverReadyForRequest();
+      });
+    }
   }
 
   public static List<CaretPositionInfo> extractPositionMarkers(@NotNull final Project project, @NotNull final Document document) {


### PR DESCRIPTION
### Summary of Changes

This PR resolves a major source of integration test slowness (timeouts) and subsequent race-condition failures.

1. **Early Server Initialization:** 
   Modified `DartTestUtils.configureDartSdk()` to call `serverReadyForRequest()` early during test `setUp()`. Because `TestFileEditorManager` does not automatically fire file-opened events in test mode, starting the server lazily during `doHighlighting()` (inside `DartAnnotator`) missed the initial file open. This left `myVisibleFileUris` empty, preventing subscriptions for outlines/navigation/diagnostics and causing a **10-second timeout** on every test.
2. **Analysis Progress Tracking (Conditional Wait):** 
   Modified `waitForAnalysisToComplete_TESTS_ONLY()` to wait for `myAnalysisInProgress` to become `false`. Additionally, added a short conditional wait loop (polling every 20ms, up to a maximum of 300ms) before the main wait loop to ensure the server has time to register that analysis has started.

---

### Why the Conditional Wait is Necessary

The transition of the server's status to `isAnalyzing = true` is asynchronous. When a test modifies/adds files:
1. The IDE sends updates to the server.
2. The server processes the updates, starts background analysis/indexing, and sends a `server.status` notification with `isAnalyzing = true`.
3. The IDE receives this status and updates `myAnalysisInProgress = true`.

Because of process communication latency, **steps 2 and 3 take up to 50-100ms**. 

If we check `myAnalysisInProgress` immediately, it is still `false`. Since the first fix established subscriptions early, the active file's highlights/outline data arrives almost instantly, allowing the wait loop to exit prematurely. A split-second later, the server starts background indexing the other files in the project, but the test has already proceeded and queried the server, leading to stale or empty results. 

The conditional wait loop polls the server's status for up to 300ms. It exits immediately as soon as the server transitions to `isAnalyzing = true` (usually within 20-40ms) or if the data is already present. This prevents a hardcoded delay while ensuring that tests only run assertions once the server is completely done analyzing.

---

### Run History & Verification

* **Original (Lazy Startup):** Timed out (>25m) on `macos-latest` due to hitting 10s timeouts on every test (such as [this failed run from PR 443](https://github.com/flutter/dart-intellij-third-party/actions/runs/27379526513/job/80912362834?pr=443)).
* **First Version (No Wait/Sleep):** Completed in ~8m but resulted in failures on semantic query tests like call hierarchies ([run logs](https://github.com/flutter/dart-intellij-third-party/actions/runs/27381411191/job/80918763808?pr=468)) because the wait loop exited before background analysis started.
* **Final Version (With Conditional Wait):** All integration tests passed successfully on `macos-latest` in **9 minutes and 27 seconds** ([successful green run](https://github.com/flutter/dart-intellij-third-party/actions/runs/27383418045/job/80925176363?pr=468)) — a **2.5x speedup** with zero timeouts.

---

### What this PR Resolves vs. What it Doesn't

#### What it Resolves:
* **The 10-second wait loop penalty:** Tests no longer hit the artificial 10-second sleep when waiting for server highlights/diagnostics.
* **Race conditions:** Semantic tests (such as call hierarchies, usages, and overrides) no longer query the server before background indexing completes.

#### What it Doesn't Resolve:
* **Process overhead:** Starting the actual external Java/Dart Analysis Server process and re-indexing the SDK on project root changes is still CPU-bound and disk-bound. This is why running tests on a larger machine (like `ubuntu-large` in [this run](https://github.com/flutter/dart-intellij-third-party/actions/runs/27384510825/job/80928541561)) still yields a faster raw execution time (~6.5m) for the remaining parts of the test harness. However, this PR ensures that the tests run correctly under all environments rather than relying on hardware specs to mask the lazy-startup subscription bug.
