### PR TITLE
Refactor DartFileListener to use Java 21 pattern matching

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
@@ -68,16 +68,16 @@ public final class DartFileListener implements AsyncFileListener {
     for (VFileEvent event : events) {
       if (event.getFileSystem() != LocalFileSystem.getInstance() && !ApplicationManager.getApplication().isUnitTestMode()) continue;
 
-      if (event instanceof VFilePropertyChangeEvent) {
-        if (((VFilePropertyChangeEvent)event).isRename()) {
-          if (PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getOldValue()) ||
-              PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(((VFilePropertyChangeEvent)event).getNewValue())) {
-            packagesFileEvents.add(event);
+      if (event instanceof VFilePropertyChangeEvent propertyChangeEvent) {
+        if (propertyChangeEvent.isRename()) {
+          if (PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(propertyChangeEvent.getOldValue()) ||
+              PackageConfigFileUtil.PACKAGE_CONFIG_JSON.equals(propertyChangeEvent.getNewValue())) {
+            packagesFileEvents.add(propertyChangeEvent);
           }
 
-          if (DartAnalysisServerService.isFileNameRespectedByAnalysisServer(((VFilePropertyChangeEvent)event).getOldValue().toString()) ||
-              DartAnalysisServerService.isFileNameRespectedByAnalysisServer(((VFilePropertyChangeEvent)event).getNewValue().toString())) {
-            moveOrRenameAnalyzableFileEvents.add(event);
+          if (DartAnalysisServerService.isFileNameRespectedByAnalysisServer(propertyChangeEvent.getOldValue().toString()) ||
+              DartAnalysisServerService.isFileNameRespectedByAnalysisServer(propertyChangeEvent.getNewValue().toString())) {
+            moveOrRenameAnalyzableFileEvents.add(propertyChangeEvent);
           }
         }
       }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/DartFileListener.java
@@ -75,8 +75,8 @@ public final class DartFileListener implements AsyncFileListener {
             packagesFileEvents.add(propertyChangeEvent);
           }
 
-          if (DartAnalysisServerService.isFileNameRespectedByAnalysisServer(propertyChangeEvent.getOldValue().toString()) ||
-              DartAnalysisServerService.isFileNameRespectedByAnalysisServer(propertyChangeEvent.getNewValue().toString())) {
+          if ((propertyChangeEvent.getOldValue() instanceof String oldValue && DartAnalysisServerService.isFileNameRespectedByAnalysisServer(oldValue)) ||
+                  (propertyChangeEvent.getNewValue() instanceof String newValue && DartAnalysisServerService.isFileNameRespectedByAnalysisServer(newValue))) {
             moveOrRenameAnalyzableFileEvents.add(propertyChangeEvent);
           }
         }


### PR DESCRIPTION
### Summary 
This PR refactors `DartFileListener.java` to adopt Java 21 **pattern matching for `instanceof`**, eliminating repetitive `(VFilePropertyChangeEvent)event` casts in `prepareChange()`.

Initially work item was focused on removing the following API Call marked as experimental in the :
- **Method Invocation:** `com.intellij.openapi.vfs.newvfs.events.VFilePropertyChangeEvent.isRename` 
  - _Source:_ `com.jetbrains.lang.dart.DartFileListener.prepareChange`

In IntelliJ 2025.3 (Build 253): JetBrains had it marked with `@ApiStatus.Experimental,` which is why the IntelliJ Plugin Verifier flags it against 2025.3 and records it in `verifier-baseline.txt:26`.
  • In IntelliJ 2026.1+ (Builds 261, 262+): JetBrains officially removed the `@ApiStatus.Experimental` tag. The Verifier treats it as a stable, standard Open API, so it is not flagged at all in 261/262.

  At runtime, isRename() exists and works identically across all supported versions (253, 261, 262). The baseline entry in 253 is just a snapshot artifact from that version's historical annotation

#### Background & Investigation on `VFilePropertyChangeEvent.isRename()`

During an audit of marked/experimental API calls, `VFilePropertyChangeEvent.isRename()` was evaluated for potential migration. Investigation revealed the following:

1. **Original Motivation ([JetBrains commit `ec06de44a23`](https://github.com/JetBrains/intellij-community/commit/ec06de44a23f2bc07560d7fd42dfddc44879abc3)):** JetBrains introduced `isRename()` explicitly to eliminate boilerplate and error-prone duplicate logic around `VirtualFile.PROP_NAME` and `FileContentUtilCore.FORCE_RELOAD_REQUESTOR` (filtering out synthetic reparse events).
2. **Public API Graduation ([JetBrains commit `2e411f0d431`](https://github.com/JetBrains/intellij-community/commit/2e411f0d431d76fba79ca0415578984cd2787523)):**
       In IntelliJ 2026.1, JetBrains officially removed the `@ApiStatus.Experimental` annotation from `isRename()` and moved it to the permanent public API dump (`api-dump.txt`).
3. **Plugin Verifier Baselines:**
       - **Build 253 (2025.3):** Flagged under experimental API due to the historical 2025 annotation.
       - **Builds 261 & 262 (2026.1+):** 0 warnings / completely absent from baselines because it is now recognized as stable Open API.

Replacing `isRename()` with manual property and requestor checks would regress against JetBrains' intended API evolution. Therefore, `isRename()` is kept as-is, and this change focuses strictly on code modernization and readability.


---

Review the contribution guidelines below:

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
