### PR TITLE
[ai] + port-pr skill

### DIFF
--- a/.agents/skills/port-pr/SKILL.md
+++ b/.agents/skills/port-pr/SKILL.md
@@ -23,7 +23,7 @@ This skill guides the agent to port architectural and conceptual changes from a 
 
 4. **Analyze the Diff:**
    - Read the changes carefully to understand what is being modified.
-   - Identify the core conceptual and architectural changes being made (e.g., refactoring DAS to LSP, updating a specific IntelliJ Platform API usage, migrating to a new UI component).
+   - Identify the core conceptual and architectural changes being made (e.g., updating the build process, updating a specific IntelliJ Platform API usage, migrating to a new UI component).
 
 5. **Map the File Structure:**
    - The file structures between `dart-intellij-third-party` and `flutter-intellij` are different, although they share some common IntelliJ plugin patterns.

--- a/.agents/skills/port-pr/SKILL.md
+++ b/.agents/skills/port-pr/SKILL.md
@@ -18,8 +18,8 @@ This skill guides the agent to port architectural and conceptual changes from a 
    - If the PR is from the `flutter/flutter-intellij` repository, the target repository is `dart-intellij-third-party`.
 
 3. **Fetch PR Details using GitHub MCP:**
-   - Use the `github` MCP server tools (like `pull_request_read`, `get_commit`, or `get_file_contents`) to fetch the PR's description, commits, and diffs. 
-   - Note: If `pull_request_read` requires repository owner and name, extract them from the PR URL.
+   - Use the `github` MCP server tools (like `get_pull_request`, `get_commit`, or `get_file_contents`) to fetch the PR's description, commits, and diffs. 
+   - Note: If `get_pull_request` requires repository owner and name, extract them from the PR URL.
 
 4. **Analyze the Diff:**
    - Read the changes carefully to understand what is being modified.
@@ -31,7 +31,7 @@ This skill guides the agent to port architectural and conceptual changes from a 
    - Use `grep_search` or codebase exploration tools in the target repository to find where the comparable logic lives.
 
 6. **Apply Changes Methodically:**
-   - Make the necessary code changes in the target repository using your file editing tools (`replace_file_content`, `multi_replace_file_content`, etc.).
+   - Make the necessary code changes in the target repository using your file editing tools (`write_file`, `edit_file`, etc.).
    - Adapt the code as necessary to fit the target repository's context, patterns, and language (Java vs Kotlin, etc.).
    - Do not just blindly copy-paste code; apply the *conceptual* changes.
 

