### PR TITLE
Update analysis server API for setClientCapabilities

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -579,6 +579,31 @@ public final class DartAnalysisServerService implements Disposable {
     return StringUtil.compareVersionNumbers(sdkVersion, MIN_WORKSPACE_APPLY_EDITS_SDK_VERSION) >= 0;
   }
 
+  public static @NotNull JsonObject buildLspCapabilities(@NotNull String sdkVersion) {
+    JsonObject lspCapabilities = new JsonObject();
+
+    if (isDartSdkVersionSufficientForWorkspaceApplyEdits(sdkVersion)) {
+      JsonObject workspace = new JsonObject();
+      workspace.addProperty("applyEdit", true);
+
+      JsonObject workspaceEdit = new JsonObject();
+      workspaceEdit.addProperty("documentChanges", false);
+      workspace.add("workspaceEdit", workspaceEdit);
+
+      lspCapabilities.add("workspace", workspace);
+    }
+
+    JsonObject textDocument = new JsonObject();
+
+    JsonObject definition = new JsonObject();
+    definition.addProperty("linkSupport", true);
+    textDocument.add("definition", definition);
+
+    lspCapabilities.add("textDocument", textDocument);
+
+    return lspCapabilities;
+  }
+
   public static boolean isDartSdkVersionSufficientForLspNavigation(@NotNull String sdkVersion) {
     return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_NAVIGATION_SDK_VERSION) >= 0;
   }
@@ -2326,10 +2351,9 @@ public final class DartAnalysisServerService implements Disposable {
         mySdkVersion = sdk.getVersion();
 
         boolean supportsUris = isDartSdkVersionSufficientForFileUri(mySdkVersion);
-        boolean supportsWorkspaceApplyEdits = isDartSdkVersionSufficientForWorkspaceApplyEdits(mySdkVersion);
         startedServer.server_setClientCapabilities(List.of("openUrlRequest", "showMessageRequest"),
                                                    supportsUris,
-                                                   supportsWorkspaceApplyEdits);
+                                                   buildLspCapabilities(mySdkVersion));
 
         myServer = startedServer;
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -37,6 +37,7 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
 
     private lateinit var bridgeServer: DartBridgeLspServer
     private lateinit var capturedListener: ResponseListener
+    private lateinit var mockServer: RemoteAnalysisServerImpl
     private val mockClient = MockLanguageClient()
     private val capturedRequests = CopyOnWriteArrayList<JsonObject>()
 
@@ -57,7 +58,7 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         dasSdkVersionField.set(das, sdk.version)
 
         val stubSocket = createStubSocket()
