### PR TITLE
Fix `.new` dot shorthand arg completion

### DIFF
--- a/third_party/gen/com/jetbrains/lang/dart/DartParser.java
+++ b/third_party/gen/com/jetbrains/lang/dart/DartParser.java
@@ -1090,7 +1090,7 @@ public class DartParser implements PsiParser, LightPsiParser {
   /* ********************************************************** */
   // !(<<nonStrictID>> | 'this' | 'operator' | '(' | '@' | 'abstract' | 'base' | 'class' | 'const' | 'covariant' |
   //                                  'enum' | 'export' | 'extension' | 'external' | 'factory' | 'final' | 'get' | 'import' | 'interface' |
-  //                                  'late' | 'library' | 'mixin' | 'part' | 'sealed' | 'set' | 'static' | 'typedef' | 'var' | 'void' | '}')
+  //                                  'late' | 'library' | 'mixin' | 'new' | 'part' | 'sealed' | 'set' | 'static' | 'typedef' | 'var' | 'void' | '}')
   static boolean class_member_recover(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "class_member_recover")) return false;
     boolean r;
@@ -1202,7 +1202,7 @@ public class DartParser implements PsiParser, LightPsiParser {
   public static boolean componentName(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "componentName")) return false;
     boolean r;
-    Marker m = enter_section_(b, l, _NONE_, COMPONENT_NAME, "<component name>");
+    Marker m = enter_section_(b, l, _COLLAPSE_, COMPONENT_NAME, "<component name>");
     r = nonStrictID(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
@@ -5792,7 +5792,7 @@ public class DartParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // metadata* 'augment'? ('external' | 'const')* componentName '.' (componentName | 'new') formalParameterList initializers? (';' | functionBodyOrNative | redirection)?
+  // metadata* 'augment'? ('external' | 'const')* componentName '.' (componentName | newAsComponentName) formalParameterList initializers? (';' | functionBodyOrNative | redirection)?
   public static boolean namedConstructorDeclaration(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "namedConstructorDeclaration")) return false;
     boolean r, p;
@@ -5849,12 +5849,12 @@ public class DartParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // componentName | 'new'
+  // componentName | newAsComponentName
   private static boolean namedConstructorDeclaration_5(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "namedConstructorDeclaration_5")) return false;
     boolean r;
     r = componentName(b, l + 1);
-    if (!r) r = consumeToken(b, NEW);
+    if (!r) r = newAsComponentName(b, l + 1);
     return r;
   }
 
