### PR TITLE
[2025.2 branch] Restore expected diagnostic in ErrorsAfterEOF.dart

### DIFF
--- a/third_party/src/test/testData/analysisServer/highlighting/ErrorsAfterEOF.dart
+++ b/third_party/src/test/testData/analysisServer/highlighting/ErrorsAfterEOF.dart
@@ -1,1 +1,1 @@
-class Foo implement<error descr="A class declaration must have a body, even if it is empty."><error descr="Expected a type name.">s</error></error>
+class Foo implement<error descr="A class declaration must have a body, even if it is empty."><error descr="Classes and mixins can only implement other classes and mixins."><error descr="Expected a type name.">s</error></error></error>


### PR DESCRIPTION
I think this was accidentally deleted and causing integration tests to fail.