### PR TITLE
Add 2025.2 to CI push triggers (#475)

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - '2025.2'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - '2025.2'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
It's actually this PR that will cause the 2025.2 branch to have test coverage (since this one will be merged to the 2025.2 branch), but gemini suggests it is still useful to have 2025.2 noted in main as a CI branch to hopefully prevent any cherry picks from accidentally deleting it.