### PR TITLE
Add release skill

### DIFF
--- a/.agents/skills/monthly-release/SKILL.md
+++ b/.agents/skills/monthly-release/SKILL.md
@@ -22,6 +22,7 @@ Use this skill when preparing, testing, validating, and publishing a new monthly
   2. Identify missing user-facing PRs (bug fixes, new features, performance enhancements).
   3. In `third_party/CHANGELOG.md`, rename `## Unreleased` to `## <new-version>` (e.g. `## 508.0.0`).
   4. Follow changelog formatting conventions:
+     - Entries must strictly use descriptive, state-based phrases (typically starting with gerunds, nouns, or verbs like *Avoid* / *Support* / *Log* / *Prevent*) rather than starting with imperative verbs like *Fix* or *Add*.
      - Under `### Removed`, do NOT repeat action verbs like "Remove" (e.g., `- untilBuild restriction (#553)`).
   5. Add a fresh empty `## Unreleased` section at the top of `third_party/CHANGELOG.md` with standard subheaders (`### Added`, `### Changed`, `### Removed`, `### Fixed`).
   6. Create PR (e.g. `Update changelog for <version> (#<PR>)`) and merge it to `main`.
@@ -29,7 +30,7 @@ Use this skill when preparing, testing, validating, and publishing a new monthly
 
 ### 2. Build & Validate
 - **Compilation & Structure Verification**:
-  1. Ensure local `main` is checked out and updated (`git fetch upstream && git checkout main && git reset --hard upstream/main`).
+  1. Ensure local `main` is checked out and updated (`git fetch upstream && git checkout main && git reset --hard upstream/main`), and navigate to the `third_party` directory (`cd third_party`).
   2. Run compilation check:
      ```shell
      ./gradlew testClasses
@@ -43,7 +44,7 @@ Use this skill when preparing, testing, validating, and publishing a new monthly
      ./gradlew test
      ```
 - **Build Prospective Release Zip Artifact**:
-  1. Run the Gradle build with `-PversionedName`:
+  1. Run the Gradle build with `-PversionedName` (from the `third_party` directory):
      ```shell
      ./gradlew buildPlugin -PversionedName
      ```