-        val mockServer = object : RemoteAnalysisServerImpl(stubSocket) {
+        mockServer = object : RemoteAnalysisServerImpl(stubSocket) {
             override fun addResponseListener(listener: ResponseListener) {
                 capturedListener = listener
                 super.addResponseListener(listener)
@@ -289,6 +290,21 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertEquals(2, result.size)
         assertEquals(DocumentHighlightKind.Write, result[0].kind)
         assertEquals(DocumentHighlightKind.Read, result[1].kind)
+    }
+
+    fun testClientCapabilities() {
+        val lspCaps = JsonObject().apply {
+            addProperty("testCap", true)
+        }
+        mockServer.server_setClientCapabilities(listOf("openUrlRequest"), true, lspCaps)
+
+        val req = requireNotNull(capturedRequests.find { it.get("method")?.asString == "server.setClientCapabilities" }) {
+            "A server.setClientCapabilities request should be generated"
+        }
+        val params = req.getAsJsonObject("params")
+        assertEquals(true, params.get("supportsUris").asBoolean)
+        val lspCapabilities = params.getAsJsonObject("lspCapabilities")
+        assertEquals(true, lspCapabilities.get("testCap").asBoolean)
     }
 
     private class MockLanguageClient : LanguageClient {

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -1049,6 +1049,7 @@ public interface AnalysisServer {
    *        client sets this capability.
    */
   public void server_setClientCapabilities(List<String> requests, boolean supportsUris, boolean supportsWorkspaceApplyEdits);
+  public void server_setClientCapabilities(List<String> requests, boolean supportsUris, Object lspCapabilities);
 
   /**
    * {@code server.setSubscriptions}

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/generated/AnalysisServer.java
@@ -1048,7 +1048,6 @@ public interface AnalysisServer {
    *        protocol (see the "lsp" domain). LSP notifications are automatically enabled when the
    *        client sets this capability.
    */
-  public void server_setClientCapabilities(List<String> requests, boolean supportsUris, boolean supportsWorkspaceApplyEdits);
   public void server_setClientCapabilities(List<String> requests, boolean supportsUris, Object lspCapabilities);
 
   /**

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -707,6 +707,15 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
   }
 
   @Override
+  public void server_setClientCapabilities(List<String> requests, boolean supportsUris, Object lspCapabilities) {
+    String id = generateUniqueId();
+    if (requests == null) {
+      requests = StringUtilities.EMPTY_LIST;
+    }
+    sendRequestToServer(id, RequestUtilities.generateClientCapabilities(id, requests, supportsUris, lspCapabilities));
+  }
+
+  @Override
   public void lsp_connectToDtd(String uri) {
     String id = generateUniqueId();
     sendRequestToServer(id, RequestUtilities.generateConnectToDtd(id, uri), new BasicConsumer() {

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -698,15 +698,6 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
   }
 
   @Override
-  public void server_setClientCapabilities(List<String> requests, boolean supportsUris, boolean supportsWorkspaceApplyEdits) {
-    String id = generateUniqueId();
-    if (requests == null) {
-      requests = StringUtilities.EMPTY_LIST;
-    }
-    sendRequestToServer(id, RequestUtilities.generateClientCapabilities(id, requests, supportsUris, supportsWorkspaceApplyEdits));
-  }
-
-  @Override
   public void server_setClientCapabilities(List<String> requests, boolean supportsUris, Object lspCapabilities) {
     String id = generateUniqueId();
     if (requests == null) {

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -1054,42 +1054,6 @@ public class RequestUtilities {
   public static JsonObject generateClientCapabilities(String idValue,
                                                       List<String> requests,
                                                       boolean supportsUris,
-                                                      boolean supportsWorkspaceApplyEdits) {
-    JsonObject params = new JsonObject();
-    params.add(REQUESTS, buildJsonElement(requests));
-    if (supportsUris) {
-      params.addProperty("supportsUris", supportsUris);
-    }
-
-    JsonObject lspCapabilities = new JsonObject();
-
-    if (supportsWorkspaceApplyEdits) {
-      JsonObject workspace = new JsonObject();
-      workspace.addProperty("applyEdit", true);
-
-      JsonObject workspaceEdit = new JsonObject();
-      workspaceEdit.addProperty("documentChanges", false);
-      workspace.add("workspaceEdit", workspaceEdit);
-
-      lspCapabilities.add("workspace", workspace);
-    }
-
-    JsonObject textDocument = new JsonObject();
-
-    JsonObject definition = new JsonObject();
-    definition.addProperty("linkSupport", true);
-    textDocument.add("definition", definition);
-
-    lspCapabilities.add("textDocument", textDocument);
-
-    params.add("lspCapabilities", lspCapabilities);
-
-    return buildJsonObjectRequest(idValue, METHOD_SERVER_SET_CAPABILITIES, params);
-  }
-
-  public static JsonObject generateClientCapabilities(String idValue,
-                                                      List<String> requests,
-                                                      boolean supportsUris,
                                                       Object lspCapabilities) {
     JsonObject params = new JsonObject();
     params.add(REQUESTS, buildJsonElement(requests));

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/utilities/RequestUtilities.java
@@ -153,6 +153,9 @@ public class RequestUtilities {
     else if (object instanceof String) {
       return new JsonPrimitive((String)object);
     }
+    else if (object instanceof JsonElement) {
+      return (JsonElement)object;
+    }
     else if (object instanceof List<?>) {
       List<?> list = (List<?>)object;
       JsonArray jsonArray = new JsonArray();
@@ -1081,6 +1084,21 @@ public class RequestUtilities {
 
     params.add("lspCapabilities", lspCapabilities);
 
+    return buildJsonObjectRequest(idValue, METHOD_SERVER_SET_CAPABILITIES, params);
+  }
+
+  public static JsonObject generateClientCapabilities(String idValue,
+                                                      List<String> requests,
+                                                      boolean supportsUris,
+                                                      Object lspCapabilities) {
+    JsonObject params = new JsonObject();
+    params.add(REQUESTS, buildJsonElement(requests));
+    if (supportsUris) {
+      params.addProperty("supportsUris", supportsUris);
+    }
+    if (lspCapabilities != null) {
+      params.add("lspCapabilities", buildJsonElement(lspCapabilities));
+    }
     return buildJsonObjectRequest(idValue, METHOD_SERVER_SET_CAPABILITIES, params);
   }
 


### PR DESCRIPTION
This updates our analysis server code to be in line with what's in the SDK repo for `setClientCapabilities`, which we will be using as we convert more analysis methods to LSP.

To test this manually, make sure the functionality related to the capabilities still work:
- Use Cmd+ click on a method or var; cursor should jump to the definition
- Trigger a quick fix; the edit should be applied

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- ~[ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)~

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