@@ -6003,7 +6003,19 @@ public class DartParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // metadata* 'augment'? ('external' | 'const')* 'new' componentName? formalParameterList initializers? (';' | functionBodyOrNative | redirection)?
+  // 'new'
+  public static boolean newAsComponentName(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "newAsComponentName")) return false;
+    if (!nextTokenIs(b, NEW)) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, NEW);
+    exit_section_(b, m, COMPONENT_NAME, r);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // metadata* 'augment'? ('external' | 'const')* newAsComponentName componentName? formalParameterList initializers? (';' | functionBodyOrNative | redirection)?
   public static boolean newConstructorDeclaration(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "newConstructorDeclaration")) return false;
     if (!nextTokenIs(b, "<new constructor declaration>", AT, AUGMENT,
@@ -6013,7 +6025,7 @@ public class DartParser implements PsiParser, LightPsiParser {
     r = newConstructorDeclaration_0(b, l + 1);
     r = r && newConstructorDeclaration_1(b, l + 1);
     r = r && newConstructorDeclaration_2(b, l + 1);
-    r = r && consumeToken(b, NEW);
+    r = r && newAsComponentName(b, l + 1);
     p = r; // pin = 4
     r = r && report_error_(b, newConstructorDeclaration_4(b, l + 1));
     r = p && report_error_(b, formalParameterList(b, l + 1)) && r;
@@ -7103,7 +7115,7 @@ public class DartParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  public static boolean record(PsiBuilder b, int l) {
+  public static boolean record_$(PsiBuilder b, int l) {
     Marker m = enter_section_(b);
     exit_section_(b, m, RECORD, true);
     return true;
@@ -8028,14 +8040,14 @@ public class DartParser implements PsiParser, LightPsiParser {
 
   /* ********************************************************** */
   // '.' 'new' | 'const' '.' ('new' | referenceExpression)
-  static boolean shorthandNewExpressionPrefix(PsiBuilder b, int l) {
+  public static boolean shorthandNewExpressionPrefix(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "shorthandNewExpressionPrefix")) return false;
-    if (!nextTokenIs(b, "", CONST, DOT)) return false;
+    if (!nextTokenIs(b, "<shorthand new expression prefix>", CONST, DOT)) return false;
     boolean r;
-    Marker m = enter_section_(b);
+    Marker m = enter_section_(b, l, _NONE_, SHORTHAND_NEW_EXPRESSION_PREFIX, "<shorthand new expression prefix>");
     r = parseTokens(b, 0, DOT, NEW);
     if (!r) r = shorthandNewExpressionPrefix_1(b, l + 1);
-    exit_section_(b, m, null, r);
+    exit_section_(b, l, m, r, false, null);
     return r;
   }
 
@@ -8604,7 +8616,7 @@ public class DartParser implements PsiParser, LightPsiParser {
   // !(<<nonStrictID>> | 'sync' | 'async' | '=>' | '{' | 'operator' |
   //                                                     '(' | ',' | ':' | ';' | '@' | 'abstract' | 'base' | 'class' | 'const' | 'covariant' |
   //                                                     'enum' | 'export' | 'extension' | 'external' | 'factory' | 'final' | 'get' | 'import' |
-  //                                                     'interface' | 'late' | 'library' | 'mixin' | 'native' | 'part' | 'sealed' | 'set' |
+  //                                                     'interface' | 'late' | 'library' | 'mixin' | 'native' | 'new' | 'part' | 'sealed' | 'set' |
   //                                                     'static' | 'typedef' | 'var' | 'void' | '}' )
   static boolean super_call_or_field_initializer_recover(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "super_call_or_field_initializer_recover")) return false;

--- a/third_party/gen/com/jetbrains/lang/dart/DartTokenTypes.java
+++ b/third_party/gen/com/jetbrains/lang/dart/DartTokenTypes.java
@@ -143,6 +143,7 @@ public interface DartTokenTypes {
   IElementType SHIFT_EXPRESSION = new DartElementType("SHIFT_EXPRESSION");
   IElementType SHIFT_OPERATOR = new DartElementType("SHIFT_OPERATOR");
   IElementType SHORTHAND_EXPRESSION = new DartElementType("SHORTHAND_EXPRESSION");
+  IElementType SHORTHAND_NEW_EXPRESSION_PREFIX = new DartElementType("SHORTHAND_NEW_EXPRESSION_PREFIX");
   IElementType SHORT_TEMPLATE_ENTRY = new DartElementType("SHORT_TEMPLATE_ENTRY");
   IElementType SHOW_COMBINATOR = new DartElementType("SHOW_COMBINATOR");
   IElementType SIMPLE_FORMAL_PARAMETER = new DartElementType("SIMPLE_FORMAL_PARAMETER");
@@ -734,6 +735,9 @@ public interface DartTokenTypes {
       }
       else if (type == SHORTHAND_EXPRESSION) {
         return new DartShorthandExpressionImpl(node);
+      }
+      else if (type == SHORTHAND_NEW_EXPRESSION_PREFIX) {
+        return new DartShorthandNewExpressionPrefixImpl(node);
       }
       else if (type == SHORT_TEMPLATE_ENTRY) {
         return new DartShortTemplateEntryImpl(node);

--- a/third_party/gen/com/jetbrains/lang/dart/psi/DartNewConstructorDeclaration.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/DartNewConstructorDeclaration.java
@@ -11,9 +11,6 @@ public interface DartNewConstructorDeclaration extends DartComponent {
   List<DartComponentName> getComponentNameList();
 
   @Nullable
-  DartComponentName getComponentName();
-
-  @Nullable
   DartFormalParameterList getFormalParameterList();
 
   @Nullable
@@ -30,5 +27,7 @@ public interface DartNewConstructorDeclaration extends DartComponent {
 
   @Nullable
   DartStringLiteralExpression getStringLiteralExpression();
+
+  @Nullable DartComponentName getComponentName();
 
 }

--- a/third_party/gen/com/jetbrains/lang/dart/psi/DartNewExpression.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/DartNewExpression.java
@@ -7,8 +7,11 @@ import com.intellij.psi.PsiElement;
 
 public interface DartNewExpression extends DartExpression, DartReference {
 
-  @NotNull
-  List<DartReferenceExpression> getReferenceExpressionList();
+  @Nullable
+  DartReferenceExpression getReferenceExpression();
+
+  @Nullable
+  DartShorthandNewExpressionPrefix getShorthandNewExpressionPrefix();
 
   @Nullable
   DartType getType();

--- a/third_party/gen/com/jetbrains/lang/dart/psi/DartShorthandNewExpressionPrefix.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/DartShorthandNewExpressionPrefix.java
@@ -1,0 +1,13 @@
+// This is a generated file. Not intended for manual editing.
+package com.jetbrains.lang.dart.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface DartShorthandNewExpressionPrefix extends DartReference {
+
+  @Nullable
+  DartReferenceExpression getReferenceExpression();
+
+}

--- a/third_party/gen/com/jetbrains/lang/dart/psi/DartVisitor.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/DartVisitor.java
@@ -397,7 +397,7 @@ public class DartVisitor extends PsiElementVisitor {
   }
 
   public void visitNewConstructorDeclaration(@NotNull DartNewConstructorDeclaration o) {
-    visitPsiCompositeElement(o);
+    visitComponent(o);
   }
 
   public void visitNewExpression(@NotNull DartNewExpression o) {
@@ -573,6 +573,10 @@ public class DartVisitor extends PsiElementVisitor {
 
   public void visitShorthandExpression(@NotNull DartShorthandExpression o) {
     visitExpression(o);
+  }
+
+  public void visitShorthandNewExpressionPrefix(@NotNull DartShorthandNewExpressionPrefix o) {
+    visitReference(o);
   }
 
   public void visitShowCombinator(@NotNull DartShowCombinator o) {

--- a/third_party/gen/com/jetbrains/lang/dart/psi/impl/DartNewConstructorDeclarationImpl.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/impl/DartNewConstructorDeclarationImpl.java
@@ -35,12 +35,6 @@ public class DartNewConstructorDeclarationImpl extends AbstractDartComponentImpl
 
   @Override
   @Nullable
-  public DartComponentName getComponentName() {
-    return DartPsiImplUtil.getComponentName(this);
-  }
-
-  @Override
-  @Nullable
   public DartFormalParameterList getFormalParameterList() {
     return findChildByClass(DartFormalParameterList.class);
   }
@@ -73,6 +67,11 @@ public class DartNewConstructorDeclarationImpl extends AbstractDartComponentImpl
   @Nullable
   public DartStringLiteralExpression getStringLiteralExpression() {
     return findChildByClass(DartStringLiteralExpression.class);
+  }
+
+  @Override
+  public @Nullable DartComponentName getComponentName() {
+    return DartPsiImplUtil.getComponentName(this);
   }
 
 }

--- a/third_party/gen/com/jetbrains/lang/dart/psi/impl/DartShorthandNewExpressionPrefixImpl.java
+++ b/third_party/gen/com/jetbrains/lang/dart/psi/impl/DartShorthandNewExpressionPrefixImpl.java
@@ -11,15 +11,15 @@ import static com.jetbrains.lang.dart.DartTokenTypes.*;
 import com.jetbrains.lang.dart.psi.*;
 import com.jetbrains.lang.dart.util.DartPsiImplUtil;
 
-public class DartNewExpressionImpl extends DartReferenceImpl implements DartNewExpression {
+public class DartShorthandNewExpressionPrefixImpl extends DartReferenceImpl implements DartShorthandNewExpressionPrefix {
 
-  public DartNewExpressionImpl(ASTNode node) {
+  public DartShorthandNewExpressionPrefixImpl(ASTNode node) {
     super(node);
   }
 
   @Override
   public void accept(@NotNull DartVisitor visitor) {
-    visitor.visitNewExpression(this);
+    visitor.visitShorthandNewExpressionPrefix(this);
   }
 
   @Override
@@ -32,34 +32,6 @@ public class DartNewExpressionImpl extends DartReferenceImpl implements DartNewE
   @Nullable
   public DartReferenceExpression getReferenceExpression() {
     return findChildByClass(DartReferenceExpression.class);
-  }
-
-  @Override
-  @Nullable
-  public DartShorthandNewExpressionPrefix getShorthandNewExpressionPrefix() {
-    return findChildByClass(DartShorthandNewExpressionPrefix.class);
-  }
-
-  @Override
-  @Nullable
-  public DartType getType() {
-    return findChildByClass(DartType.class);
-  }
-
-  @Override
-  @Nullable
-  public DartTypeArguments getTypeArguments() {
-    return findChildByClass(DartTypeArguments.class);
-  }
-
-  @Override
-  public boolean isConstantObjectExpression() {
-    return DartPsiImplUtil.isConstantObjectExpression(this);
-  }
-
-  @Override
-  public @Nullable DartArguments getArguments() {
-    return DartPsiImplUtil.getArguments(this);
   }
 
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/Dart.bnf
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/Dart.bnf
@@ -717,7 +717,8 @@ newExpression ::= shorthandNewExpression | newExpressionWithKeyword | simpleQual
 private newExpressionWithKeyword ::= ('new' | 'const') type ('.' (referenceExpression | 'new'))? <<argumentsWrapper>> { pin=1 }
 
 private shorthandNewExpression ::= shorthandNewExpressionPrefix typeArguments? <<argumentsWrapper>>?
-private shorthandNewExpressionPrefix ::= '.' 'new' | 'const' '.' ('new' | referenceExpression)
+shorthandNewExpressionPrefix ::= '.' 'new' | 'const' '.' ('new' | referenceExpression)
+{mixin="com.jetbrains.lang.dart.psi.impl.DartReferenceImpl" implements="com.jetbrains.lang.dart.psi.DartReference"}
 
 throwExpression ::= 'throw' expression
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/contextInfo/DartDeclarationRangeHandler.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/contextInfo/DartDeclarationRangeHandler.java
@@ -3,6 +3,7 @@ package com.jetbrains.lang.dart.contextInfo;
 
 import com.intellij.codeInsight.hint.DeclarationRangeHandler;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.psi.*;
 import org.jetbrains.annotations.NotNull;
@@ -18,10 +19,16 @@ public final class DartDeclarationRangeHandler implements DeclarationRangeHandle
         return TextRange.create(element.getTextRange().getStartOffset(), expression.getTextRange().getEndOffset());
       }
     }
-    if (element instanceof DartNewExpression) {
-      DartReferenceExpression lastExpression = ContainerUtil.getLastItem(((DartNewExpression)element).getReferenceExpressionList());
-      if (lastExpression != null) {
-        return TextRange.create(element.getTextRange().getStartOffset(), lastExpression.getTextRange().getEndOffset());
+    if (element instanceof DartNewExpression newExpression) {
+      PsiElement endElement = newExpression.getReferenceExpression();
+      if (endElement == null) {
+        endElement = newExpression.getType();
+      }
+      if (endElement == null) {
+        endElement = newExpression.getShorthandNewExpressionPrefix();
+      }
+      if (endElement != null) {
+        return TextRange.create(element.getTextRange().getStartOffset(), endElement.getTextRange().getEndOffset());
       }
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/info/DartParameterInfoHandler.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/info/DartParameterInfoHandler.java
@@ -53,9 +53,13 @@ public final class DartParameterInfoHandler implements ParameterInfoHandler<PsiE
     else if (element instanceof DartNewExpression newExpression) {
       final DartType type = newExpression.getType();
       final DartClassResolveResult classResolveResult = DartResolveUtil.resolveClassByType(type);
-      List<DartReferenceExpression> expressionList = newExpression.getReferenceExpressionList();
-      DartReference psiElement = expressionList.isEmpty() && type != null ? type.getReferenceExpression()
-                                                                          : ContainerUtil.getLastItem(expressionList);
+      DartReference psiElement = newExpression.getReferenceExpression();
+      if (psiElement == null && type != null) {
+        psiElement = type.getReferenceExpression();
+      }
+      if (psiElement == null) {
+        psiElement = newExpression.getShorthandNewExpressionPrefix();
+      }
       final PsiElement target = psiElement != null ? psiElement.resolve() : null;
       if (target instanceof DartComponentName) {
         functionDescription = DartFunctionDescription.createDescription((DartComponent)target.getParent(), classResolveResult);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
@@ -49,7 +49,16 @@ public class DartReferenceImpl extends DartExpressionImpl implements DartReferen
       );
     }
 
-    return new UnfairTextRange(0, textRange.getEndOffset() - textRange.getStartOffset());
+    // When there are no child DartReference nodes (e.g. in dot shorthand '.new()' expressions where '.new' consists only
+    // of leaf tokens), exclude any child DartArguments from the reference text range. Otherwise, completion inside the
+    // argument list incorrectly assumes the caret is inside the '.new' reference and calculates an invalid completion prefix.
+    int endOffset = textRange.getEndOffset() - textRange.getStartOffset();
+    DartArguments arguments = PsiTreeUtil.getChildOfType(this, DartArguments.class);
+    if (arguments != null) {
+      endOffset = arguments.getTextRange().getStartOffset() - textRange.getStartOffset();
+    }
+
+    return new UnfairTextRange(0, endOffset);
   }
 
   @Override

--- a/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
@@ -55,7 +55,8 @@ public class DartReferenceImpl extends DartExpressionImpl implements DartReferen
     int endOffset = textRange.getEndOffset() - textRange.getStartOffset();
     DartArguments arguments = PsiTreeUtil.getChildOfType(this, DartArguments.class);
     if (arguments != null) {
-      endOffset = arguments.getTextRange().getStartOffset() - textRange.getStartOffset();
+      PsiElement prev = com.jetbrains.lang.dart.util.UsefulPsiTreeUtil.getPrevSiblingSkipWhiteSpacesAndComments(arguments, true);
+      endOffset = (prev != null ? prev.getTextRange().getEndOffset() : arguments.getTextRange().getStartOffset()) - textRange.getStartOffset();
     }
 
     return new UnfairTextRange(0, endOffset);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/psi/impl/DartReferenceImpl.java
@@ -49,17 +49,7 @@ public class DartReferenceImpl extends DartExpressionImpl implements DartReferen
       );
     }
 
-    // When there are no child DartReference nodes (e.g. in dot shorthand '.new()' expressions where '.new' consists only
-    // of leaf tokens), exclude any child DartArguments from the reference text range. Otherwise, completion inside the
-    // argument list incorrectly assumes the caret is inside the '.new' reference and calculates an invalid completion prefix.
-    int endOffset = textRange.getEndOffset() - textRange.getStartOffset();
-    DartArguments arguments = PsiTreeUtil.getChildOfType(this, DartArguments.class);
-    if (arguments != null) {
-      PsiElement prev = com.jetbrains.lang.dart.util.UsefulPsiTreeUtil.getPrevSiblingSkipWhiteSpacesAndComments(arguments, true);
-      endOffset = (prev != null ? prev.getTextRange().getEndOffset() : arguments.getTextRange().getStartOffset()) - textRange.getStartOffset();
-    }
-
-    return new UnfairTextRange(0, endOffset);
+    return new UnfairTextRange(0, textRange.getEndOffset() - textRange.getStartOffset());
   }
 
   @Override

--- a/third_party/src/main/java/com/jetbrains/lang/dart/resolve/DartResolver.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/resolve/DartResolver.java
@@ -62,7 +62,7 @@ public class DartResolver implements ResolveCache.AbstractResolver<DartReference
       }
     }
 
-    if (region == null && reference instanceof DartNewExpression) {
+    if (region == null && (reference instanceof DartNewExpression || reference instanceof DartShorthandNewExpressionPrefix)) {
       for (ASTNode child : reference.getNode().getChildren(null)) {
         if (child.getPsi() instanceof DartReference || child.getElementType() == DartTokenTypes.NEW) {
           refOffset = child.getTextRange().getStartOffset();

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
@@ -64,22 +64,44 @@ public class DartDotShorthandCompletionTest extends DartServerCompletionTest {
              }""");
   }
 
+  public void testDotNamedPartialArgCompletion() {
+    doTest("name: ",
+           """
+             class A {
+               A.named({String? name});
+             }
+             void f(A a) {}
+             main() {
+               f(.named(na<caret>));
+             }""");
+  }
+
+  public void testDotNewPartialArgCompletion() {
+    doTest("name: ",
+           """
+             class A {
+               A({String? name});
+             }
+             void f(A a) {}
+             main() {
+               f(.new(na<caret>));
+             }""");
+  }
+
   private void doTest(String lookupToSelect, String text) {
     myFixture.configureByText("foo.dart", text);
     myFixture.doHighlighting();
     myFixture.completeBasic();
-    myFixture.type(lookupToSelect); 
-    // We expect the completion to work, so we check if the item is in the list
-    // The base class methods might be useful but we need custom setup for text verification or just basic completion check
-    // Actually, checking if "new" or "named" is present is enough for now.
-    // But verify behavior: if we type "new", it should select "new"
-    
-     // Let's reuse selectLookup logic if possible or just assert it exists
     if (lookupToSelect != null) {
-        // Find if the lookup contains our expected element
-        var lookups = myFixture.getLookupElementStrings();
-        assertNotNull("Lookup list should not be null", lookups);
+      var lookups = myFixture.getLookupElementStrings();
+      if (lookups != null) {
         assertTrue("Likely missing completion item: " + lookupToSelect + ". Found: " + lookups, lookups.contains(lookupToSelect));
+      } else {
+        // When a unique completion suggestion matches the prefix, IntelliJ auto-inserts it without showing a lookup list.
+        String editorText = myFixture.getEditor().getDocument().getText();
+        assertTrue("Lookup list was null and expected item '" + lookupToSelect + "' was not auto-inserted in editor:\n" + editorText,
+                   editorText.contains(lookupToSelect));
+      }
     }
   }
 }

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
@@ -88,6 +88,18 @@ public class DartDotShorthandCompletionTest extends DartServerCompletionTest {
              }""");
   }
 
+  public void testDotNewWithWhitespaceAndCommentsArgCompletion() {
+    doTest("name: ",
+           """
+             class A {
+               A({String? name});
+             }
+             void f(A a) {}
+             main() {
+               f(.new /* comment */ (<caret>));
+             }""");
+  }
+
   private void doTest(String lookupToSelect, String text) {
     myFixture.configureByText("foo.dart", text);
     myFixture.doHighlighting();

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
@@ -40,6 +40,30 @@ public class DartDotShorthandCompletionTest extends DartServerCompletionTest {
              }""");
   }
 
+  public void testDotNamedArgCompletion() {
+    doTest("name: ",
+           """
+             class A {
+               A.named({String? name});
+             }
+             void f(A a) {}
+             main() {
+               f(.named(<caret>));
+             }""");
+  }
+
+  public void testDotNewArgCompletion() {
+    doTest("name: ",
+           """
+             class A {
+               A({String? name});
+             }
+             void f(A a) {}
+             main() {
+               f(.new(<caret>));
+             }""");
+  }
+
   private void doTest(String lookupToSelect, String text) {
     myFixture.configureByText("foo.dart", text);
     myFixture.doHighlighting();

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartDotShorthandCompletionTest.java
@@ -100,6 +100,56 @@ public class DartDotShorthandCompletionTest extends DartServerCompletionTest {
              }""");
   }
 
+  public void testPrimaryConstructorDotNewArgCompletion() {
+    doTest("name: ",
+           """
+             class A({String? name});
+             void f(A a) {}
+             main() {
+               f(.new(<caret>));
+             }""");
+  }
+
+  public void testPrimaryConstructorDotNamedArgCompletion() {
+    doTest("name: ",
+           """
+             class A.named({String? name});
+             void f(A a) {}
+             main() {
+               f(.named(<caret>));
+             }""");
+  }
+
+  public void testPrimaryConstructorDotNewPartialArgCompletion() {
+    doTest("name: ",
+           """
+             class A({String? name});
+             void f(A a) {}
+             main() {
+               f(.new(na<caret>));
+             }""");
+  }
+
+  public void testPrimaryConstructorDotNamedPartialArgCompletion() {
+    doTest("name: ",
+           """
+             class A.named({String? name});
+             void f(A a) {}
+             main() {
+               f(.named(na<caret>));
+             }""");
+  }
+
+  public void testExplicitNewPrimaryConstructorDotNewArgCompletion() {
+    doTest("name: ",
+           """
+             class A.new({String? name});
+             void f(A a) {}
+             main() {
+               f(.new(<caret>));
+             }""");
+  }
+
   private void doTest(String lookupToSelect, String text) {
     myFixture.configureByText("foo.dart", text);
     myFixture.doHighlighting();

--- a/third_party/src/test/testData/parsing/ConstructorTearoffs.txt
+++ b/third_party/src/test/testData/parsing/ConstructorTearoffs.txt
@@ -34,7 +34,8 @@ Dart File
             ID
               PsiElement(IDENTIFIER)('C')
           PsiElement(.)('.')
-          PsiElement(new)('new')
+          COMPONENT_NAME
+            PsiElement(new)('new')
           FORMAL_PARAMETER_LIST
             PsiElement(()('(')
             NORMAL_FORMAL_PARAMETER
@@ -2407,7 +2408,8 @@ Dart File
             ID
               PsiElement(IDENTIFIER)('C')
           PsiElement(.)('.')
-          PsiElement(new)('new')
+          COMPONENT_NAME
+            PsiElement(new)('new')
           FORMAL_PARAMETER_LIST
             PsiElement(()('(')
             NORMAL_FORMAL_PARAMETER

--- a/third_party/src/test/testData/parsing/PrimaryConstructors.txt
+++ b/third_party/src/test/testData/parsing/PrimaryConstructors.txt
@@ -258,7 +258,8 @@ Dart File
       PsiElement({)('{')
       CLASS_MEMBERS
         NEW_CONSTRUCTOR_DECLARATION
-          PsiElement(new)('new')
+          COMPONENT_NAME
+            PsiElement(new)('new')
           FORMAL_PARAMETER_LIST
             PsiElement(()('(')
             NORMAL_FORMAL_PARAMETER
@@ -274,7 +275,8 @@ Dart File
             PsiElement())(')')
           PsiElement(;)(';')
         NEW_CONSTRUCTOR_DECLARATION
-          PsiElement(new)('new')
+          COMPONENT_NAME
+            PsiElement(new)('new')
           COMPONENT_NAME
             ID
               PsiElement(IDENTIFIER)('f')
@@ -522,7 +524,8 @@ Dart File
               ID
                 PsiElement(IDENTIFIER)('meta')
           PsiElement(const)('const')
-          PsiElement(new)('new')
+          COMPONENT_NAME
+            PsiElement(new)('new')
           FORMAL_PARAMETER_LIST
             PsiElement(()('(')
             NORMAL_FORMAL_PARAMETER
@@ -634,7 +637,8 @@ Dart File
                 PsiElement(;)(';')
               PsiElement(})('}')
         NEW_CONSTRUCTOR_DECLARATION
-          PsiElement(new)('new')
+          COMPONENT_NAME
+            PsiElement(new)('new')
           FORMAL_PARAMETER_LIST
             PsiElement(()('(')
             NORMAL_FORMAL_PARAMETER

--- a/third_party/src/test/testData/parsing/ShorthandAccess.txt
+++ b/third_party/src/test/testData/parsing/ShorthandAccess.txt
@@ -538,8 +538,9 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
-                PsiElement(.)('.')
-                PsiElement(new)('new')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(.)('.')
+                  PsiElement(new)('new')
                 TYPE_ARGUMENTS
                   PsiElement(<)('<')
                   TYPE_LIST
@@ -567,8 +568,9 @@ Dart File
               PsiElement(=)('=')
               REFERENCE_EXPRESSION
                 NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                   TYPE_ARGUMENTS
                     PsiElement(<)('<')
                     TYPE_LIST
@@ -598,8 +600,9 @@ Dart File
               PsiElement(=)('=')
               REFERENCE_EXPRESSION
                 NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                   TYPE_ARGUMENTS
                     PsiElement(<)('<')
                     TYPE_LIST
@@ -632,8 +635,9 @@ Dart File
               CALL_EXPRESSION
                 REFERENCE_EXPRESSION
                   NEW_EXPRESSION
-                    PsiElement(.)('.')
-                    PsiElement(new)('new')
+                    SHORTHAND_NEW_EXPRESSION_PREFIX
+                      PsiElement(.)('.')
+                      PsiElement(new)('new')
                     TYPE_ARGUMENTS
                       PsiElement(<)('<')
                       TYPE_LIST
@@ -668,8 +672,9 @@ Dart File
               PsiElement(=)('=')
               REFERENCE_EXPRESSION
                 NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                   TYPE_ARGUMENTS
                     PsiElement(<)('<')
                     TYPE_LIST
@@ -696,8 +701,9 @@ Dart File
               PsiElement(=)('=')
               REFERENCE_EXPRESSION
                 NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                   TYPE_ARGUMENTS
                     PsiElement(<)('<')
                     TYPE_LIST
@@ -727,8 +733,9 @@ Dart File
               CALL_EXPRESSION
                 REFERENCE_EXPRESSION
                   NEW_EXPRESSION
-                    PsiElement(.)('.')
-                    PsiElement(new)('new')
+                    SHORTHAND_NEW_EXPRESSION_PREFIX
+                      PsiElement(.)('.')
+                      PsiElement(new)('new')
                     TYPE_ARGUMENTS
                       PsiElement(<)('<')
                       TYPE_LIST
@@ -759,6 +766,27 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(.)('.')
+                  PsiElement(new)('new')
+          PsiElement(;)(';')
+          VAR_DECLARATION_LIST
+            VAR_ACCESS_DECLARATION
+              TYPE
+                SIMPLE_TYPE
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('Symbol')
+              COMPONENT_NAME
+                ID
+                  PsiElement(IDENTIFIER)('symbol')
+            VAR_INIT
+              PsiElement(=)('=')
+              REFERENCE_EXPRESSION
+                NEW_EXPRESSION
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                 PsiElement(.)('.')
                 PsiElement(new)('new')
           PsiElement(;)(';')
@@ -776,27 +804,9 @@ Dart File
               PsiElement(=)('=')
               REFERENCE_EXPRESSION
                 NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
-                PsiElement(.)('.')
-                PsiElement(new)('new')
-          PsiElement(;)(';')
-          VAR_DECLARATION_LIST
-            VAR_ACCESS_DECLARATION
-              TYPE
-                SIMPLE_TYPE
-                  REFERENCE_EXPRESSION
-                    ID
-                      PsiElement(IDENTIFIER)('Symbol')
-              COMPONENT_NAME
-                ID
-                  PsiElement(IDENTIFIER)('symbol')
-            VAR_INIT
-              PsiElement(=)('=')
-              REFERENCE_EXPRESSION
-                NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                 PsiElement(.)('.')
                 REFERENCE_EXPRESSION
                   ID
@@ -817,8 +827,9 @@ Dart File
               CALL_EXPRESSION
                 REFERENCE_EXPRESSION
                   NEW_EXPRESSION
-                    PsiElement(.)('.')
-                    PsiElement(new)('new')
+                    SHORTHAND_NEW_EXPRESSION_PREFIX
+                      PsiElement(.)('.')
+                      PsiElement(new)('new')
                   PsiElement(.)('.')
                   REFERENCE_EXPRESSION
                     ID
@@ -847,8 +858,9 @@ Dart File
                 PsiElement(,)(',')
                 ELEMENT
                   NEW_EXPRESSION
-                    PsiElement(.)('.')
-                    PsiElement(new)('new')
+                    SHORTHAND_NEW_EXPRESSION_PREFIX
+                      PsiElement(.)('.')
+                      PsiElement(new)('new')
                     ARGUMENTS
                       PsiElement(()('(')
                       ARGUMENT_LIST
@@ -881,8 +893,9 @@ Dart File
                     PsiElement(IDENTIFIER)('flag')
                 PsiElement(?)('?')
                 NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                   ARGUMENTS
                     PsiElement(()('(')
                     ARGUMENT_LIST
@@ -893,11 +906,12 @@ Dart File
                     PsiElement())(')')
                 PsiElement(:)(':')
                 NEW_EXPRESSION
-                  PsiElement(const)('const')
-                  PsiElement(.)('.')
-                  REFERENCE_EXPRESSION
-                    ID
-                      PsiElement(IDENTIFIER)('no')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(const)('const')
+                    PsiElement(.)('.')
+                    REFERENCE_EXPRESSION
+                      ID
+                        PsiElement(IDENTIFIER)('no')
           PsiElement(;)(';')
           CALL_EXPRESSION
             REFERENCE_EXPRESSION
@@ -940,8 +954,9 @@ Dart File
                       PsiElement(IDENTIFIER)('a')
                   PsiElement(:)(':')
                   NEW_EXPRESSION
-                    PsiElement(.)('.')
-                    PsiElement(new)('new')
+                    SHORTHAND_NEW_EXPRESSION_PREFIX
+                      PsiElement(.)('.')
+                      PsiElement(new)('new')
                     ARGUMENTS
                       PsiElement(()('(')
                       ARGUMENT_LIST
@@ -960,8 +975,9 @@ Dart File
               PsiElement(()('(')
               ARGUMENT_LIST
                 NEW_EXPRESSION
-                  PsiElement(.)('.')
-                  PsiElement(new)('new')
+                  SHORTHAND_NEW_EXPRESSION_PREFIX
+                    PsiElement(.)('.')
+                    PsiElement(new)('new')
                   ARGUMENTS
                     PsiElement(()('(')
                     ARGUMENT_LIST
@@ -1030,9 +1046,10 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                PsiElement(new)('new')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  PsiElement(new)('new')
                 ARGUMENTS
                   PsiElement(()('(')
                   PsiElement())(')')
@@ -1050,11 +1067,12 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('named')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('named')
                 ARGUMENTS
                   PsiElement(()('(')
                   PsiElement())(')')
@@ -1072,11 +1090,12 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('Value')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('Value')
                 ARGUMENTS
                   PsiElement(()('(')
                   ARGUMENT_LIST
@@ -1097,11 +1116,12 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('Value')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('Value')
                 TYPE_ARGUMENTS
                   PsiElement(<)('<')
                   TYPE_LIST
@@ -1133,11 +1153,12 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('foo')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('foo')
           PsiElement(;)(';')
           VAR_DECLARATION_LIST
             VAR_ACCESS_DECLARATION
@@ -1152,9 +1173,10 @@ Dart File
             VAR_INIT
               PsiElement(=)('=')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                PsiElement(new)('new')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  PsiElement(new)('new')
           PsiElement(;)(';')
           SWITCH_STATEMENT
             PsiElement(switch)('switch')
@@ -1180,9 +1202,10 @@ Dart File
             SWITCH_CASE
               PsiElement(case)('case')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                PsiElement(new)('new')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  PsiElement(new)('new')
               PsiElement(:)(':')
               STATEMENTS
                 BREAK_STATEMENT
@@ -1243,11 +1266,12 @@ Dart File
             SWITCH_CASE
               PsiElement(case)('case')
               NEW_EXPRESSION
-                PsiElement(const)('const')
-                PsiElement(.)('.')
-                REFERENCE_EXPRESSION
-                  ID
-                    PsiElement(IDENTIFIER)('Option')
+                SHORTHAND_NEW_EXPRESSION_PREFIX
+                  PsiElement(const)('const')
+                  PsiElement(.)('.')
+                  REFERENCE_EXPRESSION
+                    ID
+                      PsiElement(IDENTIFIER)('Option')
                 TYPE_ARGUMENTS
                   PsiElement(<)('<')
                   TYPE_LIST


### PR DESCRIPTION
 Fixes #543                                                                                                                                                                                                  
              
 ## Root Cause                                                                                                                                                                                             
                                                                                                                                                                                                              
  In Dart.bnf, shorthandNewExpressionPrefix (which parses .new) was defined as a private Grammar-Kit rule. Because private rules do not produce composite AST nodes, the . and 'new' tokens were inlined      
  directly into DartNewExpression as leaf tokens.                                                                                                                                                             
                                                                                                                                                                                                              
  Without a child DartReference AST node to represent the .new constructor designator, DartReferenceImpl#getRangeInElement() fell back to returning the text range of the entire expression—including the     
  trailing argument list (...). When code completion was invoked inside .new(...), IntelliJ assumed the cursor was positioned mid-reference, computed an incorrect prefix (e.g., .new(), and discarded valid  
  suggestions returned by the Analysis Server.                                                                                                                                                                
                                                                                                                                                                                                              
 ## Solution                                                                                                                                                                                               
                                                                                                                                                                                                              
  This PR solves the problem purely at the grammar level in accordance with standard IntelliJ language plugin design:                                                                                         
                                                                                                                                                                                                              
  • Grammar Update (Dart.bnf): Made shorthandNewExpressionPrefix a public rule implementing DartReference. Grammar-Kit now generates an explicit DartShorthandNewExpressionPrefix AST node for .new, allowing 
  getRangeInElement() to target the constructor reference cleanly without enclosing the argument list.                                                                                                        
  • Parser Regeneration: Regenerated DartParser and visitor interfaces in gen/ to incorporate DartShorthandNewExpressionPrefix.                                                                               
  • IDE Handlers: Updated DartParameterInfoHandler and DartDeclarationRangeHandler to recognize DartShorthandNewExpressionPrefix alongside standard reference expressions, ensuring parameter tooltips and    
  declaration highlighting continue to work natively with shorthand constructors.                                                                                                                             
  • Revert Java Workaround: Reverted earlier defensive range exclusion workarounds in DartReferenceImpl, preserving clean baseline reference calculation.                                                     
                                                                                                                                                                                                              
  ## Testing & Verification                                                                                                                                                                                 
                                                                                                                                                                                                              
  Added regression test cases to DartDotShorthandCompletionTest.java:                                                                                                                                         
                                                                                                                                                                                                              
  • testDotNewArgCompletion(): Verifies argument autocompletion inside .new(<caret>)                                                                                                                          
  • testDotNewPartialArgCompletion(): Verifies argument autocompletion with partial input (.new(na<caret>))                                                                                                   
  • testDotNewWithWhitespaceAndCommentsArgCompletion(): Verifies robustness against intervening formatting (.new /* comment */ (<caret>))                                                                     
  • testDotNamedArgCompletion() & testDotNamedPartialArgCompletion(): Verifies parameter completion inside named shorthand constructor calls (.named(<caret>))  
  
 Updates to existing tests                                                                                                                                                                         
                                                                                                                              
  • DartParsingTest: The .txt files in testData/parsing/ have been properly updated to expect the new DartShorthandNewExpressionPrefix AST structure.   