### PR TITLE
Replace Weberknecht with JDK's Websocket in DartToolingDaemonService.kt

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -35,10 +35,10 @@ import com.jetbrains.lang.dart.ide.devtools.DartDevToolsService
 import com.jetbrains.lang.dart.sdk.DartSdk
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
-import de.roderick.weberknecht.WebSocket
-import de.roderick.weberknecht.WebSocketEventHandler
-import de.roderick.weberknecht.WebSocketException
-import de.roderick.weberknecht.WebSocketMessage
+import com.jetbrains.lang.dart.websocket.WebSocket
+import com.jetbrains.lang.dart.websocket.WebSocketEventHandler
+import com.jetbrains.lang.dart.websocket.WebSocketException
+import com.jetbrains.lang.dart.websocket.WebSocketMessage
 import kotlinx.coroutines.CoroutineScope
 import java.net.URI
 import java.nio.charset.StandardCharsets


### PR DESCRIPTION
Solves #481

This PR enables the plugin to handle ping/pong requests. Whether the `commandLine.addParameter("--ping-interval=15")` is needed to be added in the code or just add the ping-interval on the sdk side will be decided later.
