### PR TITLE
Make fixes for SDK 3.13

### DIFF
--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerIntentionsTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerIntentionsTest.java
@@ -37,7 +37,7 @@ public class DartServerIntentionsTest extends CodeInsightFixtureTestCase {
   }
 
   public void testIntroduceVariableNoSelection() {
-    doTest("Assign value to new local variable");
+    doTest("Assign value to local variable");
   }
 
   public void testSurroundWithTryCatch() {
@@ -95,7 +95,7 @@ public class DartServerIntentionsTest extends CodeInsightFixtureTestCase {
       main ( )  {
        Foo<caret>
          }""");
-    IntentionAction action = myFixture.findSingleIntention("Assign value to new local variable");
+    IntentionAction action = myFixture.findSingleIntention("Assign value to local variable");
     assertEquals("""
                    main ( )  {
                     var foo = Foo

--- a/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerQuickFixTest.java
+++ b/third_party/src/test/java/com/jetbrains/dart/analysisServer/DartServerQuickFixTest.java
@@ -90,7 +90,7 @@ public class DartServerQuickFixTest extends CodeInsightFixtureTestCase {
   }
 
   public void testUseEqEqNull() {
-    doQuickFixTest("Use == null instead of 'is Null'");
+    doQuickFixTest("Use '== null' instead of 'is Null'");
   }
 
   private void doCrLfAwareTest(@NotNull final String content, @NotNull final String intentionStartText, @NotNull final String after) {

--- a/third_party/src/test/testData/analysisServer/highlighting/ErrorsAfterEOF.dart
+++ b/third_party/src/test/testData/analysisServer/highlighting/ErrorsAfterEOF.dart
@@ -1,1 +1,1 @@
-class Foo implement<error descr="A class declaration must have a body, even if it is empty."><error descr="Classes and mixins can only implement other classes and mixins."><error descr="Expected a type name.">s</error></error></error>
+class Foo implement<error descr="A class declaration must have a body, even if it is empty."><error descr="Expected a type name.">s</error></error>


### PR DESCRIPTION
This is attempting to fix the tests due to changes in Dart SDK 3.13.

```
DART_HOME=/path/to/dart-sdk ./gradlew test
```

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- ~[ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)~

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
