### PR TITLE
Add sdk guard for --ping-interval.

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonCommandLine.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonCommandLine.kt
@@ -36,8 +36,12 @@ internal fun createDtdCommandLine(sdk: DartSdk, pingInterval: Int = 15): General
   return commandLine
 }
 
-internal fun supportsDtdPingInterval(sdkVersion: String): Boolean =
-  sdkVersion.firstOrNull()?.isDigit() == true &&
-  DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_DTD_PING_INTERVAL_SDK_VERSION) >= 0
+internal fun supportsDtdPingInterval(sdkVersion: String): Boolean {
+  if (sdkVersion.isBlank() || !sdkVersion.first().isDigit()) {
+    return false
+  }
+
+  return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_DTD_PING_INTERVAL_SDK_VERSION) >= 0
+}
 
 internal fun isDtdCommandLine(text: String): Boolean = DTD_COMMAND_LINE_PATTERN.matches(text)

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonCommandLine.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonCommandLine.kt
@@ -10,6 +10,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.util.io.FileUtil
 import com.jetbrains.lang.dart.analytics.Analytics
 import com.jetbrains.lang.dart.sdk.DartSdk
+import com.jetbrains.lang.dart.sdk.DartSdkUpdateChecker
 import com.jetbrains.lang.dart.sdk.DartSdkUtil
 
 private val DTD_COMMAND_LINE_PARAMETERS = listOf(
@@ -18,18 +19,25 @@ private val DTD_COMMAND_LINE_PARAMETERS = listOf(
 )
 
 private const val DTD_PING_INTERVAL_PARAMETER_PREFIX = "--ping-interval="
+private const val MIN_DTD_PING_INTERVAL_SDK_VERSION = "3.11.0"
 
 private val DTD_COMMAND_LINE_PATTERN =
-  Regex(""".+\btooling-daemon --machine --ping-interval=\d+""")
+  Regex(""".+\btooling-daemon --machine(?: --ping-interval=\d+)?""")
 
 internal fun createDtdCommandLine(sdk: DartSdk, pingInterval: Int = 15): GeneralCommandLine {
   val commandLine = GeneralCommandLine().withWorkDirectory(sdk.homePath)
   commandLine.exePath = FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk))
   commandLine.charset = Charsets.UTF_8
   DTD_COMMAND_LINE_PARAMETERS.forEach(commandLine::addParameter)
-  commandLine.addParameter("$DTD_PING_INTERVAL_PARAMETER_PREFIX$pingInterval")
+  if (supportsDtdPingInterval(sdk.version)) {
+    commandLine.addParameter("$DTD_PING_INTERVAL_PARAMETER_PREFIX$pingInterval")
+  }
   Analytics.updateEnvironment(commandLine)
   return commandLine
 }
+
+internal fun supportsDtdPingInterval(sdkVersion: String): Boolean =
+  sdkVersion.firstOrNull()?.isDigit() == true &&
+  DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_DTD_PING_INTERVAL_SDK_VERSION) >= 0
 
 internal fun isDtdCommandLine(text: String): Boolean = DTD_COMMAND_LINE_PATTERN.matches(text)

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonCommandLineTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/toolingDaemon/DartToolingDaemonCommandLineTest.kt
@@ -13,7 +13,16 @@ class DartToolingDaemonCommandLineTest : TestCase() {
     fun testIdentifiesDtdCommandLine() {
         assertTrue(isDtdCommandLine("/path/to/dart tooling-daemon --machine --ping-interval=15"))
         assertTrue(isDtdCommandLine("/path/to/dart tooling-daemon --machine --ping-interval=30"))
-        assertFalse(isDtdCommandLine("/path/to/dart tooling-daemon --machine"))
+        assertTrue(isDtdCommandLine("/path/to/dart tooling-daemon --machine"))
         assertFalse(isDtdCommandLine("/path/to/dart tooling-daemon --machine --ping-interval=invalid"))
+    }
+
+    fun testSupportsDtdPingInterval() {
+        assertFalse(supportsDtdPingInterval("3.10.9"))
+        assertFalse(supportsDtdPingInterval("3.11.0-dev.100.0"))
+        assertTrue(supportsDtdPingInterval("3.11.0"))
+        assertTrue(supportsDtdPingInterval("3.12.0-dev.1.0"))
+        assertTrue(supportsDtdPingInterval("3.12.0"))
+        assertFalse(supportsDtdPingInterval("unknown"))
     }
 }


### PR DESCRIPTION
## Summary

Relates to https://github.com/flutter/dart-intellij-third-party/issues/597

since --ping interval option was added on sdk 3.11, we need to make sure we don't add this to the command with older sdk versions.

