### PR TITLE
[infra] + auto-assign PR review workflow

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+addReviewers: true
+addAssignees: false
+
+reviewers:
+  - helin24
+  - pq
+
+numberOfReviewers: 1

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,12 @@
+name: 'Auto Assign'
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    # Don't auto-assign for project owners.
+    if: github.actor != 'pq' && github.actor != 'helin24'
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.1

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,7 +1,13 @@
 name: 'Auto Assign'
 on:
+  # Safe because this workflow does not checkout untrusted code or execute any scripts.
+  # It strictly passes metadata to a trusted action to use the GitHub API.
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
 
 jobs:
   add-reviews:
@@ -9,4 +15,4 @@ jobs:
     # Don't auto-assign for project owners.
     if: github.actor != 'pq' && github.actor != 'helin24'
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.1
+      - uses: kentaro-m/auto-assign-action@a6d59add3a817df08cafa9b166367768d2c337f8 # v2.0.1


### PR DESCRIPTION
Adds a GitHub Action workflow to automatically assign PR reviewers for external contributions (since they can't). 

Fixes: https://github.com/flutter/dart-intellij-third-party/issues/556.

Notes:
* This is using a random assignment but we could consider role-based OWNERS-file-driven assignment down the road.
* This skips PRs from owners for now (leaving them to request a review themselves); we could re-evaluate that too obviously.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
