### PR TITLE
[infra] migrate integration tests to ubuntu-large runner

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         dart-version: ['stable']
-        os: [macos-latest]
+        os: [ubuntu-large]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
 


### PR DESCRIPTION
This has been a bad week for the integration tests.

Gemini summarizes:

> Based on an analysis of the last 20 runs of the "integration tests" workflow in the flutter/dart-intellij-third-party repository, here is the performance breakdown:
>
> Calculated Statistics
> Shortest Duration: 1m 31s (Run #77)
>
> Longest Duration: 25m 30s (Run #79)
>
> Average Duration: ~14m 13s
>
> Total Failed/Cancelled Runs: 11 (4 Failed, 7 Cancelled/Timeout)

The cancelled runs in particular have been messing us up and interfering w/ @JavadAsadi's work.

Historically we've had a lot of trouble here (e.g., https://github.com/flutter/dart-intellij-third-party/issues/260) but I'm not sure we ever tried a different runner?

This change migrates us to `ubuntu-large` over the standard `macos` one.  

The first run clocks in at 6m which is encouraging (considering the average for `macos` was 14m).

We'll have to keep an eye on it but this seems like a good experiment? 🤞 


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
