### PR TITLE
Override getFileUri to use capital drive letters

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -61,6 +61,16 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
         return DartAnalysisServerService.isFileNameRespectedByAnalysisServer(file.name)
     }
 
+    /**
+     * Re-implements [LspServerDescriptor.getFileUri] to preserve uppercase Windows drive letters (`C:`).
+     *
+     * By default, the underlying JetBrains [LspServerDescriptor.getFileUri] lowercases drive letters (`c%3A`)
+     * to match VS Code conventions. However, legacy server messages sent by the Dart plugin (such as file
+     * synchronizations via `analysis.updateContent`) use uppercase drive letters derived from IntelliJ VFS paths.
+     * Because the Analysis Server evaluates path strings case-sensitively, a casing discrepancy between legacy
+     * and LSP-over-legacy requests causes the server to treat the same file as two distinct contexts, leading
+     * to duplicate analysis errors and sticky markers (see dart-lang/sdk#63819).
+     */
     override fun getFileUri(file: VirtualFile): String {
         val escapedPath = URLUtil.encodePath(getFilePath(file))
         val url = VirtualFileManager.constructUrl(URLUtil.FILE_PROTOCOL, escapedPath)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -6,7 +6,10 @@
 package com.jetbrains.lang.dart.lsp
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.OSAgnosticPathUtil
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.platform.dartlsp.api.Lsp4jServer
 import com.intellij.platform.dartlsp.api.LspCommunicationChannel
 import com.intellij.platform.dartlsp.api.ProjectWideLspServerDescriptor
@@ -37,6 +40,7 @@ import com.intellij.platform.dartlsp.api.customization.LspSemanticTokensDisabled
 import com.intellij.platform.dartlsp.api.customization.LspSignatureHelpDisabled
 import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchyDisabled
 import com.intellij.platform.dartlsp.api.customization.LspWorkspaceSymbolDisabled
+import com.intellij.util.io.URLUtil
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.sdk.DartConfigurable
 
@@ -55,6 +59,17 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
 
     override fun isSupportedFile(file: VirtualFile): Boolean {
         return DartAnalysisServerService.isFileNameRespectedByAnalysisServer(file.name)
+    }
+
+    override fun getFileUri(file: VirtualFile): String {
+        val escapedPath = URLUtil.encodePath(getFilePath(file))
+        val url = VirtualFileManager.constructUrl(URLUtil.FILE_PROTOCOL, escapedPath)
+        val uri = VfsUtil.toUri(url)?.toString() ?: url
+        val prefix = "file:///"
+        if (uri.startsWith(prefix) && OSAgnosticPathUtil.startsWithWindowsDrive(uri.substring(prefix.length))) {
+            return prefix + uri[prefix.length].uppercase() + uri.substring(prefix.length + 1)
+        }
+        return uri
     }
 
     override val lspCommunicationChannel: LspCommunicationChannel

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -253,8 +253,13 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
     fun testGetFileUriFormatting() {
         val descriptor = DartLspServerDescriptor(project)
         val file = myFixture.configureByText("foo.dart", "void main() {}").virtualFile
-        val expectedUri = DartAnalysisServerService.getInstance(project).getFileUri(file)
-        assertEquals(expectedUri, descriptor.getFileUri(file))
+        val uri = descriptor.getFileUri(file)
+        assertTrue(uri.startsWith("file:///"))
+        if (com.intellij.openapi.util.SystemInfo.isWindows) {
+            val pathAfterPrefix = uri.substring("file:///".length)
+            assertTrue(pathAfterPrefix[0].isUpperCase())
+            assertEquals(':', pathAfterPrefix[1])
+        }
     }
 
     private class MockLanguageClient : LanguageClient {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -250,6 +250,13 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertTrue(mockClient.publishedDiagnostics?.diagnostics?.isEmpty() == true)
     }
 
+    fun testGetFileUriFormatting() {
+        val descriptor = DartLspServerDescriptor(project)
+        val file = myFixture.configureByText("foo.dart", "void main() {}").virtualFile
+        val expectedUri = DartAnalysisServerService.getInstance(project).getFileUri(file)
+        assertEquals(expectedUri, descriptor.getFileUri(file))
+    }
+
     private class MockLanguageClient : LanguageClient {
         var publishedDiagnostics: PublishDiagnosticsParams? = null
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -255,10 +255,9 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         val file = myFixture.configureByText("foo.dart", "void main() {}").virtualFile
         val uri = descriptor.getFileUri(file)
         assertTrue(uri.startsWith("file:///"))
-        if (com.intellij.openapi.util.SystemInfo.isWindows) {
-            val pathAfterPrefix = uri.substring("file:///".length)
-            assertTrue(pathAfterPrefix[0].isUpperCase())
-            assertEquals(':', pathAfterPrefix[1])
+        val pathAfterPrefix = uri.substring("file:///".length)
+        if (pathAfterPrefix.length >= 2 && (pathAfterPrefix[1] == ':' || pathAfterPrefix.substring(1).startsWith("%3A"))) {
+            assertTrue("Drive letter must be uppercase in: $uri", pathAfterPrefix[0].isUpperCase())
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/dart-intellij-third-party/issues/533

This mostly copies `getFileUri` from the IntelliJ LSP implementation but leaves out the last line lowercasing the drive letter.

We are otherwise sending uppercase drive letters, and we want to match the casing when sending LSP requests.

To test this, I reproduced the problem described in https://github.com/dart-lang/sdk/issues/63819 on Windows and verified that this change fixes the problem and does not show any duplicated errors after using LSP hover. I also made sure that hover still works as expected on mac.