### PR TITLE
fix: remove deprecated analysis_updateOptions call on server startup

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -111,7 +111,6 @@ import org.dartlang.analysis.server.protocol.AnalysisError;
 import org.dartlang.analysis.server.protocol.AnalysisErrorFixes;
 import org.dartlang.analysis.server.protocol.AnalysisErrorSeverity;
 import org.dartlang.analysis.server.protocol.AnalysisErrorType;
-import org.dartlang.analysis.server.protocol.AnalysisOptions;
 import org.dartlang.analysis.server.protocol.AnalysisService;
 import org.dartlang.analysis.server.protocol.AnalysisStatus;
 import org.dartlang.analysis.server.protocol.AvailableSuggestionSet;
@@ -2326,7 +2325,6 @@ public final class DartAnalysisServerService implements Disposable {
 
         mySdkVersion = sdk.getVersion();
 
-        startedServer.analysis_updateOptions(new AnalysisOptions(true, true, true, true, false, true, false));
         boolean supportsUris = isDartSdkVersionSufficientForFileUri(mySdkVersion);
         boolean supportsWorkspaceApplyEdits = isDartSdkVersionSufficientForWorkspaceApplyEdits(mySdkVersion);
         startedServer.server_setClientCapabilities(List.of("openUrlRequest", "showMessageRequest"),


### PR DESCRIPTION
### Description / Summary:                                                                   
                                                                                               
  This PR removes the redundant and deprecated startedServer.analysis_updateOptions(...) call  
  and its unused import from DartAnalysisServerService.java.                                   
                                                                                               
  ### Background & Context:                                                                    
                                                                                               
  1. Deprecated Server Protocol Method: analysis.updateOptions was deprecated in the Dart      
  Analysis Server protocol when static analysis configuration was consolidated into            
  analysis_options.yaml (introduced in Dart 1.20 and standardized in Dart 2.0+).               
  2. Plugin Minimum SDK Alignment: The Dart IntelliJ plugin enforces MIN_SDK_VERSION = "2.12"  
  (DartAnalysisServerService.java). All supported SDK versions rely on analysis_options.yaml   
  for analysis settings rather than imperative startup RPC calls.
  3. IDE Version Independent: This call belongs purely to the Dart Analysis Server JSON-RPC    
  protocol and is completely independent of any IntelliJ IDEA platform version (2025.3, 2026.1,
  2026.2, etc.).
  4. Generated Code Policy (thirdPartySrc): Per repository policy (README.md), generated files 
  inside thirdPartySrc (such as AnalysisServer.java and RemoteAnalysisServerImpl.java) are     
  bulk-copied from upstream and must not be edited directly. Plugin Verifier baseline warnings 
  for those generated files continue to be tracked in verifier-baseline.txt.
  ──────
  ### Changes Included:
  
  • third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java: 
      • Removed startedServer.analysis_updateOptions(new AnalysisOptions(...)) on server       
      startup.
      • Removed unused import org.dartlang.analysis.server.protocol.AnalysisOptions.           
  
  ──────
  ### Verification:
  
  [✓] Project compiled cleanly (./gradlew compileJava).
  [✓] All unit tests passed (./gradlew test --tests "com.jetbrains.lang.dart.*" - BUILD        
  SUCCESSFUL).
  [✓] Verified IDE startup without protocol errors.
  ──────
  TAG=agy
  CONV=72ac0397-ef69-41e4-91ef-6fe3c2fa80e5
