### PR TITLE
Enable ping interval for Dart tooling Daemon

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/dtd/DTDProcess.kt
@@ -130,6 +130,7 @@ class DTDProcess {
     commandLine.charset = StandardCharsets.UTF_8
     commandLine.addParameter("tooling-daemon")
     commandLine.addParameter("--machine")
+    commandLine.addParameter("--ping-interval=15")
     Analytics.updateEnvironment(commandLine)
 
     osProcessHandler = object : KillableProcessHandler(commandLine) {
@@ -230,7 +231,7 @@ class DTDProcess {
       if (processRunning) return
 
       // The first line of text is the command issued, which can be ignored.
-      val text = event.text.trim().takeUnless { it.endsWith(" tooling-daemon --machine") }
+      val text = event.text.trim().takeUnless { it.endsWith(" tooling-daemon --machine --ping-interval=15") }
         ?: return
 
       var uri: String? = null
@@ -255,4 +256,3 @@ interface DTDProcessListener {
   fun onWebSocketOpen() {}
   fun onProcessStarted(uri: String?) {}
 }
-

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -93,6 +93,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
     commandLine.charset = StandardCharsets.UTF_8
     commandLine.addParameter("tooling-daemon")
     commandLine.addParameter("--machine")
+    commandLine.addParameter("--ping-interval=15")
     Analytics.updateEnvironment(commandLine)
 
     logger.info("Starting Dart Tooling Daemon, sdk ${sdk.version}")
@@ -300,7 +301,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
       if (serviceRunning) return
 
       // The first line of text is the command issued, which can be ignored.
-      val text = event.text.trim().takeUnless { it.endsWith(" tooling-daemon --machine") }
+      val text = event.text.trim().takeUnless { it.endsWith(" tooling-daemon --machine --ping-interval=15") }
                  ?: return
 
       var uri: String? = null


### PR DESCRIPTION
# Summary

Relates to #208 [Norton](https://github.com/Dart-Code/Dart-Code/issues/5794) #205 

- Enabling ping intervals for Dart Tooling Daemon keeps the connection reliable while the daemon is idle.

- It prevents proxies, VPNs, antivirus software, and network devices from dropping an apparently inactive connection.
- If DTD doesn’t receive a pong within the next interval, it considers the connection dead and closes it, allowing reconnection instead of retaining a stale socket. This follows Dart’s
    WebSocket ping behavior (https://api.dart.dev/dart-io/WebSocket/pingInterval.html).