### PR TITLE
Use FilenameIndex.getVirtualFilesByName in DartVmServiceDebugProcess

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.GlobalSearchScopesCore;
@@ -48,7 +47,6 @@ import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceSt
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceSuspendContext;
 import com.jetbrains.lang.dart.ide.runner.server.webdev.DartDaemonParserUtil;
 import com.jetbrains.lang.dart.util.DartBazelFileUtil;
-import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -403,16 +401,15 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       if (remoteUri.startsWith(DartUrlResolver.DART_PREFIX)) continue;
       if (remoteUri.startsWith(DartUrlResolver.PACKAGE_PREFIX)) continue;
 
-      final PsiFile[] localFilesWithSameName = ReadAction.compute(() -> {
+      final Collection<VirtualFile> localFilesWithSameName = ReadAction.computeBlocking(() -> {
         final String remoteFileName = PathUtil.getFileName(remoteUri);
         final GlobalSearchScope scope = GlobalSearchScopesCore.directoryScope(getSession().getProject(), projectRoot, true);
-        return FilenameIndex.getFilesByName(getSession().getProject(), remoteFileName, scope);
+        return FilenameIndex.getVirtualFilesByName(remoteFileName, scope);
       });
 
       int howManyFilesMatch = 0;
 
-      for (PsiFile psiFile : localFilesWithSameName) {
-        final VirtualFile file = DartResolveUtil.getRealVirtualFile(psiFile);
+      for (VirtualFile file : localFilesWithSameName) {
         if (file == null) continue;
 
         LOG.assertTrue(file.getPath().startsWith(projectRoot.getPath() + "/"), file.getPath() + "," + projectRoot.getPath());

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -401,7 +401,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       if (remoteUri.startsWith(DartUrlResolver.DART_PREFIX)) continue;
       if (remoteUri.startsWith(DartUrlResolver.PACKAGE_PREFIX)) continue;
 
-      final Collection<VirtualFile> localFilesWithSameName = ReadAction.computeBlocking(() -> {
+      final Collection<VirtualFile> localFilesWithSameName = ReadAction.compute(() -> {
         final String remoteFileName = PathUtil.getFileName(remoteUri);
         final GlobalSearchScope scope = GlobalSearchScopesCore.directoryScope(getSession().getProject(), projectRoot, true);
         return FilenameIndex.getVirtualFilesByName(remoteFileName, scope);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -410,6 +410,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       int howManyFilesMatch = 0;
 
       for (VirtualFile file : localFilesWithSameName) {
+        com.intellij.openapi.progress.ProgressManager.checkCanceled();
         if (file == null) continue;
 
         LOG.assertTrue(file.getPath().startsWith(projectRoot.getPath() + "/"), file.getPath() + "," + projectRoot.getPath());

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcess.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.ui.InputValidator;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Disposer;
@@ -410,7 +411,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       int howManyFilesMatch = 0;
 
       for (VirtualFile file : localFilesWithSameName) {
-        com.intellij.openapi.progress.ProgressManager.checkCanceled();
+        ProgressManager.checkCanceled();
         if (file == null) continue;
 
         LOG.assertTrue(file.getPath().startsWith(projectRoot.getPath() + "/"), file.getPath() + "," + projectRoot.getPath());


### PR DESCRIPTION
### Description
Replaces the deprecated `FilenameIndex.getFilesByName` API with `FilenameIndex.getVirtualFilesByName` in `DartVmServiceDebugProcess.guessRemoteProjectRoot`. 

This change avoids constructing unnecessary `PsiFile` objects and ASTs when only `VirtualFile` paths are needed to guess the remote project root during remote debugging sessions.

### Relevant Issues
Part of #242

### Manual Verification
Follow these steps to manually verify the change in the IDE sandbox (`./gradlew runIde`):

1. **Configure Dart SDK:**
   - Open **Settings / Preferences** (`Ctrl+Alt+S` / `Cmd+,`) ➔ **Languages & Frameworks** ➔ **Dart**.
   - Check **Enable Dart support for the project...** and select your project module in the modules table.
   - Set your local Dart SDK path (e.g., `/path/to/dart-sdk`).

2. **Prepare a Sample Project:**
   - Open/Create a Dart project containing a `pubspec.yaml` and `bin/main.dart`:
     ```dart
     void main() {
       print("Debugging Dart VM Service");
     }
     ```
   - Place a breakpoint on the `print` line in `bin/main.dart`.

3. **Start Dart Process with VM Service Enabled:**
   - In a terminal, run:
     ```bash
     dart run --enable-vm-service=5858 --pause-isolates-on-start bin/main.dart
     ```
   - Copy the output VM Service URL (e.g. `http://127.0.0.1:5858/<auth-code>/`).

4. **Run Dart Remote Debug:**
   - In the IDE, go to **Run** ➔ **Edit Configurations...**
   - Add a **Dart Remote Debug** configuration selecting the project directory.
   - Click **Debug**.
   - Paste the VM Service URL into the dialog prompt and click **OK**.

5. **Expected Behavior:**
   - `DartVmServiceDebugProcess` connects to the VM service.
   - `guessRemoteProjectRoot()` executes using `FilenameIndex.getVirtualFilesByName` without throwing `ReadAction` or threading errors.
   - Execution pauses at the breakpoint in `bin/main.dart` with valid stack frames.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)
