### PR TITLE
Add instructions for dev build

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To receive development builds of the Dart plugin in IntelliJ IDEA:
 
 1. Open **Settings** (or **Preferences** on macOS) in IntelliJ IDEA.
 2. Go to **Plugins**.
-3. Click the ⚙️ (**Gear icon**) at the top right of the Plugins panel and select **Manage Plugin Repositories...**.
+3. Click the ⚙️ (**Gear icon**) at the top of the Plugins panel and select **Manage Plugin Repositories...**.
 4. Click **+** and add the dev channel repository URL:
    ```text
    https://plugins.jetbrains.com/plugins/dev/6351

--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@
 [![integration tests](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml/badge.svg?label=integration%20tests)](https://github.com/flutter/dart-intellij-third-party/actions/workflows/integration_tests.yaml)
 
 
+## Installing Dev Builds
+
+To receive development builds of the Dart plugin in IntelliJ IDEA:
+
+1. Open **Settings** (or **Preferences** on macOS) in IntelliJ IDEA.
+2. Go to **Plugins**.
+3. Click the ⚙️ (**Gear icon**) at the top right of the Plugins panel and select **Manage Plugin Repositories...**.
+4. Click **+** and add the dev channel repository URL:
+   ```text
+   https://plugins.jetbrains.com/plugins/dev/6351
+   ```
+5. Click **OK**. The IDE will now check for and install updates from the `dev` channel.
+
+
 ## Development setup
 
 1. Clone this repository with

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Retrieving diagnostics server with JetBrains LSP (#493)
+- Documenting the process for installing dev builds (#544)
 
 ### Changed
 


### PR DESCRIPTION
We have instructions for using the dev build in the Flutter plugin but not here. I wanted a spot in README to point users to when we suggest they try out a fix.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
