### PR TITLE
Avoid starting bridge server in unit test mode

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -2341,8 +2341,10 @@ public final class DartAnalysisServerService implements Disposable {
           connectToDtd(dtdUri);
         }
 
-        // Start the LSP Bridge Server
-        myProject.getService(DartBridgeLspServerManager.class).startBridgeServer();
+        // Start the LSP Bridge Server unless in unit test mode
+        if (!ApplicationManager.getApplication().isUnitTestMode()) {
+          myProject.getService(DartBridgeLspServerManager.class).startBridgeServer();
+        }
       }
       catch (Exception e) {
         stopServer();

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -270,11 +270,11 @@ public final class DartAnalysisServerService implements Disposable {
     return ApplicationInfo.getInstance().getApiVersion();
   }
 
-  private final @NotNull List<AnalysisServerListener> myAdditionalServerListeners = new SmartList<>();
-  private final @NotNull List<RequestListener> myRequestListeners = new SmartList<>();
-  private final @NotNull List<ResponseListener> myResponseListeners = new SmartList<>();
-  private final @NotNull List<DartQuickAssistIntentionListener> myQuickAssistIntentionListeners = new SmartList<>();
-  private final @NotNull List<DartQuickFixListener> myQuickFixListeners = new SmartList<>();
+  private final @NotNull List<AnalysisServerListener> myAdditionalServerListeners = ContainerUtil.createLockFreeCopyOnWriteList();
+  private final @NotNull List<RequestListener> myRequestListeners = ContainerUtil.createLockFreeCopyOnWriteList();
+  private final @NotNull List<ResponseListener> myResponseListeners = ContainerUtil.createLockFreeCopyOnWriteList();
+  private final @NotNull List<DartQuickAssistIntentionListener> myQuickAssistIntentionListeners = ContainerUtil.createLockFreeCopyOnWriteList();
+  private final @NotNull List<DartQuickFixListener> myQuickFixListeners = ContainerUtil.createLockFreeCopyOnWriteList();
 
   private final AnalysisServerListener myAnalysisServerListener = new AnalysisServerListenerAdapter() {
     @Override


### PR DESCRIPTION
The problem with `DartParameterInfoTest` in integration tests may be due to bridge server starting during the test. The failing test does some server teardown that shuts down the bridge server, which removes a listener and triggers the concurrent modification exception. More info from gemini below:


### Problem
In PR #494, `Integration Tests (ubuntu-large)` intermittently failed during test teardown (e.g., in `DartParameterInfoTest > testParamInfo8`):
```
Caused by: java.util.ConcurrentModificationException
        at java.base/java.util.AbstractList$Itr.checkForComodification(AbstractList.java:401)
        at java.base/java.util.AbstractList$Itr.remove(AbstractList.java:386)
        at com.jetbrains.lang.dart.analyzer.DartAnalysisServerService.removeResponseListener(DartAnalysisServerService.java:714)
        at com.jetbrains.lang.dart.lsp.DartBridgeLspServer.stop(DartBridgeLspServer.kt:197)
        at com.jetbrains.lang.dart.lsp.DartBridgeLspServerManager$ActiveConnection.close(DartBridgeLspServerManager.kt:138)
```

  When  Disposer.dispose()  tore down the test project fixture, the LSP bridge manager called  DartBridgeLspServer.stop() , which removed its response listener from  DartAnalysisServerService.myResponseListeners . Because  myResponseListeners
  is backed by a non-thread-safe  SmartList , modifying it while another thread/loop was iterating caused a  ConcurrentModificationException . IntelliJ's test harness intercepted this error via  TestLoggerFactory  and converted it into a
  TestLoggerAssertionError , failing the completing test case.