--- a/.agents/skills/monthly-release/SKILL.md
+++ b/.agents/skills/monthly-release/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: monthly-release
+description: Step-by-step guide for performing monthly releases of the Dart IntelliJ plugin.
+---
+
+# Monthly Plugin Release Process
+
+Use this skill when preparing, testing, validating, and publishing a new monthly release of the Dart IntelliJ plugin (`dart-intellij-third-party`).
+
+> [!NOTE]
+> **Platform Compatibility Policy**: `untilBuild` is intentionally omitted in `gradle.properties` and `build.gradle.kts` to maintain open-ended compatibility with future IDE builds without artificial version caps. Do NOT add `untilBuild` caps during monthly releases.
+
+---
+
+## Release Process Checklist
+
+### 1. Update Changelog for the Release
+- **Branch**: `changelog` (created off `upstream/main`)
+- **Goal**: Collect unreleased user-facing PRs into the release version header and set up a new `## Unreleased` block.
+- **Steps**:
+  1. Review commits merged since the previous release (`git log <last-release-commit>..upstream/main`).
+  2. Identify missing user-facing PRs (bug fixes, new features, performance enhancements).
+  3. In `third_party/CHANGELOG.md`, rename `## Unreleased` to `## <new-version>` (e.g. `## 508.0.0`).
+  4. Follow changelog formatting conventions:
+     - Under `### Removed`, do NOT repeat action verbs like "Remove" (e.g., `- untilBuild restriction (#553)`).
+  5. Add a fresh empty `## Unreleased` section at the top of `third_party/CHANGELOG.md` with standard subheaders (`### Added`, `### Changed`, `### Removed`, `### Fixed`).
+  6. Create PR (e.g. `Update changelog for <version> (#<PR>)`) and merge it to `main`.
+  7. Delete local and remote `changelog` branch upon merge (`git branch -D changelog`).
+
+### 2. Build & Validate
+- **Compilation & Structure Verification**:
+  1. Ensure local `main` is checked out and updated (`git fetch upstream && git checkout main && git reset --hard upstream/main`).
+  2. Run compilation check:
+     ```shell
+     ./gradlew testClasses
+     ```
+  3. Run plugin structure validation:
+     ```shell
+     ./gradlew verifyPluginStructure
+     ```
+  4. Run unit tests:
+     ```shell
+     ./gradlew test
+     ```
+- **Build Prospective Release Zip Artifact**:
+  1. Run the Gradle build with `-PversionedName`:
+     ```shell
+     ./gradlew buildPlugin -PversionedName
+     ```
+  2. **Behavior**:
+     - Gradle reads the release version (`<version>`) directly from `CHANGELOG.md`.
+     - The `-PversionedName` flag instructs `build.gradle.kts` to output `Dart-<version>-<commitHash>.zip`.
+     - Generated zip location: `third_party/build/distributions/Dart-<version>-<commitHash>.zip`.
+
+### 3. Upload Release Candidate to Google Drive
+- **Location**: [Devexp folder releases > Dart plugin builds](https://drive.google.com/corp/drive/folders/14PIy3OCZW5WBJjjFeKcqTXTf1ZhXAUCY?resourcekey=0-0WZ8mFRUYRhQzRw9UgQLQQ)
+- **Goal**: Upload `Dart-<version>-<commitHash>.zip` to the designated Google Drive folder for team testing prior to public Marketplace release.
+
+### 4. Perform Manual Testing Across IDE Versions
+Perform manual sanity checks across all supported IDE platform versions (IntelliJ IDEA Ultimate/Community and Android Studio):
+- **Baseline Smoke Tests**:
+  - [ ] **Create New Project**: Verify new Dart project creation succeeds.
+  - [ ] **Open Existing Project**: Verify existing Dart project opens cleanly.
+  - [ ] **Run & Debug**: Run a Dart app/script, hit breakpoints, inspect variables.
+- **Targeted Release Tests**:
+  - [ ] Verify all new features and bug fixes introduced in the release (e.g. LSP Go to Definition navigation, LSP diagnostics server error clearing, Windows path URI casing, DTD connection ping interval resilience).
+  - [ ] Verify installation on latest EAP / Canary IDE builds without version incompatibility warnings.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ These skills are located in the [.agents/skills/](.agents/skills/) directory. Th
 ### Available Workspace Skills:
 * **[Code Review](.agents/skills/code-review/SKILL.md):** Performs a pedantic, multi-perspective code review (covering logic, correctness, resource safety, design, and styleguide compliance) on your uncommitted changes.
 * **[Migrate DAS to LSP](.agents/skills/migrate-das-to-lsp/SKILL.md):** Guide for converting legacy Dart Analysis Server (DAS) feature implementations to JetBrains LSP in the Dart IntelliJ plugin.
+* **[Monthly Release](.agents/skills/monthly-release/SKILL.md):** Step-by-step guide for preparing, validating, testing, and publishing monthly releases of the Dart IntelliJ plugin.
 * **[Patch Copied LSP Sources](.agents/skills/patch-copied-lsp-sources/SKILL.md):** Automates copying and patching of JetBrains LSP sources.
 * **[Port PR](.agents/skills/port-pr/SKILL.md):** Fetches a Pull Request from either the dart-intellij-third-party or flutter-intellij repository and conceptually ports its changes to the other repository.
 


### PR DESCRIPTION
Analogous to https://github.com/flutter/flutter-intellij/pull/9072

This captures the steps for releasing the Dart plugin. I tested similarly as the Flutter skill by checking out a commit prior to release changes for 508 and seeing that the steps executed and recommended were reasonable. There will probably be additional changes with future releases, as 508 didn't require much additional work beyond basic building and testing (some releases have required more changes for compatibility with new versions, etc.).

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- ~[ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)~

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
