### PR TITLE
Replace TemplateContextType.isInContext deprecated method

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/template/DartTemplateContextType.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/template/DartTemplateContextType.java
@@ -1,6 +1,7 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.ide.template;
 
+import com.intellij.codeInsight.template.TemplateActionContext;
 import com.intellij.codeInsight.template.TemplateContextType;
 import com.intellij.openapi.fileTypes.SyntaxHighlighter;
 import com.intellij.openapi.util.NlsContexts;
@@ -32,9 +33,10 @@ public abstract class DartTemplateContextType extends TemplateContextType {
   }
 
   @Override
-  public boolean isInContext(@NotNull PsiFile file, int offset) {
+  public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
+    PsiFile file = templateActionContext.getFile();
     if (file.getLanguage() instanceof DartLanguage) {
-      PsiElement element = file.findElementAt(offset);
+      PsiElement element = file.findElementAt(templateActionContext.getStartOffset());
       return element != null && isInContext(element);
     }
     return false;


### PR DESCRIPTION
### Description
Replaced deprecated method `isInContext` from `TemplateContextType` class in `DartTemplateContextType.java` file

Note: Work of this PR was originally [here](https://github.com/flutter/dart-intellij-third-party/pull/528), but it was closed due to CLA problems.

### Testing steps:
**1. Run the IDE in Sandbox mode with the plugin**
**2. Prepare a Live Template for testing**
   Inside the Sandbox IDE window:
- Go to the IDE settings (Settings / Preferences).
- Navigate to `Editor` > `Live Templates`.
- Click the + (Add) button and select `Live Template`.
- Give it an abbreviation (e.g., `dtest`) and some template code (e.g., `print('hello');`).
- At the bottom, you will see a red warning saying "No applicable contexts". Click Define.
- Find `Dart` option (which matches the `contextId` registered in the `plugin.xml`) and check it.
- Apply.
 
**3. Test the "Happy Path" (It should work)**
- Create a .dart file inside the Sandbox IDE
- Start typing the abbreviation previously defined (dtest).
- The IDE should suggest the template. If you press Tab, the code will expand. This confirms that `file.getLanguage() instanceof DartLanguage` evaluated to true.

**4. Test the "Negative Path" (It should not work)**
- Create a file with a different extension in the same project, for example test.java or test.txt.
- Attempt to type the abbreviation (dtest).
- The IDE should not suggest or expand the template, since the condition requiring it to be a DartLanguage file is not met.

---

Review the contribution guidelines below:

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change) (N/A)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>