--- a/.agents/skills/port-pr/SKILL.md
+++ b/.agents/skills/port-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: port-pr
+description: Fetches a Pull Request from either the dart-intellij-third-party or flutter-intellij repository and conceptually ports its changes to the other repository.
+---
+
+# Port PR Skill
+
+This skill guides the agent to port architectural and conceptual changes from a Pull Request in one repository to another (specifically between the Dart and Flutter IntelliJ plugins).
+
+## Step-by-Step Instructions
+
+1. **Obtain the PR Link:**
+   - If the user did not provide a Pull Request link or number in their request, ask them for the PR link before proceeding.
+
+2. **Determine Origin and Target Repositories:**
+   - Examine the PR link to determine the origin repository.
+   - If the PR is from the Dart plugin repository (e.g., `JetBrains/intellij-plugins` or the `dart-intellij-third-party` fork), the target repository is `flutter-intellij`.
+   - If the PR is from the `flutter/flutter-intellij` repository, the target repository is `dart-intellij-third-party`.
+
+3. **Fetch PR Details using GitHub MCP:**
+   - Use the `github` MCP server tools (like `pull_request_read`, `get_commit`, or `get_file_contents`) to fetch the PR's description, commits, and diffs. 
+   - Note: If `pull_request_read` requires repository owner and name, extract them from the PR URL.
+
+4. **Analyze the Diff:**
+   - Read the changes carefully to understand what is being modified.
+   - Identify the core conceptual and architectural changes being made (e.g., refactoring DAS to LSP, updating a specific IntelliJ Platform API usage, migrating to a new UI component).
+
+5. **Map the File Structure:**
+   - The file structures between `dart-intellij-third-party` and `flutter-intellij` are different, although they share some common IntelliJ plugin patterns.
+   - Map the origin files to their equivalent or corresponding files in the target repository. 
+   - Use `grep_search` or codebase exploration tools in the target repository to find where the comparable logic lives.
+
+6. **Apply Changes Methodically:**
+   - Make the necessary code changes in the target repository using your file editing tools (`replace_file_content`, `multi_replace_file_content`, etc.).
+   - Adapt the code as necessary to fit the target repository's context, patterns, and language (Java vs Kotlin, etc.).
+   - Do not just blindly copy-paste code; apply the *conceptual* changes.
+
+7. **Verify Changes:**
+   - Ensure the new code follows the style guidelines of the target repository.
+   - If tests are affected or needed, update or add them.
+   - Compile or lint the code if possible to verify correctness before presenting the changes to the user.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -60,3 +60,5 @@ enforce standard modern Java/Kotlin coding conventions, but strictly police the 
 - **Meaningful Naming:** Variables should describe their intent (e.g., `timeoutInMs` instead of `t`).
 - **Copyrights:** All new Dart, Java and Kotlin files should include a copyright header.
 - **Changelog Entries:** Enforce that there is a changelog entry for all user-facing changes. Entries must strictly match the existing grammatical style using descriptive, state-based phrases (typically starting with gerunds, nouns, or verbs like *Avoid* / *Support* / *Log* / *Prevent*) rather than starting with the imperative verb *Fix* or *Add*.
+- **Portability:** Flag any references to local directories (e.g., `/Users/username/...`), hardcoded LDAP/usernames, or environment-specific paths that could make tools, scripts, or agent skills less portable.
+- **Agent Skills Documentation:** Enforce that any newly created or added agent skills (i.e., new `SKILL.md` files) are documented in the repository's `README.md`.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ These skills are located in the [.agents/skills/](.agents/skills/) directory. Th
 * **[Code Review](.agents/skills/code-review/SKILL.md):** Performs a pedantic, multi-perspective code review (covering logic, correctness, resource safety, design, and styleguide compliance) on your uncommitted changes.
 * **[Migrate DAS to LSP](.agents/skills/migrate-das-to-lsp/SKILL.md):** Guide for converting legacy Dart Analysis Server (DAS) feature implementations to JetBrains LSP in the Dart IntelliJ plugin.
 * **[Patch Copied LSP Sources](.agents/skills/patch-copied-lsp-sources/SKILL.md):** Automates copying and patching of JetBrains LSP sources.
+* **[Port PR](.agents/skills/port-pr/SKILL.md):** Fetches a Pull Request from either the dart-intellij-third-party or flutter-intellij repository and conceptually ports its changes to the other repository.
 
 ### How to use:
 Tell your AI assistant to run the desired skill (e.g. by typing `/code-review` or asking *"Run the code-review skill on my changes"*). The agent will automatically find, load, and follow the instructions in the corresponding `SKILL.md` file.


### PR DESCRIPTION
As detected by the [conversation-auditor skill](https://github.com/pq/pq-agent-skills#%EF%B8%8F-conversation-auditor), we commonly want to apply changes made in one plugin repo to the other. This skillifies that.

Along the way I caught some portability issues and updated the style guide; similarly I added a change to make sure reviews catch undocumented skills.

**Changes:**
* **New Agent Skill (`port-pr`):** Added a new skill in `.agents/skills/port-pr/SKILL.md` that instructs the AI agent on how to conceptually port a Pull Request between the Dart and Flutter plugins.
* **README Updates:** Documented the new `port-pr` skill in the `README.md` under the AI Coding Agent Skills section.
* **Styleguide Enhancements (`.gemini/styleguide.md`):**
  * **Portability:** Added a rule to flag references to hardcoded local directories, environment-specific paths, or LDAPs during code review.
  * **Agent Skills Documentation:** Added a rule enforcing that all newly created agent skills (`SKILL.md` files) must be documented in the repository's `README.md`.



---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
