### PR TITLE
Loosen dtd process test concurrent requests

### DIFF
--- a/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DTDProcessTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DTDProcessTest.kt
@@ -24,7 +24,7 @@ class DTDProcessTest : BasePlatformTestCase() {
         const val STARTUP_TIMEOUT_SECONDS = 5L
         const val RESPONSE_TIMEOUT_SECONDS = 2L
         const val CONCURRENT_REQUESTS_TIMEOUT_SECONDS = 5L
-        const val CONCURRENT_REQUESTS_COUNT = 100
+        const val CONCURRENT_REQUESTS_COUNT = 10
     }
 
     private lateinit var dtdProcess: DTDProcess


### PR DESCRIPTION
Reduce concurrent rquest to 10 to avoid flakiness.