### PR TITLE
Fix settings analytics not being sent

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartStartupActivity.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartStartupActivity.kt
@@ -150,23 +150,33 @@ class DartStartupActivity : ProjectActivity {
   }
 
   private suspend fun reportSettingsAnalytics(project: Project) {
-    val (dartSupportEnabled, sdkVersion, experimentalLspFeaturesEnabled) = readAction {
+    val info = readAction {
       val sdk = DartSdk.getDartSdk(project)
       val enabled = sdk != null && project.moduleManager.modules.any { DartSdkLibUtil.isDartSdkEnabled(it) }
       val version = sdk?.version ?: "unknown"
       val experimentalEnabled = DartConfigurable.isExperimentalLspFeaturesEnabled(project)
-      Triple(enabled, version, experimentalEnabled)
+      SettingsReportInfo(sdk, enabled, version, experimentalEnabled)
     }
 
-    if (!dartSupportEnabled) return
+    if (!info.dartSupportEnabled || info.sdk == null) return
+
+    val config = Analytics.getConfiguration(info.sdk, project)
+    if (config.suppressAnalytics) return
 
     val settingsData = SettingsData(project)
-    settingsData["experimentalLspFeaturesEnabled"] = experimentalLspFeaturesEnabled
-    settingsData["sdkVersion"] = sdkVersion
+    settingsData["experimentalLspFeaturesEnabled"] = info.experimentalLspFeaturesEnabled
+    settingsData["sdkVersion"] = info.sdkVersion
 
     Analytics.report(settingsData)
   }
 }
+
+private data class SettingsReportInfo(
+  val sdk: DartSdk?,
+  val dartSupportEnabled: Boolean,
+  val sdkVersion: String,
+  val experimentalLspFeaturesEnabled: Boolean
+)
 
 fun excludeBuildAndToolCacheFolders(module: Module, pubspecYamlFile: VirtualFile) {
   prepareExcludeBuildAndToolCacheFolders(module, pubspecYamlFile)?.invoke()

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -38,8 +38,16 @@ import com.jetbrains.lang.dart.websocket.WebSocketMessage
 import kotlinx.coroutines.CoroutineScope
 import java.net.URI
 import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicInteger
+
+private data class PendingRequest(
+  val method: String,
+  val params: JsonObject,
+  val includeSecret: Boolean,
+  val consumer: DartToolingDaemonConsumer
+)
 
 @Service(Service.Level.PROJECT)
 class DartToolingDaemonService private constructor(val project: Project, cs: CoroutineScope) : Disposable {
@@ -59,6 +67,8 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
   private var secret: String? = null
 
   private var lastSentRootUris: List<String> = emptyList()
+
+  private val pendingRequests = ConcurrentLinkedQueue<PendingRequest>()
 
   private val nextRequestId = AtomicInteger()
   private val consumerMap: MutableMap<Int, DartToolingDaemonConsumer> = mutableMapOf()
@@ -141,6 +151,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
     uri = null
     secret = null
     lastSentRootUris = emptyList()
+    pendingRequests.clear()
     consumerMap.clear()
     servicesMap.clear()
   }
@@ -171,10 +182,15 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
   @Throws(WebSocketException::class)
   fun sendRequest(method: String, params: JsonObject, includeSecret: Boolean, consumer: DartToolingDaemonConsumer) {
     if (!webSocketReady) {
-      logger.warn("sendRequest(\"$method\") called when the socket is not ready")
+      logger.debug("sendRequest(\"$method\") queued because the socket is not ready")
+      pendingRequests.add(PendingRequest(method, params, includeSecret, consumer))
       return
     }
 
+    doSendRequest(method, params, includeSecret, consumer)
+  }
+
+  private fun doSendRequest(method: String, params: JsonObject, includeSecret: Boolean, consumer: DartToolingDaemonConsumer) {
     val request = JsonObject()
     request.addProperty("jsonrpc", "2.0")
     request.addProperty("method", method)
@@ -313,6 +329,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
       serviceRunning = false
       webSocketReady = false
       uri = null
+      pendingRequests.clear()
       logger.info("DTD terminated, exit code: ${event.exitCode}")
     }
   }
@@ -322,6 +339,16 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
       logger.info("Connected to DTD successfully")
       webSocketReady = true
       ensureRootsUpToDate()
+
+      while (true) {
+        val pending = pendingRequests.poll() ?: break
+        try {
+          doSendRequest(pending.method, pending.params, pending.includeSecret, pending.consumer)
+        }
+        catch (e: Exception) {
+          logger.warn("Failed to send queued DTD request for ${pending.method}", e)
+        }
+      }
 
       // Fake request to make sure the tooling daemon works
       //val params = JsonObject()
