### PR TITLE
Fix read access exception in DartAnalysisServerService.updateVisibleFiles

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -967,24 +967,24 @@ public final class DartAnalysisServerService implements Disposable {
   }
 
   public void updateVisibleFiles() {
-    ApplicationManager.getApplication().assertReadAccessAllowed();
+    ApplicationManager.getApplication().runReadAction(() -> {
+      synchronized (myLock) {
+        final List<String> newVisibleFileUris = new ArrayList<>();
 
-    synchronized (myLock) {
-      final List<String> newVisibleFileUris = new ArrayList<>();
+        for (VirtualFile file : FileEditorManager.getInstance(myProject).getSelectedFiles()) {
+          if (isLocalAnalyzableFile(file)) {
+            newVisibleFileUris.add(getFileUri(file));
+          }
+        }
 
-      for (VirtualFile file : FileEditorManager.getInstance(myProject).getSelectedFiles()) {
-        if (isLocalAnalyzableFile(file)) {
-          newVisibleFileUris.add(getFileUri(file));
+        if (!Comparing.haveEqualElements(myVisibleFileUris, newVisibleFileUris)) {
+          myVisibleFileUris.clear();
+          myVisibleFileUris.addAll(newVisibleFileUris);
+          analysis_setPriorityFiles();
+          analysis_setSubscriptions();
         }
       }
-
-      if (!Comparing.haveEqualElements(myVisibleFileUris, newVisibleFileUris)) {
-        myVisibleFileUris.clear();
-        myVisibleFileUris.addAll(newVisibleFileUris);
-        analysis_setPriorityFiles();
-        analysis_setSubscriptions();
-      }
-    }
+    });
   }
 
   /**

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerHighlightingTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerHighlightingTest.java
@@ -4,6 +4,7 @@ package com.jetbrains.dart.analysisServer;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.undo.UndoManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
@@ -25,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.awt.datatransfer.StringSelection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class DartServerHighlightingTest extends CodeInsightFixtureTestCase {
   @Override
@@ -411,10 +413,10 @@ public class DartServerHighlightingTest extends CodeInsightFixtureTestCase {
   public void testUpdateVisibleFilesWithoutReadAccess() throws Exception {
     myFixture.configureByText("firstFile.dart", "class Foo {}");
     final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getProject());
-    com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread(() -> {
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
       assertFalse("Read access should not be allowed before calling updateVisibleFiles()",
-                  com.intellij.openapi.application.ApplicationManager.getApplication().isReadAccessAllowed());
+                  ApplicationManager.getApplication().isReadAccessAllowed());
       service.updateVisibleFiles();
-    }).get(10, java.util.concurrent.TimeUnit.SECONDS);
+    }).get(10, TimeUnit.SECONDS);
   }
 }

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerHighlightingTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerHighlightingTest.java
@@ -407,4 +407,14 @@ public class DartServerHighlightingTest extends CodeInsightFixtureTestCase {
 //                             }\
 //                            """);
 //  }
+
+  public void testUpdateVisibleFilesWithoutReadAccess() throws Exception {
+    myFixture.configureByText("firstFile.dart", "class Foo {}");
+    final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getProject());
+    com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      assertFalse("Read access should not be allowed before calling updateVisibleFiles()",
+                  com.intellij.openapi.application.ApplicationManager.getApplication().isReadAccessAllowed());
+      service.updateVisibleFiles();
+    }).get(10, java.util.concurrent.TimeUnit.SECONDS);
+  }
 }


### PR DESCRIPTION
Part of https://github.com/flutter/dart-intellij-third-party/issues/462 - addresses the 2nd crash.

Wrap updateVisibleFiles in runReadAction instead of assertReadAccessAllowed so that event listeners invoked on the event dispatch thread outside of an active read action do not throw thread access exceptions.
