### PR TITLE
Report usage analytics for Dart run and debug sessions

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analytics/Analytics.kt
@@ -9,7 +9,9 @@ package com.jetbrains.lang.dart.analytics
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.intellij.CommonBundle
+import com.intellij.execution.Executor
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.ide.plugins.PluginManagerCore
@@ -284,6 +286,17 @@ object Analytics {
 
   @JvmStatic
   fun report(data: AnalyticsData) = data.reportTo(reporter)
+
+  @JvmStatic
+  fun recordRunOrDebugSession(mechanism: String, executor: Executor, project: Project?) {
+    val type = if (executor.id == DefaultDebugExecutor.EXECUTOR_ID) {
+      AnalyticsConstants.DEBUG_SESSION_TYPE
+    } else {
+      AnalyticsConstants.RUN_SESSION_TYPE
+    }
+    report(SessionData(type, mechanism, project))
+  }
+
   @JvmStatic
   fun updateEnvironment(commandLine: GeneralCommandLine) {
     updateEnvironment(commandLine.environment)
@@ -325,6 +338,9 @@ class LegacyHoverData(id: String?, project: Project?) :
 
 class SettingsData(project: Project?) :
   AnalyticsData(AnalyticsConstants.SETTINGS_TYPE, "settings", project)
+
+class SessionData(type: String, mechanism: String, project: Project?) :
+  AnalyticsData(type, mechanism, project)
 
 abstract class AnalyticsData(type: String, val id: String?, val project: Project? = null) {
   val data = mutableMapOf<String, Any>()
@@ -415,6 +431,13 @@ object AnalyticsConstants {
   internal const val FIX_TYPE = "fix"
   internal const val LEGACY_HOVER_TYPE = "legacy_hover"
   internal const val SETTINGS_TYPE = "settings"
+  internal const val DEBUG_SESSION_TYPE = "debug_session"
+  internal const val RUN_SESSION_TYPE = "run_session"
+
+  const val MECHANISM_APP = "app"
+  const val MECHANISM_TESTS = "tests"
+  const val MECHANISM_REMOTE = "remote"
+  const val MECHANISM_WEB = "web"
 }
 
 sealed class DataValue<T>(val name: String) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunConfiguration.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartCommandLineRunConfiguration.java
@@ -9,6 +9,8 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.PathUtil;
+import com.jetbrains.lang.dart.analytics.Analytics;
+import com.jetbrains.lang.dart.analytics.AnalyticsConstants;
 import com.jetbrains.lang.dart.ide.runner.base.DartRunConfigurationBase;
 import com.jetbrains.lang.dart.ide.runner.server.ui.DartCommandLineConfigurationEditorForm;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +35,7 @@ public class DartCommandLineRunConfiguration extends DartRunConfigurationBase {
 
   @Override
   public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) throws ExecutionException {
+    Analytics.recordRunOrDebugSession(AnalyticsConstants.MECHANISM_APP, executor, getProject());
     return new DartCommandLineRunningState(env);
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartRemoteDebugConfiguration.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/DartRemoteDebugConfiguration.java
@@ -19,6 +19,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.analytics.Analytics;
+import com.jetbrains.lang.dart.analytics.AnalyticsConstants;
 import com.jetbrains.lang.dart.ide.runner.server.ui.DartRemoteDebugConfigurationEditor;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -74,6 +76,7 @@ public class DartRemoteDebugConfiguration extends RunConfigurationBase<Element> 
   @Override
   public @Nullable RunProfileState getState(final @NotNull Executor executor,
                                             final @NotNull ExecutionEnvironment environment) {
+    Analytics.recordRunOrDebugSession(AnalyticsConstants.MECHANISM_REMOTE, executor, getProject());
     return EmptyRunProfileState.INSTANCE;
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfiguration.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfiguration.java
@@ -18,6 +18,8 @@ import com.intellij.util.PathUtil;
 import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.analytics.Analytics;
+import com.jetbrains.lang.dart.analytics.AnalyticsConstants;
 import com.jetbrains.lang.dart.ide.runner.server.ui.DartWebdevConfigurationEditorForm;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -54,6 +56,7 @@ public class DartWebdevConfiguration extends LocatableConfigurationBase<DartWebd
   @Override
   public @Nullable RunProfileState getState(final @NotNull Executor executor,
                                             final @NotNull ExecutionEnvironment env) throws ExecutionException {
+    Analytics.recordRunOrDebugSession(AnalyticsConstants.MECHANISM_WEB, executor, getProject());
     return new DartWebdevRunningState(env);
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunConfiguration.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/test/DartTestRunConfiguration.java
@@ -11,6 +11,8 @@ import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.PathUtil;
 import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.analytics.Analytics;
+import com.jetbrains.lang.dart.analytics.AnalyticsConstants;
 import com.jetbrains.lang.dart.ide.runner.base.DartRunConfigurationBase;
 import com.jetbrains.lang.dart.ide.runner.test.ui.DartTestConfigurationEditorForm;
 import org.jetbrains.annotations.NotNull;
@@ -36,6 +38,7 @@ public class DartTestRunConfiguration extends DartRunConfigurationBase {
 
   @Override
   public @Nullable RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) throws ExecutionException {
+    Analytics.recordRunOrDebugSession(AnalyticsConstants.MECHANISM_TESTS, executor, getProject());
     return new DartTestRunningState(env);
   }
 


### PR DESCRIPTION
I've been looking into using JetBrains DAP, which would allow us to remove usages of the legacy analysis server for file mapping (this functionality does not exist in LSP analysis server because debug adapter in Dart SDK takes care of it). DAP seems promising, but I also want to check the usage of the current run/debug mechanisms. Then if we transition, we will be able to check whether we are getting equivalent usage, and the relative numbers of users may also inform how much time we spend on verifying DAP setups before releasing.