### PR TITLE
Replace Weberknecht with JDK's Websocket in VmServiceBase and WebSock…

### DIFF
--- a/third_party/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/third_party/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -17,17 +17,16 @@ import com.google.common.collect.Maps;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import de.roderick.weberknecht.WebSocket;
-import de.roderick.weberknecht.WebSocketEventHandler;
-import de.roderick.weberknecht.WebSocketException;
-import de.roderick.weberknecht.WebSocketMessage;
+import com.jetbrains.lang.dart.websocket.WebSocket;
+import com.jetbrains.lang.dart.websocket.WebSocketEventHandler;
+import com.jetbrains.lang.dart.websocket.WebSocketException;
+import com.jetbrains.lang.dart.websocket.WebSocketMessage;
 import org.dartlang.vm.service.consumer.*;
 import org.dartlang.vm.service.element.*;
 import org.dartlang.vm.service.internal.RequestSink;
 import org.dartlang.vm.service.internal.VmServiceConst;
 import org.dartlang.vm.service.internal.WebSocketRequestSink;
 import org.dartlang.vm.service.logging.Logging;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -62,12 +61,7 @@ abstract class VmServiceBase implements VmServiceConst {
     }
 
     // Create web socket and observatory
-    WebSocket webSocket;
-    try {
-      webSocket = new WebSocket(uri);
-    } catch (WebSocketException e) {
-      throw new IOException("Failed to create websocket: " + url, e);
-    }
+    WebSocket webSocket = new WebSocket(uri);
     final VmService vmService = new VmService();
 
     // Setup event handler for forwarding responses

--- a/third_party/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/internal/WebSocketRequestSink.java
+++ b/third_party/thirdPartySrc/vmServiceDrivers/org/dartlang/vm/service/internal/WebSocketRequestSink.java
@@ -14,8 +14,8 @@
 package org.dartlang.vm.service.internal;
 
 import com.google.gson.JsonObject;
-import de.roderick.weberknecht.WebSocket;
-import de.roderick.weberknecht.WebSocketException;
+import com.jetbrains.lang.dart.websocket.WebSocket;
+import com.jetbrains.lang.dart.websocket.WebSocketException;
 import org.dartlang.vm.service.logging.Logging;
 
 /**


### PR DESCRIPTION
## Summary

This is the last service using the Weberknecht. After this pull request there will be no usage of Weberknecht in Dart plugin and we can safely remove the dependecy.

I had some manual tests to make sure VMService is working as expected with the new Websocket.

The only change I added to logic was creating the Websocket object with no try catch expression.

## Manual test

Use the plugin to debug a dart script. Intelij plugin uses a command like this:
```
dart
    --enable-asserts
    --pause_isolates_on_start
    --enable-vm-service:50788
    --no-serve-devtools
   /path/to/your/script
```
this will automatically use the VmService and if the application runs succesfully it means VMService connection has been succesful.

In order to check the messages put some breakpoints in the Websocket class. Check the messages to see if everything is working fine.


More edge cases are tested by a script in notebook