### PR TITLE
Add custom request for diagnostics port

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Added
+- Retrieving diagnostics server with JetBrains LSP (#493)
 
 ### Changed
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerDiagnosticsAction.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerDiagnosticsAction.java
@@ -15,12 +15,16 @@ import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.analytics.Analytics;
 import com.jetbrains.lang.dart.analytics.AnalyticsData;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.lsp.DartLspService;
+import com.jetbrains.lang.dart.sdk.DartConfigurable;
+import com.jetbrains.lang.dart.sdk.DartSdkUpdateChecker;
 
 import org.dartlang.analysis.server.protocol.RequestError;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class AnalysisServerDiagnosticsAction extends DumbAwareAction {
+  private static final String MIN_LSP_DIAGNOSTIC_SERVER_SDK_VERSION = "3.13.0-106.0.dev";
 
   public AnalysisServerDiagnosticsAction() {
     super(DartBundle.messagePointer("analysis.server.show.diagnostics.text"));
@@ -47,7 +51,14 @@ public class AnalysisServerDiagnosticsAction extends DumbAwareAction {
   }
 
   void run(final @NotNull Project project, @Nullable AnActionEvent event) {
-    fallbackToLegacy(project);
+    String sdkVersion = DartAnalysisServerService.getInstance(project).getSdkVersion();
+    if (!sdkVersion.isEmpty() &&
+        DartConfigurable.isExperimentalLspFeaturesEnabled(project) &&
+        DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_DIAGNOSTIC_SERVER_SDK_VERSION) >= 0) {
+      useLspOverLegacy(project);
+    } else {
+      fallbackToLegacy(project);
+    }
 
     if (event != null) {
       Analytics.report(AnalyticsData.forAction(this, event));
@@ -57,6 +68,23 @@ public class AnalysisServerDiagnosticsAction extends DumbAwareAction {
         Analytics.report(AnalyticsData.forAction(actionManager.getId(this), project));
       }
     }
+  }
+
+  private void useLspOverLegacy(@NotNull Project project) {
+    DartLspService.getDiagnosticServerPort(project)
+      .thenAccept(port -> {
+        if (project.isDisposed()) return;
+        if (port != null) {
+          BrowserUtil.browse("http://localhost:" + port + "/status");
+        } else {
+          fallbackToLegacy(project);
+        }
+      })
+      .exceptionally(ex -> {
+        if (project.isDisposed()) return null;
+        fallbackToLegacy(project);
+        return null;
+      });
   }
 
   private void fallbackToLegacy(@NotNull Project project) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -31,7 +31,6 @@ import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.LanguageClientAware
-import org.eclipse.lsp4j.services.LanguageServer
 import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
 import java.util.concurrent.CompletableFuture
@@ -63,7 +62,7 @@ import java.util.concurrent.ConcurrentHashMap
  * To ensure the server is fully up to date before processing a request, we also explicitly call
  * `das.updateFilesContent()` before forwarding any client request.
  */
-class DartBridgeLspServer(private val project: Project) : LanguageServer, TextDocumentService, WorkspaceService,
+class DartBridgeLspServer(private val project: Project) : DartLanguageServer, TextDocumentService, WorkspaceService,
     LanguageClientAware {
     companion object {
         private val logger = PluginLogger.createLogger(DartBridgeLspServer::class.java)
@@ -231,6 +230,10 @@ class DartBridgeLspServer(private val project: Project) : LanguageServer, TextDo
         return forwardRequest("textDocument/hover", params, Hover::class.java)
     }
 
+    override fun diagnosticServer(): CompletableFuture<DiagnosticServerResult> {
+        return forwardRequest("dart/diagnosticServer", null, DiagnosticServerResult::class.java)
+    }
+
     // Implement other TextDocumentService methods as needed, returning unsupported or forwarding.
     
     override fun didOpen(params: DidOpenTextDocumentParams) {
@@ -271,7 +274,7 @@ class DartBridgeLspServer(private val project: Project) : LanguageServer, TextDo
      * Note: We use the same [legacyId] for both the outer legacy request and the inner LSP request
      * to simplify tracking and matching.
      */
-    private fun <T> forwardRequest(method: String, params: Any, responseClass: Class<T>): CompletableFuture<T> {
+    private fun <T> forwardRequest(method: String, params: Any?, responseClass: Class<T>): CompletableFuture<T> {
         val future = CompletableFuture<T>()
         
         val ready = runReadAction { das.serverReadyForRequest() }
@@ -295,7 +298,9 @@ class DartBridgeLspServer(private val project: Project) : LanguageServer, TextDo
             addProperty("jsonrpc", JSONRPC_VERSION)
             addProperty("id", legacyId)
             addProperty("method", method)
-            add("params", GSON.toJsonTree(params))
+            if (params != null && params != Unit) {
+                add("params", GSON.toJsonTree(params))
+            }
         }
 
         val legacyRequest = JsonObject().apply {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLanguageServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLanguageServer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.lsp
+
+import com.intellij.openapi.project.Project
+import com.intellij.platform.dartlsp.api.Lsp4jServer
+import com.intellij.platform.dartlsp.api.LspServerManager
+import com.intellij.util.concurrency.AppExecutorUtil
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Custom Language Server interface for Dart to support custom LSP requests.
+ */
+interface DartLanguageServer : Lsp4jServer {
+    /**
+     * Returns the port of the diagnostic server.
+     */
+    @JsonRequest("dart/diagnosticServer")
+    fun diagnosticServer(): CompletableFuture<DiagnosticServerResult>
+}
+
+data class DiagnosticServerResult(
+    val port: Int
+)
+
+object DartLspService {
+    @JvmStatic
+    fun getDiagnosticServerPort(project: Project): CompletableFuture<Int?> {
+        return CompletableFuture.supplyAsync({
+            if (project.isDisposed) return@supplyAsync null
+            val server = LspServerManager.getInstance(project)
+                .getServersForProvider(DartLspServerSupportProvider::class.java)
+                .firstOrNull() ?: return@supplyAsync null
+            val result = server.sendRequestSync { (it as DartLanguageServer).diagnosticServer() }
+            result?.port
+        }, AppExecutorUtil.getAppExecutorService())
+    }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -7,6 +7,7 @@ package com.jetbrains.lang.dart.lsp
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.dartlsp.api.Lsp4jServer
 import com.intellij.platform.dartlsp.api.LspCommunicationChannel
 import com.intellij.platform.dartlsp.api.ProjectWideLspServerDescriptor
 import com.intellij.platform.dartlsp.api.customization.LspCallHierarchyDisabled
@@ -49,6 +50,8 @@ import com.jetbrains.lang.dart.sdk.DartConfigurable
  * 3. The LSP feature customizations (e.g. enabling/disabling hover support dynamically based on settings).
  */
 class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "Dart (Bridge)") {
+
+    override val lsp4jServerClass: Class<out Lsp4jServer> = DartLanguageServer::class.java
 
     override fun isSupportedFile(file: VirtualFile): Boolean {
         return DartAnalysisServerService.isFileNameRespectedByAnalysisServer(file.name)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -12,7 +12,8 @@ enum class LspMethod(
 ) {
     INITIALIZE("initialize"),
     SHUTDOWN("shutdown"),
-    HOVER("textDocument/hover", isExperimental = true, presentableName = "hover");
+    HOVER("textDocument/hover", isExperimental = true, presentableName = "hover"),
+    DIAGNOSTIC_SERVER("dart/diagnosticServer", isExperimental = true, presentableName = "diagnostic server");
 
     companion object {
         fun fromMethod(method: String): LspMethod? = entries.find { it.method == method }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -10,10 +10,10 @@ enum class LspMethod(
     val isExperimental: Boolean = false,
     val presentableName: String? = null
 ) {
-    INITIALIZE("initialize"),
-    SHUTDOWN("shutdown"),
+    DIAGNOSTIC_SERVER("dart/diagnosticServer", isExperimental = true, presentableName = "diagnostic server"),
     HOVER("textDocument/hover", isExperimental = true, presentableName = "hover"),
-    DIAGNOSTIC_SERVER("dart/diagnosticServer", isExperimental = true, presentableName = "diagnostic server");
+    INITIALIZE("initialize"),
+    SHUTDOWN("shutdown");
 
     companion object {
         fun fromMethod(method: String): LspMethod? = entries.find { it.method == method }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -191,6 +191,41 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertTrue("Response contents should contain Hover Content", result.contents.toString().contains("Hover Content"))
     }
 
+    fun testDiagnosticServerRequest() {
+        val future = bridgeServer.diagnosticServer()
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val outerParams = jsonObject.getAsJsonObject("params")
+        val lspMessage = outerParams.getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("dart/diagnosticServer", lspMessage.get("method").asString)
+        assertFalse("lspMessage should not have params when null is passed", lspMessage.has("params"))
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": {
+                    "port": 9123
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(9123, result.port)
+    }
+
     fun testForwardNotification() {
         // Simulate a diagnostics notification from DAS
         val notificationJson = """


### PR DESCRIPTION
This adds a custom request to retrieve the diagnostic port, used here:
<img width="1008" height="726" alt="image" src="https://github.com/user-attachments/assets/4b327c9c-64e0-42a1-8804-7b7e37bc714d" />

This also shows an example of checking the SDK version to make sure that the analysis server supports the LSP-over-legacy request. (As we are transitioning more things to LSP, ask me for a doc of when SDK supports LSP-over-legacy requests - most have been available for >2 years, but there are some exceptions that will require a version check).

(This was previously implemented with lsp4ij back in https://github.com/flutter/dart-intellij-third-party/pull/391/changes)