### PR TITLE
Support LSP hover for external library files (pub-cache, SDK)

### DIFF
--- a/.agents/skills/patch-copied-lsp-sources/SKILL.md
+++ b/.agents/skills/patch-copied-lsp-sources/SKILL.md
@@ -55,3 +55,6 @@ Here is the details of the changes made by the patch script:
 
 7. **Intention Directory Names**:
    - Rename the intention descriptions folder `LspIntention` to `DartLspIntention` and update `descriptionDirectoryName` to `DartLspIntention` in `dart-lsp-impl.xml` to prevent collision.
+
+8. **Support External Library Files**:
+   - Remove `if (!ProjectFileIndex.getInstance(project).isInContent(file)) return false` from `LspServerImpl.isSupportedFile(file)` so that the Dart LSP bridge can serve external library files (such as pub-cache packages and Dart SDK libraries like `dart:io`).

--- a/.agents/skills/patch-copied-lsp-sources/scripts/patch.py
+++ b/.agents/skills/patch-copied-lsp-sources/scripts/patch.py
@@ -246,6 +246,24 @@ lsp.rename.action.text=LSP-Based Rename
             with open(code_vision_path, "w", encoding="utf-8") as f:
                 f.write(code_vision_content)
 
+    # 10. Modify LspServerImpl.kt to remove ProjectFileIndex.isInContent check so external library files (pub-cache, SDK) are supported
+    lsp_server_impl_path = os.path.join(base_dir, "third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/LspServerImpl.kt")
+    if os.path.exists(lsp_server_impl_path):
+        with open(lsp_server_impl_path, "r", encoding="utf-8") as f:
+            lsp_server_impl_content = f.read()
+        target_line = "    if (!ProjectFileIndex.getInstance(project).isInContent(file)) return false\n"
+        import_line = "import com.intellij.openapi.roots.ProjectFileIndex\n"
+        modified = False
+        if target_line in lsp_server_impl_content:
+            lsp_server_impl_content = lsp_server_impl_content.replace(target_line, "")
+            modified = True
+        if import_line in lsp_server_impl_content:
+            lsp_server_impl_content = lsp_server_impl_content.replace(import_line, "")
+            modified = True
+        if modified:
+            with open(lsp_server_impl_path, "w", encoding="utf-8") as f:
+                f.write(lsp_server_impl_content)
+
     print("Patch applied successfully!")
 
 if __name__ == "__main__":

--- a/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/LspServerImpl.kt
+++ b/third_party/thirdPartySrc/platform-lsp/src/com/intellij/platform/dartlsp/impl/LspServerImpl.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.ex.DocumentEx
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.io.FileUtilRt
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.dartlsp.api.Lsp4jServer
@@ -144,7 +143,6 @@ class LspServerImpl internal constructor(
   internal fun isSupportedFile(file: VirtualFile): Boolean {
     if (!file.isInLocalFileSystem) return false
     if (unsupportedFilePaths.contains(file.path)) return false
-    if (!ProjectFileIndex.getInstance(project).isInContent(file)) return false
 
     return descriptor.isSupportedFile(file)
       .also { if (!it) unsupportedFilePaths.add(file.path) }


### PR DESCRIPTION
The initial change using LSP makes hover unavailable to library files, e.g. if we open a Flutter framework file that an app depends on. Since legacy LSP provides this, I think we should enable it for these other files if possible. (To check this change, open up a Flutter SDK file and make sure hover works in that file as well.)

The current change is one in the copied LSP code. I'm wondering if there's a possibility of making this available as an option in the public-facing API so that we can have this in the future while using the open source version? @alexander-doroshko 