### PR TITLE
Fix deprecated ActionPlaces.isMainMenuOrActionSearch method invocation in DartPopFrameAction

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/actions/DartPopFrameAction.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/actions/DartPopFrameAction.java
@@ -36,10 +36,12 @@ public class DartPopFrameAction extends AnAction implements DumbAware {
 
   @Override
   public void update(@NotNull AnActionEvent e) {
+    String place = e.getPlace();
     DartVmServiceStackFrame frame = getStackFrame(e);
     boolean enabled = frame != null && frame.canDrop();
+    boolean isMainMenuOrSearch = ActionPlaces.MAIN_MENU.equals(place) || ActionPlaces.ACTION_SEARCH.equals(place);
 
-    if (ActionPlaces.isMainMenuOrActionSearch(e.getPlace()) || ActionPlaces.DEBUGGER_TOOLBAR.equals(e.getPlace())) {
+    if (isMainMenuOrSearch || ActionPlaces.DEBUGGER_TOOLBAR.equals(place)) {
       e.getPresentation().setEnabled(enabled);
     }
     else {


### PR DESCRIPTION
## Summary

This PR addresses a deprecated method invocation in the Dart IntelliJ plugin:

* **Method Invocation**: `com.intellij.openapi.actionSystem.ActionPlaces.isMainMenuOrActionSearch`
* **Source**: `com.jetbrains.lang.dart.ide.runner.actions.DartPopFrameAction.update`

Replaces the deprecated `ActionPlaces.isMainMenuOrActionSearch` call with explicit checks for `ActionPlaces.MAIN_MENU` and `ActionPlaces.ACTION_SEARCH`. Also reuses the retrieved `place` string to avoid redundant calls to `e.getPlace()`.

Part of umbrella issue https://github.com/flutter/dart-intellij-third-party/issues/242.

## Verification

The following validation checks were run and passed successfully:

* `./gradlew testClasses`
* `./gradlew verifyPluginStructure`
* `./gradlew test --tests "com.jetbrains.lang.dart.*"`

### Manual validation

`DartPopFrameAction` is added to the Debug tool-window toolbar by `DartVmServiceDebugProcess.registerAdditionalActions()`.

To validate the change:

1. Debugged a Dart program containing nested function calls.
2. Stopped at a breakpoint in the innermost function.
3. Verified that **Drop Frame (Dart)** was visible and enabled for an intermediate stack frame.
4. Invoked the action and verified that execution rewound to the caller frame and the debugging session remained functional.
5. Selected the root `main` frame and verified that the action remained visible but was disabled, as expected, because there was no caller frame to return to.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change - N/A)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>