### PR TITLE
Remove deprecated analysis_getReachableSources method

### DIFF
--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -144,22 +144,6 @@ public interface AnalysisServer {
   public void analysis_getNavigation(String file, int offset, int length, GetNavigationConsumer consumer);
 
   /**
-   * {@code analysis.getReachableSources}
-   *
-   * Return the transitive closure of reachable sources for a given file.
-   *
-   * If a request is made for a file which does not exist, or which is not currently subject to
-   * analysis (e.g. because it is not associated with any analysis root specified to
-   * analysis.setAnalysisRoots), an error of type GET_REACHABLE_SOURCES_INVALID_FILE will be
-   * generated.
-   *
-   * @param file The file for which reachable source information is being requested.
-   *
-   * @deprecated
-   */
-  public void analysis_getReachableSources(String file, GetReachableSourcesConsumer consumer);
-
-  /**
    * {@code analysis.getSignature}
    *
    * Return the signature information associated with the given location in the given file. If the

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -331,12 +331,6 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     sendRequestToServer(id, RequestUtilities.generateAnalysisGetNavigation(id, file, offset, length), consumer);
   }
 
-  @Deprecated
-  @Override
-  public void analysis_getReachableSources(String file, GetReachableSourcesConsumer consumer) {
-    // TODO(scheglov) implement
-  }
-
   @Override
   public void analysis_getSignature(String file, int offset, GetSignatureConsumer consumer) {
   }

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -331,6 +331,7 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     sendRequestToServer(id, RequestUtilities.generateAnalysisGetNavigation(id, file, offset, length), consumer);
   }
 
+  @Deprecated
   @Override
   public void analysis_getReachableSources(String file, GetReachableSourcesConsumer consumer) {
     // TODO(scheglov) implement


### PR DESCRIPTION
### Summary
---

- Remove the deprecated analysis_getReachableSources(String file, GetReachableSourcesConsumer consumer);
declaration from AnalysisServer.
- Remove its corresponding no-op override from RemoteAnalysisServerImpl.
- Eliminate the related deprecated API warning from the IntelliJ Plugin Verifier reports.

---
### Verification

The following commands completed successfully:

- `./gradlew buildPlugin`
- `./gradlew :test --tests "com.jetbrains.lang.dart.*"`
- `./gradlew :test --tests "com.jetbrains.dart.*" -PverboseTests`
- `./gradlew verifyPlugin`
- `./gradlew verifyPluginProjectConfiguration`
- `./gradlew verifyPluginSignature`
- `./gradlew verifyPluginStructure`

The analysis_getReachableSources warning is no longer present in the Plugin Verifier reports for IU-253, IU-261, or IU-262.

Screenshots are not applicable because this change does not affect the UI.

Review the contribution guidelines below:

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] I've included the required information in the description above.
- [X] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