@@ -406,6 +433,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
       webSocketReady = false
       secret = null
       lastSentRootUris = emptyList()
+      pendingRequests.clear()
     }
   }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonService.kt
@@ -59,6 +59,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
   var webSocketListener: DartToolingDaemonWebSocketListener? = null
 
   private lateinit var webSocket: WebSocket
+  @Volatile
   var webSocketReady: Boolean = false
     private set
 
@@ -181,13 +182,28 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
 
   @Throws(WebSocketException::class)
   fun sendRequest(method: String, params: JsonObject, includeSecret: Boolean, consumer: DartToolingDaemonConsumer) {
-    if (!webSocketReady) {
-      logger.debug("sendRequest(\"$method\") queued because the socket is not ready")
+    if (!webSocketReady || !pendingRequests.isEmpty()) {
+      logger.debug("sendRequest(\"$method\") queued because the socket is not ready or there are pending requests")
       pendingRequests.add(PendingRequest(method, params, includeSecret, consumer))
+      if (webSocketReady) {
+        drainPendingRequests()
+      }
       return
     }
 
     doSendRequest(method, params, includeSecret, consumer)
+  }
+
+  private fun drainPendingRequests() {
+    while (webSocketReady) {
+      val pending = pendingRequests.poll() ?: break
+      try {
+        doSendRequest(pending.method, pending.params, pending.includeSecret, pending.consumer)
+      }
+      catch (e: Exception) {
+        logger.warn("Failed to send queued DTD request for ${pending.method}", e)
+      }
+    }
   }
 
   private fun doSendRequest(method: String, params: JsonObject, includeSecret: Boolean, consumer: DartToolingDaemonConsumer) {
@@ -339,16 +355,7 @@ class DartToolingDaemonService private constructor(val project: Project, cs: Cor
       logger.info("Connected to DTD successfully")
       webSocketReady = true
       ensureRootsUpToDate()
-
-      while (true) {
-        val pending = pendingRequests.poll() ?: break
-        try {
-          doSendRequest(pending.method, pending.params, pending.includeSecret, pending.consumer)
-        }
-        catch (e: Exception) {
-          logger.warn("Failed to send queued DTD request for ${pending.method}", e)
-        }
-      }
+      drainPendingRequests()
 
       // Fake request to make sure the tooling daemon works
       //val params = JsonObject()

--- a/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DartToolingDaemonServiceTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/dartToolingDaemon/DartToolingDaemonServiceTest.kt
@@ -22,7 +22,7 @@ class DartToolingDaemonServiceTest : BasePlatformTestCase() {
 
     private companion object {
         const val INITIALIZATION_TIMEOUT_SECONDS = 5
-        const val EXPECTED_REQUEST_COUNT = 3
+        const val EXPECTED_REQUEST_COUNT = 4
     }
 
     override fun setUp() {
@@ -59,6 +59,10 @@ class DartToolingDaemonServiceTest : BasePlatformTestCase() {
             }
         }
 
+        // Send an early request before starting the service (while webSocketReady is false)
+        val earlyParams = JsonObject().apply { addProperty("streamId", "Service") }
+        dartToolingDaemonService.sendRequest("streamListen", earlyParams, includeSecret = true) {}
+
         dartToolingDaemonService.startService()
         UIUtil.dispatchAllInvocationEvents()
         PlatformTestUtil.waitWithEventsDispatching(
@@ -67,6 +71,9 @@ class DartToolingDaemonServiceTest : BasePlatformTestCase() {
             INITIALIZATION_TIMEOUT_SECONDS
         )
 
+        val streamListenId = idOfRequest(sentRequestsById, "a streamListen request") {
+            it["method"]?.asString == "streamListen"
+        }
         val getActiveLocationId =
             idOfRequest(sentRequestsById, "a registerService request for Editor.getActiveLocation") {
                 it.isRegisterService("Editor", "getActiveLocation")
@@ -78,6 +85,7 @@ class DartToolingDaemonServiceTest : BasePlatformTestCase() {
             it["method"]?.asString == "FileSystem.setIDEWorkspaceRoots"
         }
 
+        assertSuccessResponse(responsesById, streamListenId)
         assertSuccessResponse(responsesById, getActiveLocationId)
         assertSuccessResponse(responsesById, navigateToCodeId)
         assertSuccessResponse(responsesById, setWorkspaceRootsId)


### PR DESCRIPTION
This is to fix settings not being sent to analytics frequently due to DTD for analytics not being available yet. (follow up to https://github.com/flutter/dart-intellij-third-party/pull/386).

The main change is adding a queue for pending analytics requests. To check this, run workbench and make sure there are no errors related to analytics not being ready. 

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- ~[ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)~

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
