### PR TITLE
Refactor: Replace deprecated getData call in DartProblemsViewPanel

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -127,7 +127,7 @@ public class DartProblemsViewPanel extends SimpleToolWindowPanel implements Copy
 
   private void popupInvoked(Component component, int x, int y) {
     DefaultActionGroup group = new DefaultActionGroup();
-    if (getData(CommonDataKeys.NAVIGATABLE.getName()) != null) {
+    if (createNavigatable() != null) {
       group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_EDIT_SOURCE));
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/DartProblemsViewPanel.java
@@ -127,7 +127,7 @@ public class DartProblemsViewPanel extends SimpleToolWindowPanel implements Copy
 
   private void popupInvoked(Component component, int x, int y) {
     DefaultActionGroup group = new DefaultActionGroup();
-    if (createNavigatable() != null) {
+    if (myTable.getSelectedObject() != null) {
       group.add(ActionManager.getInstance().getAction(IdeActions.ACTION_EDIT_SOURCE));
     }
 


### PR DESCRIPTION
### Summary
Replaced the legacy internal call to `getData(CommonDataKeys.NAVIGATABLE.getName())` with a direct invocation of the `createNavigatable()` helper method.
This cleans up a leftover deprecation from the component's transition to the modern `UiDataProvider` and `DataSink` APIs, which lazy-binds this exact same logic.

This PR has been approved previously on this  [fork](https://github.com/ranbeuer/dart-intellij-third-party/): https://github.com/ranbeuer/dart-intellij-third-party/pull/6

### Test instructions
1. Run the IDE with the Plugin: From the third_party/ directory, execute the Gradle task to run a sandboxed IDE instance:
Shell Script
`./gradlew runIde`
2. Open a Project with a Dart File: In the new IDE window that opens, create or open a project that contains a Dart file.
3. Introduce an Error: Add a simple analysis error to the Dart file to ensure the "Dart Problems" view is populated. 
For example:
```
void main() {
  String x = 123; // Type error: A value of type 'int' can't be assigned to a variable of type 'String'.
}
```
5. Open the Dart Analysis View: If it's not already open, you can find it via View -> Tool Windows -> Dart Analysis.
6. Test the Context Menu:
   - In the Dart Problems view, you should see the error you just created.
   - Right-click on the error in the table.
   - Verify: The context menu that appears should contain the "Edit Source" (or "Jump to Source") action.
7. Test the Action:
   - Click on "Edit Source".
   - Verify: The IDE should navigate to the correct line in your Dart file where the error is located.

###  Verification
The following validation checks were run and passed successfully:

`./gradlew testClasses`
`./gradlew verifyPluginStructure`
`./gradlew test --tests "com.jetbrains.lang.dart.*"`

### Screenshots
Even though no change was made to the UI, this screenshot is for showing the unchanged UI behavior of the component.
<img width="2226" height="1117" alt="7xm6tnGwizjqUxw" src="https://github.com/user-attachments/assets/d2388e6f-38a3-4c24-ae80-27350ceef836" />

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
