### PR TITLE
Remove remaining until build mentions

### DIFF
--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -102,7 +102,7 @@ intellijPlatform {
         }
 
         println("plugin version: ${version.get()}")
-        println("ideaVersion: ${ideaVersion.sinceBuild.get()} and above")
+        println("ideaVersion: ${this.ideaVersion.sinceBuild.get()} and above")
 
         changeNotes = provider {
             project.changelog.renderItem(project.changelog.getLatest(), Changelog.OutputType.HTML)

--- a/third_party/build.gradle.kts
+++ b/third_party/build.gradle.kts
@@ -102,7 +102,7 @@ intellijPlatform {
         }
 
         println("plugin version: ${version.get()}")
-        println("ideaVersion: ${ideaVersion.sinceBuild.get()} to ${ideaVersion.untilBuild.orNull}")
+        println("ideaVersion: ${ideaVersion.sinceBuild.get()} and above")
 
         changeNotes = provider {
             project.changelog.renderItem(project.changelog.getLatest(), Changelog.OutputType.HTML)
@@ -313,7 +313,6 @@ tasks {
     printProductsReleases {
         channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
         types = listOf(IntelliJPlatformType.IntellijIdeaCommunity, IntelliJPlatformType.IntellijIdeaUltimate, IntelliJPlatformType.AndroidStudio)
-        untilBuild = provider { null }
         doLast {
             println()
             println("Mapping printProductsReleases output to ideV:")


### PR DESCRIPTION
I thought this was needed to fix dev build, but it turns out that was an unrelated issue (or non-issue / not reproducible / intermittent).

This is reasonable for cleanup anyway; my initial removal of `untilBuild` left a couple places that still put in nulls for it which is unnecessary.

To test, make sure `./gradlew buildPlugin` still works.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- ~[ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)~

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
