### PR TITLE
[ai] gather context before subagent `code-review`s

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -46,11 +46,16 @@ Perform a multi-pass analysis of the diff:
 ## Step-by-Step Execution
 1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of replace_file_content, write_to_file, or similar tools). If so, and you are in an interactive session, pause and ask the user:
    > "I noticed we wrote this code in our current conversation. Should I spin up a sub-agent for an unbiased review?"
-   - If they agree, invoke a subagent to perform the rest of this skill.
+   - If they agree: **Before** invoking the subagent, you (the parent agent) must gather the required context (by executing steps 2, 3, and 4 yourself). This avoids the subagent stalling on permission prompts. Pass all these outputs directly into the subagent's prompt and explicitly instruct it to skip those steps, so it can review the code without needing to execute commands itself.
    - If they decline, or if you are already in a fresh conversation/subagent, proceed to the next step.
-   If you are in a non-interactive environment, automatically invoke a subagent to perform the review.
+   If you are in a non-interactive environment, gather the context as described above and automatically invoke a subagent, passing the context and instructing it to skip steps 2, 3, and 4.
+   
+    > [!IMPORTANT]
+    > Instruct the subagent that if it encounters permission errors or stalls while running any other commands, it should use the **`send_message`** tool to notify you immediately.
 2. Retrieve the current changes (using `git diff`).
 3. Read `.gemini/styleguide.md` if present.
 4. Run `bash ./tool/check_agent_skills.sh` (if the file exists) to verify skill documentation integrity. Record any failures as `[MUST-FIX]` items.
+
+   *(Note for subagents: If context was not provided by your parent and you are executing steps 2-4 yourself, the system may pause to ask the user for permission. If you get stuck waiting, use the **`send_message`** tool to notify your parent agent.)*
 5. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.
 6. Output the categorized review comments with code references (file names, line numbers) and clear explanations/recommendations, including the results of the script checks.


### PR DESCRIPTION
Updates the `code-review` skill to resolve a common issue where autonomous subagents silently stall while waiting for user permission to execute context-gathering commands (e.g., `git diff` or shell scripts).

Before this, if the correct perms hadn't been set in the parent conversation, the subagent would just stop. The skill now instructs the interactive parent agent to proactively gather all necessary context (diffs, styleguides, and script outputs) *before* spinning up the subagent. This gathered context is injected directly into the subagent's prompt, bypassing the need for the subagent to execute terminal commands itself.

### Key Changes
- **Parent Context Gathering**: The parent agent now executes steps 2, 3, and 4 in the main thread (where permission prompts are visible) and passes the output to the subagent.
- **Skip Instructions**: Added explicit instructions telling the subagent to skip context-gathering steps when context is provided, preventing redundant command execution.
- **Permission Stall Fallback**: Added a `> [!IMPORTANT]` block and fallback notes instructing subagents to use the **`send_message`** tool to notify the parent agent if they encounter unexpected permission errors or hangs during execution.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
