### PR TITLE
Rename DartInlayHintsProvider to DartClosingLabelsInlayHintsProvider

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Changed
 - Go to Definition implemented with JetBrains LSP (#539)
-- Rename `DartInlayHintsProvider` to `DartClosingLabelsInlayHintsProvider` to reflect that it only renders closing labels; provider ID and user settings are unchanged (#551)
 
 ### Removed
 

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 - Go to Definition implemented with JetBrains LSP (#539)
-- Renamed `DartInlayHintsProvider` to `DartClosingLabelsInlayHintsProvider` — it only renders closing labels; provider ID and user settings are unchanged (#551)
+- Rename `DartInlayHintsProvider` to `DartClosingLabelsInlayHintsProvider` to reflect that it only renders closing labels; provider ID and user settings are unchanged (#551)
 
 ### Removed
 

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Go to Definition implemented with JetBrains LSP (#539)
+- Renamed `DartInlayHintsProvider` to `DartClosingLabelsInlayHintsProvider` — it only renders closing labels; provider ID and user settings are unchanged (#551)
 
 ### Removed
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartClosingLabelManager.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartClosingLabelManager.java
@@ -5,7 +5,7 @@ import com.intellij.codeInsight.hints.declarative.DeclarativeInlayHintsSettings;
 import com.intellij.codeInsight.hints.declarative.impl.DeclarativeInlayHintsPassFactory;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.EditorFactory;
-import com.jetbrains.lang.dart.hints.DartInlayHintsProvider;
+import com.jetbrains.lang.dart.hints.DartClosingLabelsInlayHintsProvider;
 
 import java.util.Arrays;
 
@@ -16,7 +16,7 @@ public class DartClosingLabelManager {
 
   public void setShowClosingLabels(boolean value) {
     if (value != getShowClosingLabels()) {
-      DeclarativeInlayHintsSettings.Companion.getInstance().setProviderEnabled(DartInlayHintsProvider.PROVIDER_ID, value);
+      DeclarativeInlayHintsSettings.Companion.getInstance().setProviderEnabled(DartClosingLabelsInlayHintsProvider.PROVIDER_ID, value);
 
       Arrays.stream(EditorFactory.getInstance().getAllEditors())
         .filter(editor -> editor.getProject() != null && DartAnalysisServerService.isLocalAnalyzableFile(editor.getVirtualFile()))
@@ -25,6 +25,6 @@ public class DartClosingLabelManager {
   }
 
   public boolean getShowClosingLabels() {
-    return Boolean.TRUE.equals(DeclarativeInlayHintsSettings.Companion.getInstance().isProviderEnabled(DartInlayHintsProvider.PROVIDER_ID));
+    return Boolean.TRUE.equals(DeclarativeInlayHintsSettings.Companion.getInstance().isProviderEnabled(DartClosingLabelsInlayHintsProvider.PROVIDER_ID));
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/hints/DartClosingLabelsInlayHintsProvider.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/hints/DartClosingLabelsInlayHintsProvider.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiFile
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 
-class DartInlayHintsProvider : InlayHintsProvider {
+class DartClosingLabelsInlayHintsProvider : InlayHintsProvider {
   companion object {
     const val PROVIDER_ID: String = "dart.closing.labels"
   }

--- a/third_party/src/main/resources/META-INF/plugin.xml
+++ b/third_party/src/main/resources/META-INF/plugin.xml
@@ -154,7 +154,7 @@
        implementationClass="com.jetbrains.lang.dart.ide.template.postfix.DartPostfixTemplateProvider"/>
 
     <codeInsight.declarativeInlayProvider language="Dart"
-                                          implementationClass="com.jetbrains.lang.dart.hints.DartInlayHintsProvider"
+                                          implementationClass="com.jetbrains.lang.dart.hints.DartClosingLabelsInlayHintsProvider"
                                           isEnabledByDefault="true"
                                           group="OTHER_GROUP"
                                           providerId="dart.closing.labels"


### PR DESCRIPTION
The class only renders closing labels; with LSP inlay hints planned (#159) the old name becomes misleading. `providerId` ("dart.closing.labels") and all registration attributes are unchanged, so persisted user settings are unaffected. No functional change.

The "Flutter widget closing label" still works. Nothing more to test.

Disclaimer: This was mainly developed by Claude Fable 5 with the help of [superpowers](https://github.com/obra/superpowers)

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
