### PR TITLE
Handle SkipDefaultValuesSerializationFilters param deprecation

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfiguration.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfiguration.java
@@ -15,12 +15,12 @@ import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.PathUtil;
-import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.jetbrains.lang.dart.DartBundle;
 import com.jetbrains.lang.dart.analytics.Analytics;
 import com.jetbrains.lang.dart.analytics.AnalyticsConstants;
 import com.jetbrains.lang.dart.ide.runner.server.ui.DartWebdevConfigurationEditorForm;
+import org.jdom.Attribute;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -62,7 +62,7 @@ public class DartWebdevConfiguration extends LocatableConfigurationBase<DartWebd
 
   @Override
   public @Nullable String suggestedName() {
-    // Attempt to compute the relative path to the html file, i.e. some "web/index.html"
+    // Attempt to compute the relative path to the HTML file, i.e. some "web/index.html"
     // If not successful, return at least the file name, i.e. some "index.html"
     final String htmlFilePath = myParameters.getHtmlFilePath();
     String htmlFilePathRelativeFromWorkingDir = null;
@@ -84,7 +84,13 @@ public class DartWebdevConfiguration extends LocatableConfigurationBase<DartWebd
   @Override
   public void writeExternal(@NotNull Element element) throws WriteExternalException {
     super.writeExternal(element);
-    XmlSerializer.serializeInto(myParameters, element, new SkipDefaultValuesSerializationFilters());
+    Element serializedState = XmlSerializer.serialize(myParameters);
+    if (serializedState != null) {
+      for (Attribute attribute : serializedState.getAttributes()) {
+        element.setAttribute(attribute.getName(), attribute.getValue());
+      }
+      element.addContent(serializedState.cloneContent());
+    }
   }
 
   @Override

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfigurationTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/runner/server/webdev/DartWebdevConfigurationTest.java
@@ -1,0 +1,22 @@
+package com.jetbrains.lang.dart.ide.runner.server.webdev;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.jdom.Element;
+
+public class DartWebdevConfigurationTest extends BasePlatformTestCase {
+
+    public void testSerializationAndDeserialization() {
+        ConfigurationFactory myFactory = DartWebdevConfigurationType.getInstance().getConfigurationFactories()[0];
+
+        DartWebdevConfiguration myOriginalConfig = new DartWebdevConfiguration(getProject(), myFactory, "TestConfig");
+        myOriginalConfig.getParameters().setHtmlFilePath("web/index.html");
+
+        Element myElement = new Element("configuration");
+        myOriginalConfig.writeExternal(myElement);
+
+        DartWebdevConfiguration myRestoredConfig = new DartWebdevConfiguration(getProject(), myFactory, "TestConfig");
+        myRestoredConfig.readExternal(myElement);
+
+        assertEquals("web/index.html", myRestoredConfig.getParameters().getHtmlFilePath());
+    }
+}


### PR DESCRIPTION
### Changes
The override of the `writeExternal` method was using `XmlSerializer.serializeInto`, with 3 params, included a new instance of `SkipDefaultValuesSerializationFilters` which was recently deprecated.

Faster and less disruptive solution was moving from `XmlSerializer.serializeInto` to `XmlSerializer.serialize` with just one param, preventing refactors that could potentially break `clone()` and `getParameters()` methods.

`XmlSerializer.serialize(Object)` automatically ignores default and null values, this means it replaces the old work done by `SkipDefaultValuesSerializationFilters`.

### Why was this needed?
JetBrains declared this as deprecated because direct mutation of existing DOM elements causes problems with the modern state system.

### Verification Steps
  1. Run Sandbox IDE and open a Dart project (`./gradlew runIde`).
  2. Go to Run > Edit Configurations...
  3. Click + (Add New Configuration) and select Dart Web.
  4. Set the HTML file field (e.g., web/index.html) and click Apply / OK.
  5. Close and reopen the project (or restart the IDE) to force the configuration to persist to disk   
  and reload.
  6. Reopen Run > Edit Configurations... and select the Dart Web configuration:
      • Expected Result: The configuration settings (e.g., HTML file path) persist intact and are not  
      reset to defaults.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
