### PR TITLE
Remove foojay resolver

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -133,6 +133,9 @@ kotlin {
 }
 
 java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
+    }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }

--- a/third_party/settings.gradle.kts
+++ b/third_party/settings.gradle.kts
@@ -1,5 +1,2 @@
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
-}
 
 rootProject.name = "Dart"


### PR DESCRIPTION
This was initially added for specifying a version of java, which was required for lsp4ij. Since we've removed lsp4ij, I think we should be able to remove foojay resolver as well. Instead, we will just depend on whatever version of java is on the build server and expect that it will be backward compatible.