### PR TITLE
Update Dart PR request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,26 @@
-- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.
+Thanks for your contribution! Please replace this text with:
+
+- a description of what this PR is changing and why
+- any relevant issues
+- a description of how to manually verify the change is working (or detect that it's not working)
+- screenshots/gif if relevant
 
 ---
 
+Review the contribution guidelines below:
+
 - [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
+- [ ] I've included the required information in the description above.
+- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)
 
 <details>
   <summary>Contribution guidelines:</summary><br>
 
-- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
+- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
 - Larger or significant changes should be discussed in an issue before creating a PR.
-- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
-- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
+- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
+  `dart format`.
+- Java and Kotlin contributions should strive to follow Java and Kotlin best
+  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
+
 </details>


### PR DESCRIPTION
This is mainly copying the Flutter PR template. I wanted to note that we should have some test steps to verify any changes made, so that we can refer to them as we are doing plugin testing before releases or have an easier time detecting if a change has broken the plugin.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
