### PR TITLE
Improve WebSocket.kt code by using sendLock instead of @Synchronized.

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/websocket/WebSocket.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/websocket/WebSocket.kt
@@ -47,9 +47,9 @@ class WebSocket(private val uri: URI) {
 
     @Throws(WebSocketException::class)
     fun send(text: String) {
-        val webSocket = jdkWebSocket.get() ?: throw WebSocketException("WebSocket is not connected")
         synchronized(sendLock)
         {
+            val webSocket = jdkWebSocket.get() ?: throw WebSocketException("WebSocket is not connected")
             val future = webSocket.sendText(text, true).toCompletableFuture()
             try {
                 future.get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/websocket/WebSocket.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/websocket/WebSocket.kt
@@ -12,6 +12,7 @@ import java.net.http.WebSocket as JdkWebSocket
 import java.nio.ByteBuffer
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A thin wrapper around the JDK [java.net.http.WebSocket] that originally mirrored the API of the
@@ -19,8 +20,8 @@ import java.util.concurrent.TimeUnit
  */
 class WebSocket(private val uri: URI) {
 
-    @Volatile
-    private var jdkWebSocket: JdkWebSocket? = null
+    private val jdkWebSocket = AtomicReference<JdkWebSocket?>()
+    private val sendLock = Any()
 
     @Volatile
     var eventHandler: WebSocketEventHandler? = null
@@ -44,26 +45,27 @@ class WebSocket(private val uri: URI) {
         }
     }
 
-    @Synchronized
     @Throws(WebSocketException::class)
     fun send(text: String) {
-        val webSocket = jdkWebSocket ?: throw WebSocketException("WebSocket is not connected")
-        val future = webSocket.sendText(text, true).toCompletableFuture()
-        try {
-            future.get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        } catch (e: Exception) {
-            future.cancel(true)
-            if (e is InterruptedException) {
-                Thread.currentThread().interrupt()
+        val webSocket = jdkWebSocket.get() ?: throw WebSocketException("WebSocket is not connected")
+        synchronized(sendLock)
+        {
+            val future = webSocket.sendText(text, true).toCompletableFuture()
+            try {
+                future.get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            } catch (e: Exception) {
+                future.cancel(true)
+                if (e is InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+                throw WebSocketException("Failed to send WebSocket message", e)
             }
-            throw WebSocketException("Failed to send WebSocket message", e)
         }
     }
 
-    @Synchronized
     @Throws(WebSocketException::class)
     fun close() {
-        val webSocket = jdkWebSocket ?: return
+        val webSocket = jdkWebSocket.getAndSet(null) ?: return
         val future = webSocket.sendClose(JdkWebSocket.NORMAL_CLOSURE, "Normal Closure").toCompletableFuture()
         try {
             future.get(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
@@ -73,8 +75,6 @@ class WebSocket(private val uri: URI) {
                 Thread.currentThread().interrupt()
             }
             throw WebSocketException("Failed to close WebSocket gracefully", e)
-        } finally {
-            jdkWebSocket = null
         }
     }
 
@@ -82,7 +82,7 @@ class WebSocket(private val uri: URI) {
         private val pendingText = StringBuilder()
 
         override fun onOpen(webSocket: JdkWebSocket) {
-            jdkWebSocket = webSocket
+            jdkWebSocket.set(webSocket)
             webSocket.request(Long.MAX_VALUE)
             eventHandler?.onOpen()
         }
@@ -100,14 +100,14 @@ class WebSocket(private val uri: URI) {
         // We could use the statusCode and the reason for logging purposes
         override fun onClose(webSocket: JdkWebSocket, statusCode: Int, reason: String): CompletionStage<*>? {
             pendingText.clear()
-            jdkWebSocket = null
+            jdkWebSocket.compareAndSet(webSocket, null)
             eventHandler?.onClose()
             return null
         }
 
         override fun onError(webSocket: JdkWebSocket, error: Throwable) {
             pendingText.clear()
-            jdkWebSocket = null
+            jdkWebSocket.compareAndSet(webSocket, null)
             eventHandler?.onClose()
         }
 


### PR DESCRIPTION
## Summary

This pr is a refactor of WebSocket class.

- instead of using Synchronized over the send() and close() method a sendLock is used.
- Use AtomicReference for thread safty and use val instead of var


### Testing

All the websocket related integration test are passed.
I also ran a manual testing and everything seems ok.

These changes are initiated because of recommendations of Gemini on this [pr](https://github.com/flutter/flutter-intellij/pull/9060)