### PR TITLE
[ai] add a subagent check to keep reviews unbiased

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -44,7 +44,11 @@ Perform a multi-pass analysis of the diff:
 - **API Design:** Are new functions/methods single-responsibility? Do the parameters make sense? Are visibility modifiers (public, private, protected) used correctly?
 
 ## Step-by-Step Execution
-1. Retrieve the current changes (using `git diff`).
-2. Read `.gemini/styleguide.md` if present.
-3. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.
-4. Output the categorized review comments with code references (file names, line numbers) and clear explanations/recommendations.
+1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of `replace_file_content`, `write_to_file`, or similar tools). If so, pause and ask the user:
+   > "I noticed we wrote this code in our current conversation. Should I spin up a sub-agent for an unbiased review?"
+   - If they agree, invoke a subagent to perform the rest of this skill.
+   - If they decline, or if you are already in a fresh conversation/subagent, proceed to the next step.
+2. Retrieve the current changes (using `git diff`).
+3. Read `.gemini/styleguide.md` if present.
+4. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.
+5. Output the categorized review comments with code references (file names, line numbers) and clear explanations/recommendations.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -44,10 +44,11 @@ Perform a multi-pass analysis of the diff:
 - **API Design:** Are new functions/methods single-responsibility? Do the parameters make sense? Are visibility modifiers (public, private, protected) used correctly?
 
 ## Step-by-Step Execution
-1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of `replace_file_content`, `write_to_file`, or similar tools). If so, pause and ask the user:
+1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of replace_file_content, write_to_file, or similar tools). If so, and you are in an interactive session, pause and ask the user:
    > "I noticed we wrote this code in our current conversation. Should I spin up a sub-agent for an unbiased review?"
    - If they agree, invoke a subagent to perform the rest of this skill.
    - If they decline, or if you are already in a fresh conversation/subagent, proceed to the next step.
+   If you are in a non-interactive environment, automatically invoke a subagent to perform the review.
 2. Retrieve the current changes (using `git diff`).
 3. Read `.gemini/styleguide.md` if present.
 4. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.


### PR DESCRIPTION
Reviews can be biased by conversation history so this updates the review skill to check and offer to run in a sub-agent (with a clear head).


Analog to: https://github.com/flutter/flutter-intellij/pull/9075

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
