### PR TITLE
Make IntelliJ LSP Client compilable against 2025.3

### DIFF
--- a/third_party/thirdPartySrc/platform-lsp/resources/dart-lsp-impl.xml
+++ b/third_party/thirdPartySrc/platform-lsp/resources/dart-lsp-impl.xml
@@ -57,7 +57,7 @@
     <platform.backend.documentation.targetProvider
                                                    implementation="com.intellij.platform.dartlsp.impl.features.documentation.LspDocumentationTargetProvider"/>
     <formattingService implementation="com.intellij.platform.dartlsp.impl.features.formatter.LspFormattingService"/>
-    <lang.importOptimizer language="" implementationClass="com.intellij.platform.dartlsp.impl.features.formatter.LspImportOptimizer" order="last"/>
+    <lang.importOptimizer language="Dart" implementationClass="com.intellij.platform.dartlsp.impl.features.formatter.LspImportOptimizer" order="last"/>
     <lang.foldingBuilder language="" implementationClass="com.intellij.platform.dartlsp.impl.features.folding.LspFoldingBuilder"/>
     <gotoSymbolContributor implementation="com.intellij.platform.dartlsp.impl.features.workspaceSymbol.LspGoToSymbolContributor"/>
     <gotoClassContributor implementation="com.intellij.platform.dartlsp.impl.features.workspaceSymbol.LspGoToClassContributor"/>

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/LspServerImpl.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/LspServerImpl.kt
@@ -249,7 +249,7 @@ class LspServerImpl internal constructor(
         val exToLog = (e as? LspInitializationException)?.cause ?: e
         logWarn("Failed to start LSP server", exToLog)
 
-        val lspServerManager = ReadAction.computeBlocking<LspServerManagerImpl?, Throwable> {
+        val lspServerManager = ReadAction.compute<LspServerManagerImpl?, Throwable> {
           if (!project.isDisposed) LspServerManagerImpl.getInstanceImpl(project) else null
         }
         val text = (if (e is LspInitializationException) "$e\nCaused by:\n" else "") + exToLog.stackTraceToString()

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/connector/Lsp4jServerConnector.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/connector/Lsp4jServerConnector.kt
@@ -79,7 +79,7 @@ internal abstract class Lsp4jServerConnector protected constructor(private val l
         }
         finally {
           logger.debug("$descriptor: LSP server listener thread finished")
-          val lspServerManager = ReadAction.computeBlocking<LspServerManagerImpl?, Throwable> {
+          val lspServerManager = ReadAction.compute<LspServerManagerImpl?, Throwable> {
             if (!lspServer.project.isDisposed) LspServerManagerImpl.getInstanceImpl(lspServer.project) else null
           }
           val text = "${descriptor.lspCommunicationChannel.javaClass.simpleName} connection closed"

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/connector/LspServerProcessListenerBase.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/connector/LspServerProcessListenerBase.kt
@@ -14,7 +14,7 @@ internal open class LspServerProcessListenerBase(private val lspServer: LspServe
     val text = "Exit code: ${event.exitCode}\nCommand line: ${event.processHandler}"
     lspServer.logInfo("LSP server process terminated. $text")
 
-    val lspServerManager = ReadAction.computeBlocking<LspServerManagerImpl?, Throwable> {
+    val lspServerManager = ReadAction.compute<LspServerManagerImpl?, Throwable> {
       if (!lspServer.project.isDisposed) LspServerManagerImpl.getInstanceImpl(lspServer.project) else null
     }
     lspServerManager?.handleMaybeUnexpectedServerStop(lspServer, text)

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/codeLens/LspCodeVisionProvider.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/codeLens/LspCodeVisionProvider.kt
@@ -64,5 +64,5 @@ internal class LspCodeVisionProvider : CodeVisionProvider<Unit>, DumbAware {
   override val relativeOrderings: List<CodeVisionRelativeOrdering> = emptyList()
   override val id: String = LSP_CODE_VISION_PROVIDER_ID
   override val name: String = LspBundle.message("codeLens.LspCodeVisionProvider.name")
-  override val singleEntryPerLine: Boolean = false
+  //override val singleEntryPerLine: Boolean = false
 }

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/formatter/LspFormattingService.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/formatter/LspFormattingService.kt
@@ -8,7 +8,7 @@ import com.intellij.formatting.service.FormattingService.Feature
 import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.lang.ImportOptimizer
 import com.intellij.lang.LanguageFormatting
-import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.impl.DocumentImpl
 import com.intellij.openapi.vfs.VirtualFile
@@ -30,15 +30,13 @@ import org.eclipse.lsp4j.TextEdit
 internal class LspFormattingService : AsyncDocumentFormattingService() {
   override fun getName() = LspBundle.message("lsp.based.formatter")
   override fun getNotificationGroupId() = LspServerNotificationsHandlerImpl.SHOW_MESSAGE_NOTIFICATION_GROUP
-  override fun getFeatures() = setOf(Feature.FORMAT_FRAGMENTS, Feature.OPTIMIZE_IMPORTS)
+  override fun getFeatures() = setOf(Feature.FORMAT_FRAGMENTS/*, Feature.OPTIMIZE_IMPORTS*/)
 
   // No need to save the document, LSP servers work fine with unsaved content
   override fun prepareForFormatting(document: Document, formattingContext: FormattingContext): Unit = Unit
 
-  override fun canFormat(psiFile: PsiFile): Boolean = canFormat(psiFile, *emptyArray<Feature>())
-
-  override fun canFormat(psiFile: PsiFile, vararg features: Feature): Boolean {
-    val goal = LspFormattingGoal.getFormattingGoal(features) ?: return false
+  override fun canFormat(psiFile: PsiFile): Boolean {
+    val goal = LspFormattingGoal.FullFileFormatting
     val lspServer: LspServer? = when (goal) {
       LspFormattingGoal.FullFileFormatting -> findServerToFormatThisFile(psiFile, true)
       LspFormattingGoal.RangeFormatting -> findServerToFormatThisFile(psiFile, false)
@@ -164,10 +162,10 @@ internal class LspFormattingService : AsyncDocumentFormattingService() {
   ) : LspFormattingTask(lspServer, file, formattingRequest) {
     override fun fetchTextEdits(): List<TextEdit> {
       val formattingOptions = createFormattingOptions()
-      val document = runReadActionBlocking { formattingRequest.context.containingFile.fileDocument }
+      val document = runReadAction { formattingRequest.context.containingFile.fileDocument }
 
       return formattingRequest.formattingRanges.flatMap { textRange ->
-        val lspDocuments = runReadActionBlocking {
+        val lspDocuments = runReadAction {
           val range = getLsp4jRange(document, textRange.startOffset, textRange.length)
           lspServer.documentMapping.getDocumentRangesSync(file, document, range)
         }

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/formatter/LspImportOptimizer.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/formatter/LspImportOptimizer.kt
@@ -117,7 +117,7 @@ private fun doesOtherFormattingServiceWantToWork(psiFile: PsiFile): Boolean =
     it !is LspFormattingService &&
     it !is CoreFormattingService &&
     it.getFeatures().contains(FormattingService.Feature.OPTIMIZE_IMPORTS) &&
-    it.canFormat(psiFile, FormattingService.Feature.OPTIMIZE_IMPORTS) &&
+    //it.canFormat(psiFile, FormattingService.Feature.OPTIMIZE_IMPORTS) &&
     it.getImportOptimizers(psiFile).any { optimizer -> optimizer !is LspImportOptimizer && optimizer.supports(psiFile) }
   }
 

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/usages/LspUsageSearcher.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/features/usages/LspUsageSearcher.kt
@@ -4,7 +4,7 @@ import com.intellij.find.usages.api.PsiUsage
 import com.intellij.find.usages.api.Usage
 import com.intellij.find.usages.api.UsageSearchParameters
 import com.intellij.find.usages.api.UsageSearcher
-import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.platform.dartlsp.impl.documentMapping
 import com.intellij.platform.dartlsp.impl.mapLocation
@@ -33,9 +33,9 @@ internal class LspUsageSearcher : UsageSearcher {
 private class LspReferencesQuery(private val searchTarget: LspSearchTarget) : AbstractQuery<Usage>() {
   override fun processResults(consumer: Processor<in Usage>): Boolean {
     for (lspServer in searchTarget.lspServers) {
-      val docPosition = runReadActionBlocking {
-        val document = FileDocumentManager.getInstance().getDocument(searchTarget.file) ?: return@runReadActionBlocking null
-        val offset = getOffsetInDocument(document, searchTarget.position) ?: return@runReadActionBlocking null
+      val docPosition = runReadAction {
+        val document = FileDocumentManager.getInstance().getDocument(searchTarget.file) ?: return@runReadAction null
+        val offset = getOffsetInDocument(document, searchTarget.position) ?: return@runReadAction null
         lspServer.documentMapping.getDocumentPosition(searchTarget.file, document, offset)
       } ?: continue
       val documentIdentifier = docPosition.document.id
@@ -49,7 +49,7 @@ private class LspReferencesQuery(private val searchTarget: LspSearchTarget) : Ab
 
       if (resultLocations.isNullOrEmpty()) continue
 
-      runReadActionBlocking {
+      runReadAction {
         val psiManager = PsiManager.getInstance(lspServer.project)
 
         for (resultLocation in resultLocations) {

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/util/LspNavigationUtils.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/util/LspNavigationUtils.kt
@@ -1,7 +1,7 @@
 // Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.intellij.platform.dartlsp.util
 
-import com.intellij.openapi.application.runReadActionBlocking
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
@@ -68,7 +68,7 @@ fun showLspNavigationPopup(server: LspServer, locations: List<Location>, @Nls ti
         }
         icon = file.fileType.icon
 
-        val document = runReadActionBlocking {
+        val document = runReadAction {
           FileDocumentManager.getInstance().getDocument(file)
         }
         val range = value.range


### PR DESCRIPTION
@helin24

This PR makes the code in the `third_party/thirdPartySrc/platform-lsp` folder compilable against Android Studio Panda and IntelliJ IDEA 2025.3. The code stays compilable against 2026.1 and 2026.2.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
