### PR TITLE
Fix RunContentDescriptor bug during app run/debug

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - Prevent memory leak by closing DTD WebSocket connections and clearing listeners when disposing projects (#449)
+- Split screen `RunContentDescriptor` error during app run/debug (#506)
 
 ## 506.1.0
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartRunner.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/DartRunner.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RunnerSettings
 import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.execution.executors.DefaultDebugExecutor
+import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.GenericProgramRunner
 import com.intellij.execution.ui.RunContentDescriptor
@@ -30,6 +31,7 @@ import com.jetbrains.lang.dart.ide.runner.server.webdev.DartWebdevConfiguration
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunConfiguration
 import com.jetbrains.lang.dart.logging.PluginLogger
 import com.jetbrains.lang.dart.util.DartUrlResolver
+import java.lang.reflect.Method
 
 class DartRunner : GenericProgramRunner<RunnerSettings>() {
   override fun getRunnerId(): String = "DartRunner"
@@ -116,27 +118,52 @@ class DartRunner : GenericProgramRunner<RunnerSettings>() {
 
     FileDocumentManager.getInstance().saveAllDocuments()
 
-    val debugSession = XDebuggerManager
-      .getInstance(project)
-      .startSession(env, object : XDebugProcessStarter() {
-        override fun start(session: XDebugSession): XDebugProcess {
-          val dartUrlResolver = DartUrlResolver
-            .getInstance(project, executionInfo.contextFileOrDir)
-          val dartVmServiceDebugProcess = DartVmServiceDebugProcess(
-            session,
-            executionInfo.executionResult,
-            dartUrlResolver,
-            dasExecutionContextId,
-            executionInfo.debugType,
-            VM_SERVICE_TIMEOUT_IN_MS,
-            executionInfo.currentWorkingDirectory
-          )
+    val starter = object : XDebugProcessStarter() {
+      override fun start(session: XDebugSession): XDebugProcess {
+        val dartUrlResolver = DartUrlResolver
+          .getInstance(project, executionInfo.contextFileOrDir)
+        val dartVmServiceDebugProcess = DartVmServiceDebugProcess(
+          session,
+          executionInfo.executionResult,
+          dartUrlResolver,
+          dasExecutionContextId,
+          executionInfo.debugType,
+          VM_SERVICE_TIMEOUT_IN_MS,
+          executionInfo.currentWorkingDirectory
+        )
 
-          dartVmServiceDebugProcess.start()
-          return dartVmServiceDebugProcess
+        dartVmServiceDebugProcess.start()
+        return dartVmServiceDebugProcess
+      }
+    }
+
+    val manager = XDebuggerManager.getInstance(project)
+    val hooks = builderHooks
+    if (hooks != null) {
+      try {
+        var builder = hooks.newSessionBuilderMethod.invoke(manager, starter)
+        builder = hooks.environmentMethod.invoke(builder, env)
+        if (hooks.contentToReuseMethod != null && env.contentToReuse != null) {
+          builder = hooks.contentToReuseMethod.invoke(builder, env.contentToReuse)
         }
-      })
+        if (hooks.sessionNameMethod != null) {
+          builder = hooks.sessionNameMethod.invoke(builder, env.runProfile.name)
+        }
+        if (hooks.showTabMethod != null) {
+          val showTab = env.executor.id != DefaultRunExecutor.EXECUTOR_ID
+          builder = hooks.showTabMethod.invoke(builder, showTab)
+        }
+        val sessionResult = hooks.startSessionMethod.invoke(builder)
+        val getDescriptorMethod = sessionResult.javaClass.getMethod("getRunContentDescriptor")
+        return getDescriptorMethod.invoke(sessionResult) as? RunContentDescriptor
+      } catch (e: Exception) {
+        LOG.error("Failed to start debug session via reflection, falling back to legacy", e)
+      }
+    }
 
+    @Suppress("DEPRECATION")
+    val debugSession = manager.startSession(env, starter)
+    @Suppress("DEPRECATION")
     return debugSession.runContentDescriptor
   }
 
@@ -150,5 +177,37 @@ class DartRunner : GenericProgramRunner<RunnerSettings>() {
   companion object {
     private val LOG = PluginLogger.createLogger(DartRunner::class.java)
     private const val VM_SERVICE_TIMEOUT_IN_MS = 5000
+
+    private class BuilderHooks(
+      val newSessionBuilderMethod: Method,
+      val environmentMethod: Method,
+      val sessionNameMethod: Method?,
+      val contentToReuseMethod: Method?,
+      val showTabMethod: Method?,
+      val startSessionMethod: Method
+    )
+
+    private val builderHooks: BuilderHooks? = findBuilderHooks()
+
+    private fun findBuilderHooks(): BuilderHooks? {
+      return try {
+        val nsb = XDebuggerManager::class.java.getMethod("newSessionBuilder", XDebugProcessStarter::class.java)
+        val builderClass = nsb.returnType
+        val env = builderClass.getMethod("environment", ExecutionEnvironment::class.java)
+        val ss = builderClass.getMethod("startSession")
+        var sn: Method? = null
+        var ctr: Method? = null
+        var st: Method? = null
+        try {
+          sn = builderClass.getMethod("sessionName", String::class.java)
+          ctr = builderClass.getMethod("contentToReuse", RunContentDescriptor::class.java)
+          st = builderClass.getMethod("showTab", Boolean::class.javaPrimitiveType)
+        } catch (_: NoSuchMethodException) {
+        }
+        BuilderHooks(nsb, env, sn, ctr, st, ss)
+      } catch (_: NoSuchMethodException) {
+        null
+      }
+    }
   }
 }


### PR DESCRIPTION
This should fix the split debugger part of https://github.com/flutter/dart-intellij-third-party/issues/462. It's similar to https://github.com/flutter/flutter-intellij/pull/8908, https://github.com/flutter/flutter-intellij/pull/8878, ~~but in this case since we are only supporting 2025.3+, reflection isn't needed.~~ Oops - actually, reflection is needed for anything below 2026.1 :(

To verify this change is working, run a Dart app and make sure the RunContentDescriptor error doesn't show up.