### PR TITLE
Fix Java version incompatibility

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -24,10 +24,23 @@ class VerboseTestListener : TestListener, Serializable {
     }
 }
 
-// Specify UTF-8 for all compilations so we avoid Windows-1252.
+// Read javaVersion from gradle.properties
+val javaVersionStr = providers.gradleProperty("javaVersion").get()
+val javaVersionInt = javaVersionStr.toInt()
+val kotlinJvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(javaVersionStr)
+val javaVer = JavaVersion.toVersion(javaVersionStr)
+
 allprojects {
     tasks.withType<JavaCompile> {
+        // Specify UTF-8 for all compilations so we avoid Windows-1252.
         options.encoding = "UTF-8"
+        // Enforce the target bytecode version and standard library API level across all Java compilation tasks.
+        options.release.set(javaVersionInt)
+    }
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        compilerOptions {
+            jvmTarget.set(kotlinJvmTarget)
+        }
     }
     tasks.withType<Test> {
         systemProperty("file.encoding", "UTF-8")
@@ -132,19 +145,17 @@ sourceSets {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        jvmTarget.set(kotlinJvmTarget)
     }
 }
 
 java {
     toolchain {
-        val versionProvider = providers.gradleProperty("javaVersion")
-            .map { it.toInt() }
-            .map { JavaLanguageVersion.of(it) }
-        languageVersion.set(versionProvider)
+        // Dynamically use the running JVM version for the toolchain so Gradle does not search for or download a specific JDK on CI or locally.
+        languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
     }
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = javaVer
+    targetCompatibility = javaVer
 }
 
 dependencies {

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -39,6 +39,7 @@ allprojects {
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
+            // Same as above, but for kotlin.
             jvmTarget.set(kotlinJvmTarget)
         }
     }
@@ -151,7 +152,8 @@ kotlin {
 
 java {
     toolchain {
-        // Dynamically use the running JVM version for the toolchain so Gradle does not search for or download a specific JDK on CI or locally.
+        // Dynamically use the running JVM version for the toolchain so Gradle does not search for or download a
+        // specific JDK on CI or locally. (if we set this to a specific version, it's likely to break dev build.)
         languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
     }
     sourceCompatibility = javaVer

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -13,6 +13,8 @@ import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 class VerboseTestListener : TestListener, Serializable {
     override fun beforeSuite(suite: TestDescriptor) {}
@@ -27,7 +29,7 @@ class VerboseTestListener : TestListener, Serializable {
 // Read javaVersion from gradle.properties
 val javaVersionStr = providers.gradleProperty("javaVersion").get()
 val javaVersionInt = javaVersionStr.toInt()
-val kotlinJvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(javaVersionStr)
+val kotlinJvmTarget = JvmTarget.fromTarget(javaVersionStr)
 val javaVer = JavaVersion.toVersion(javaVersionStr)
 
 allprojects {
@@ -37,7 +39,7 @@ allprojects {
         // Enforce the target bytecode version and standard library API level across all Java compilation tasks.
         options.release.set(javaVersionInt)
     }
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    tasks.withType<KotlinCompile> {
         compilerOptions {
             // Same as above, but for kotlin.
             jvmTarget.set(kotlinJvmTarget)

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -138,7 +138,10 @@ kotlin {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(JavaVersion.current().majorVersion))
+        val versionProvider = providers.gradleProperty("javaVersion")
+            .map { it.toInt() }
+            .map { JavaLanguageVersion.of(it) }
+        languageVersion.set(versionProvider)
     }
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21


### PR DESCRIPTION
This was causing a version incompatibility for 2025.3 when I built locally:
```
com.intellij.diagnostic.PluginException: Cannot create extension (class=com.jetbrains.lang.dart.ide.index.DartPartUriIndex) [Plugin: Dart]
        at com.intellij.serviceContainer.ComponentManagerImpl.createError(ComponentManagerImpl.kt:962)
        at com.intellij.openapi.extensions.impl.XmlExtensionAdapter.doCreateInstance(XmlExtensionAdapter.kt:73)
        at com.intellij.openapi.extensions.impl.XmlExtensionAdapter.createInstance(XmlExtensionAdapter.kt:33)
        at com.intellij.openapi.extensions.impl.ExtensionPointImpl.processAdapter(ExtensionPointImpl.kt:404)
        at com.intellij.openapi.extensions.impl.ExtensionPointImpl.createExtensionInstances(ExtensionPointImpl.kt:377)
        at com.intellij.openapi.extensions.impl.ExtensionPointImpl.getExtensionList(ExtensionPointImpl.kt:223)
        at com.intellij.openapi.extensions.ExtensionPointName.getExtensionList(ExtensionPointName.kt:54)
        at com.intellij.platform.ide.IdeFingerprintKt.computeIdeFingerprint(IdeFingerprint.kt:93)
        at com.intellij.platform.ide.IdeFingerprintKt.fingerprint$lambda$0(IdeFingerprint.kt:24)
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:86)
        at com.intellij.platform.ide.IdeFingerprintKt.ideFingerprint(IdeFingerprint.kt:28)
        at com.intellij.platform.ide.IdeFingerprintKt.ideFingerprint$default(IdeFingerprint.kt:27)
        at com.intellij.platform.ide.bootstrap.ApplicationLoader$loadApp$2$1.invokeSuspend(ApplicationLoader.kt:141)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:610)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runDefaultDispatcherTask(CoroutineScheduler.kt:1194)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:906)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:775)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:762)
Caused by: com.intellij.diagnostic.PluginException: Cannot load class com.jetbrains.lang.dart.ide.index.DartPartUriIndex (
  error: com/jetbrains/lang/dart/ide/index/DartPartUriIndex has been compiled by a more recent version of the Java Runtime (class file version 67.0), this version of the Java Runtime only recognizes class file versions up to 65.0,
```

I think this issue was introduced by https://github.com/flutter/dart-intellij-third-party/pull/469.

Anyway, I tested this by building locally, and it doesn't cause the problem on 2025.3.