### PR TITLE
Lsp document highlight

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Retrieving diagnostics server with JetBrains LSP (#493)
 - Documenting the process for installing dev builds (#544)
+- Highlighting read vs write variable occurrences (JetBrains LSP, experimental feature) (#PR)
 
 ### Changed
 - Go to Definition implemented with JetBrains LSP (#539)

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 - Retrieving diagnostics server with JetBrains LSP (#493)
 - Documenting the process for installing dev builds (#544)
-- Highlighting read vs write variable occurrences (JetBrains LSP, experimental feature) (#PR)
+- Highlighting read vs write variable occurrences (JetBrains LSP, experimental feature) (#552)
 
 ### Changed
 - Go to Definition implemented with JetBrains LSP (#539)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -10,6 +10,7 @@ import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.google.gson.reflect.TypeToken
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.Project
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
@@ -241,14 +242,14 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
     // Note: We advertise linkSupport: true in server.setClientCapabilities (see RequestUtilities.java)
     // so DAS is guaranteed to return List<LocationLink> for textDocument/definition.
     override fun definition(params: DefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
-        val type = object : com.google.gson.reflect.TypeToken<List<LocationLink>>() {}.type
+        val type = object : TypeToken<List<LocationLink>>() {}.type
         return forwardRequest<List<LocationLink>>("textDocument/definition", params, type).thenApply { links ->
             Either.forRight(links ?: emptyList())
         }
     }
 
     override fun documentHighlight(params: DocumentHighlightParams): CompletableFuture<List<DocumentHighlight>> {
-        val type = object : com.google.gson.reflect.TypeToken<List<DocumentHighlight>>() {}.type
+        val type = object : TypeToken<List<DocumentHighlight>>() {}.type
         return forwardRequest<List<DocumentHighlight>>("textDocument/documentHighlight", params, type)
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -21,6 +21,8 @@ import org.eclipse.lsp4j.DidChangeWatchedFilesParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
+import org.eclipse.lsp4j.DocumentHighlight
+import org.eclipse.lsp4j.DocumentHighlightParams
 import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.HoverParams
 import org.eclipse.lsp4j.InitializeParams
@@ -211,6 +213,7 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
         val capabilities = ServerCapabilities().apply {
             setHoverProvider(true)
             setDefinitionProvider(true)
+            setDocumentHighlightProvider(true)
             // Add other capabilities as we support them.
         }
         return CompletableFuture.completedFuture(InitializeResult(capabilities))
@@ -242,6 +245,11 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
         return forwardRequest<List<LocationLink>>("textDocument/definition", params, type).thenApply { links ->
             Either.forRight(links ?: emptyList())
         }
+    }
+
+    override fun documentHighlight(params: DocumentHighlightParams): CompletableFuture<List<DocumentHighlight>> {
+        val type = object : com.google.gson.reflect.TypeToken<List<DocumentHighlight>>() {}.type
+        return forwardRequest<List<DocumentHighlight>>("textDocument/documentHighlight", params, type)
     }
 
     override fun diagnosticServer(): CompletableFuture<DiagnosticServerResult> {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -21,7 +21,9 @@ import com.intellij.platform.dartlsp.api.customization.LspCompletionDisabled
 import com.intellij.platform.dartlsp.api.customization.LspCustomization
 import com.intellij.platform.dartlsp.api.customization.LspDiagnosticsDisabled
 import com.intellij.platform.dartlsp.api.customization.LspDocumentColorDisabled
+import com.intellij.platform.dartlsp.api.customization.LspDocumentHighlightsCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspDocumentHighlightsDisabled
+import com.intellij.platform.dartlsp.api.customization.LspDocumentHighlightsSupport
 import com.intellij.platform.dartlsp.api.customization.LspDocumentLinkDisabled
 import com.intellij.platform.dartlsp.api.customization.LspDocumentSymbolDisabled
 import com.intellij.platform.dartlsp.api.customization.LspFindReferencesDisabled
@@ -42,6 +44,7 @@ import com.intellij.platform.dartlsp.api.customization.LspSemanticTokensDisabled
 import com.intellij.platform.dartlsp.api.customization.LspSignatureHelpDisabled
 import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchyDisabled
 import com.intellij.platform.dartlsp.api.customization.LspWorkspaceSymbolDisabled
+import com.intellij.psi.PsiFile
 import com.intellij.util.io.URLUtil
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.sdk.DartConfigurable
@@ -125,7 +128,15 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
         override val documentLinkCustomizer = LspDocumentLinkDisabled
         override val foldingRangeCustomizer = LspFoldingRangeDisabled
         override val inlayHintCustomizer = LspInlayHintDisabled
-        override val documentHighlightsCustomizer = LspDocumentHighlightsDisabled
+        override val documentHighlightsCustomizer: LspDocumentHighlightsCustomizer
+            get() = if (DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
+                object : LspDocumentHighlightsSupport() {
+                    // The default implementation only serves plain-text/TextMate files.
+                    override fun shouldAskServerForDocumentHighlights(psiFile: PsiFile): Boolean = true
+                }
+            } else {
+                LspDocumentHighlightsDisabled
+            }
         override val signatureHelpCustomizer = LspSignatureHelpDisabled
         override val documentSymbolCustomizer = LspDocumentSymbolDisabled
         override val workspaceSymbolCustomizer = LspWorkspaceSymbolDisabled

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -12,6 +12,7 @@ enum class LspMethod(
 ) {
     DEFINITION("textDocument/definition", isExperimental = true, presentableName = "navigation"),
     DIAGNOSTIC_SERVER("dart/diagnosticServer", isExperimental = true, presentableName = "diagnostic server"),
+    DOCUMENT_HIGHLIGHT("textDocument/documentHighlight", isExperimental = true, presentableName = "read/write highlighting"),
     HOVER("textDocument/hover", isExperimental = true, presentableName = "hover"),
     INITIALIZE("initialize"),
     SHUTDOWN("shutdown");

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -149,9 +149,11 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
 
         bridgeServer.hover(params)
 
-        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
-        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
-        assertEquals("123", jsonObject!!.get("id").asString)
+        val jsonObject = requireNotNull(capturedRequests.find { it.get("method")?.asString == "lsp.handle" }) {
+            "An lsp.handle request should be sent to DAS"
+        }
+        
+        assertEquals("123", jsonObject.get("id")?.asString)
 
         val outerParams = jsonObject.getAsJsonObject("params")
         val lspMessage = outerParams.getAsJsonObject("lspMessage")

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -273,8 +273,9 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
 
         val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
         assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
 
-        val lspMessage = jsonObject!!.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
         assertEquals("123", lspMessage.get("id").asString)
         assertEquals("textDocument/documentHighlight", lspMessage.get("method").asString)
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -19,6 +19,8 @@ import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import org.dartlang.analysis.server.protocol.DartLspApplyWorkspaceEditParams
 import org.dartlang.analysis.server.protocol.MessageAction
+import org.eclipse.lsp4j.DocumentHighlightKind
+import org.eclipse.lsp4j.DocumentHighlightParams
 import org.eclipse.lsp4j.HoverParams
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
@@ -259,6 +261,45 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         if (pathAfterPrefix.length >= 2 && (pathAfterPrefix[1] == ':' || pathAfterPrefix.substring(1).startsWith("%3A"))) {
             assertTrue("Drive letter must be uppercase in: $uri", pathAfterPrefix[0].isUpperCase())
         }
+    }
+
+    fun testDocumentHighlightRequest() {
+        val params = DocumentHighlightParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(1, 2)
+        }
+
+        val future = bridgeServer.documentHighlight(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+
+        val lspMessage = jsonObject!!.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("textDocument/documentHighlight", lspMessage.get("method").asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": [
+                    {"range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 5}}, "kind": 3},
+                    {"range": {"start": {"line": 2, "character": 2}, "end": {"line": 2, "character": 3}}, "kind": 2}
+                  ]
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertEquals(2, result.size)
+        assertEquals(DocumentHighlightKind.Write, result[0].kind)
+        assertEquals(DocumentHighlightKind.Read, result[1].kind)
     }
 
     private class MockLanguageClient : LanguageClient {


### PR DESCRIPTION
Enables LSP `textDocument/documentHighlight` through the bridge behind the experimental-LSP setting. With SDKs that provide highlight kinds, the Dart Analysis Server sets `DocumentHighlightKind` Read/Write/Text (dart-lang/sdk#62929), so writes get the write caret color — matching Java/Kotlin behavior. Contributes one of the endpoints listed in #546; object-pattern highlights (#92) work in LSP mode.

SDK requirements and degradation, verified in the IDE sandbox:

- Read/write kinds require a Dart SDK ≥ 3.13 (first build containing dart-lang/sdk#62929 is `3.13.0-107.0.dev`; verified with `3.13.0-282.3.beta`). On current stable (3.12.x) the server returns kind-less highlights and everything renders with the read color — visually today's behavior.
- Even on kind-less SDKs the LSP occurrences are more complete than the built-in PSI pass: e.g. all references of a local function, including its declaration, are highlighted. 
- On very old SDKs whose legacy server predates the shared `documentHighlight` handler, the forwarded request fails and caret identifier highlighting is absent while the flag is on (a warning is logged); this matches the exposure shape the hover migration shipped with.

Trade-offs: Find Usages read/write classification is not covered by LSP documentHighlight (would need a `ReadWriteAccessDetector`, see design doc).

Per the migrate-das-to-lsp skill: there is no Dart legacy provider to gate for this feature — the platform automatically prefers the LSP highlight handler over the built-in PSI identifier highlighting while the flag is on, and injected fragments / non-local files intentionally fall back to the built-in pass.

**Testing note for reviewers:** the bundled LSP client caches documentHighlight results per (document, offset) until the document is modified. Results fetched *before* enabling the experimental flag, restarting the analysis server, or switching the Dart SDK are served stale at previously visited caret positions — which can look like the feature "doesn't work" (all occurrences render as read). Make any edit to the file to invalidate the cache before judging the colors. Also note that swapping the SDK on disk does not restart an already-running analysis server — use the "Restart Dart Analysis Server" action first.


<img width="275" height="223" alt="SCR-20260730-pbma" src="https://github.com/user-attachments/assets/d402fef7-8083-4284-b924-a89fb67cea1a" />

Disclaimer: This was mainly developed by Claude Fable 5 with the help of [superpowers](https://github.com/obra/superpowers)

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>

