### PR TITLE
[infra] retry build on transient gradle failures

### DIFF
--- a/third_party/tool/kokoro/build.sh
+++ b/third_party/tool/kokoro/build.sh
@@ -6,6 +6,33 @@ setup
 echo "kokoro build start"
 
 cd third_party
-./gradlew buildPlugin
+
+MAX_RETRIES=3
+RETRY_DELAY_SECS=15
+ATTEMPT=1
+
+# Retry the build a few times to address transient failures.
+# See: https://github.com/flutter/flutter-intellij/issues/9009
+while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
+  echo "Running buildPlugin (Attempt $ATTEMPT of $MAX_RETRIES)..."
+  
+  if ./gradlew buildPlugin; then
+    echo "Gradle build completed successfully."
+    break
+  else
+    exit_code=$?
+  fi
+
+  echo "Build failed on attempt $ATTEMPT."
+  
+  if [[ $ATTEMPT -eq $MAX_RETRIES ]]; then
+    echo "All $MAX_RETRIES attempts failed. Exiting."
+    exit $exit_code
+  fi
+
+  echo "Waiting $RETRY_DELAY_SECS seconds before retrying..."
+  sleep $RETRY_DELAY_SECS
+  ATTEMPT=$((ATTEMPT + 1))
+done
 
 echo "kokoro build finished"

--- a/third_party/tool/kokoro/build.sh
+++ b/third_party/tool/kokoro/build.sh
@@ -21,7 +21,7 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
     break
   else
     exit_code=$?
-    if [[ $exit_code -eq 130 || $exit_code -eq 143 ]]; then
+    if [[ $exit_code -ge 128 ]]; then
       echo "Build interrupted. Exiting."
       exit $exit_code
     fi

--- a/third_party/tool/kokoro/build.sh
+++ b/third_party/tool/kokoro/build.sh
@@ -21,6 +21,10 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
     break
   else
     exit_code=$?
+    if [[ $exit_code -eq 130 || $exit_code -eq 143 ]]; then
+      echo "Build interrupted. Exiting."
+      exit $exit_code
+    fi
   fi
 
   echo "Build failed on attempt $ATTEMPT."


### PR DESCRIPTION
Corresponds to Flutter Plugin support added w/ https://github.com/flutter/flutter-intellij/pull/9010.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
