### PR TITLE
Fix 'project-initialize' deprecated code and memory leak on close IDE

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
@@ -183,6 +183,7 @@ public final class DartModuleBuilder extends ModuleBuilder {
     // This perfectly handles both WebStorm (already initialized) and IntelliJ IDEA (needs to wait).
 
     DumbService.getInstance(module.getProject()).runWhenSmart(() -> {
+      if (module.isDisposed()) return;
       if (ModalityState.current() == ModalityState.nonModal()) {
         runnable.run();
       }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
@@ -139,7 +139,7 @@ public final class DartModuleBuilder extends ModuleBuilder {
       DartSdkUtil.updateKnownSdkPaths(project, wizardData.dartSdkPath);
 
       final LibraryTable.ModifiableModel libraryTableModifiableModel =
-              ModifiableModelsProvider.getInstance().getLibraryTableModifiableModel(project);
+        ModifiableModelsProvider.getInstance().getLibraryTableModifiableModel(project);
 
       DartSdkLibUtil.ensureDartSdkConfigured(project, libraryTableModifiableModel, wizardData.dartSdkPath);
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleBuilder.java
@@ -15,13 +15,13 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.WebModuleBuilder;
 import com.intellij.openapi.module.WebModuleTypeBase;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModifiableModelsProvider;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
-import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -139,7 +139,7 @@ public final class DartModuleBuilder extends ModuleBuilder {
       DartSdkUtil.updateKnownSdkPaths(project, wizardData.dartSdkPath);
 
       final LibraryTable.ModifiableModel libraryTableModifiableModel =
-        ModifiableModelsProvider.getInstance().getLibraryTableModifiableModel(project);
+              ModifiableModelsProvider.getInstance().getLibraryTableModifiableModel(project);
 
       DartSdkLibUtil.ensureDartSdkConfigured(project, libraryTableModifiableModel, wizardData.dartSdkPath);
 
@@ -178,20 +178,20 @@ public final class DartModuleBuilder extends ModuleBuilder {
   }
 
   static void runWhenNonModalIfModuleNotDisposed(final @NotNull Runnable runnable, final @NotNull Module module) {
-    // runnable must not be executed immediately because the new project model might be not yet committed, so Dart SDK won't be found
-    // In WebStorm we get already initialized project at this point, but in IntelliJ IDEA - not yet initialized.
+    // runnable must not be executed immediately because the new project model might be not yet committed, so Dart SDK won't be found.
+    // DumbService.runWhenSmart waits for the project to be fully initialized, loaded, and indexed.
+    // This perfectly handles both WebStorm (already initialized) and IntelliJ IDEA (needs to wait).
 
-    if (module.getProject().isInitialized()) {
-      ApplicationManager.getApplication().invokeLater(runnable, ModalityState.nonModal(), module.getDisposed());
-      return;
-    }
-
-    StartupManager.getInstance(module.getProject()).runWhenProjectIsInitialized(() -> {
+    DumbService.getInstance(module.getProject()).runWhenSmart(() -> {
       if (ModalityState.current() == ModalityState.nonModal()) {
         runnable.run();
       }
       else {
-        ApplicationManager.getApplication().invokeLater(runnable, ModalityState.nonModal(), o -> module.isDisposed());
+        ApplicationManager.getApplication().invokeLater(
+                runnable,
+                ModalityState.nonModal(),
+                o -> module.isDisposed()
+        );
       }
     });
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleWizardStep.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/projectWizard/DartModuleWizardStep.java
@@ -5,6 +5,7 @@ import com.intellij.ide.util.projectWizard.ProjectBuilder;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.util.Disposer;
 
 import javax.swing.*;
 
@@ -37,6 +38,6 @@ public class DartModuleWizardStep extends ModuleWizardStep implements Disposable
 
   @Override
   public void dispose() {
-
+    Disposer.dispose(myPeer);
   }
 }


### PR DESCRIPTION
### Changes
- Replace StartupManager with DumbService since JetBrains has been marking StartupManager's imperative methods as obsolete in favor of declarative listeners (for plugins) and DumbService (for dynamic actions like Wizards), with the goal of improving load times and avoiding interface blocking.
- During manually tests a memory leak was found, so it was fixed by manually disposing of the peer during the IDE closing procedure.

### How to test
*For the deprecated code*
- Run the project
- Create a new `Dart` project (CLI is ok)
- When the IDE finishes, make sure you see in the logs that the `dart pub run` command was successfully executed and `pubspec.yaml` file is opened. 

*For the memory leak*
- Checkout `main` branch
- Open/create a new `Dart` project (CLI project is enough)
- Let the IDE finish initialization
- Close the IDE and you will see an error in the stacktrace (`DartModuleBuilder` is there)
- Checkout this branch and repeat steps 2, 3 and 4; you will not see the error now.

Note: Reviewed original [PR](https://github.com/ranbeuer/dart-intellij-third-party/pull/4) 

---

Review the contribution guidelines below:

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change) (N/A)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
