### PR TITLE
Add type definition navigation using LSP bridge

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Populate Dart Analysis tool window errors and warnings using Language Server Protocol (LSP) publishDiagnostics notifications (#520)
+- Go to Type Declaration implemented with JetBrains LSP
 
 ### Changed
 

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 - Populate Dart Analysis tool window errors and warnings using Language Server Protocol (LSP) publishDiagnostics notifications (#520)
-- Go to Type Declaration implemented with JetBrains LSP
+- Go to Type Declaration implemented with JetBrains LSP (#615)
 
 ### Changed
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -563,6 +563,10 @@ public final class DartAnalysisServerService implements Disposable {
     definition.addProperty("linkSupport", true);
     textDocument.add("definition", definition);
 
+    JsonObject typeDefinition = new JsonObject();
+    typeDefinition.addProperty("linkSupport", true);
+    textDocument.add("typeDefinition", typeDefinition);
+
     if (supportsLspDiagnostics) {
       JsonObject publishDiagnostics = new JsonObject();
       publishDiagnostics.addProperty("relatedInformation", true);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -44,6 +44,7 @@ import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.LanguageClientAware
 import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
+import org.eclipse.lsp4j.TypeDefinitionParams
 import java.lang.reflect.Type
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -227,6 +228,7 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
         val capabilities = ServerCapabilities().apply {
             setHoverProvider(true)
             setDefinitionProvider(true)
+            setTypeDefinitionProvider(true)
             setDocumentHighlightProvider(true)
             // Add other capabilities as we support them.
         }
@@ -257,6 +259,13 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
     override fun definition(params: DefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
         val type = object : TypeToken<List<LocationLink>>() {}.type
         return forwardRequest<List<LocationLink>>("textDocument/definition", params, type).thenApply { links ->
+            Either.forRight(links ?: emptyList())
+        }
+    }
+
+    override fun typeDefinition(params: TypeDefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
+        val type = object : TypeToken<List<LocationLink>>() {}.type
+        return forwardRequest<List<LocationLink>>("textDocument/typeDefinition", params, type).thenApply { links ->
             Either.forRight(links ?: emptyList())
         }
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -32,7 +32,7 @@ import com.intellij.platform.dartlsp.api.customization.LspFormattingDisabled
 import com.intellij.platform.dartlsp.api.customization.LspGoToDefinitionCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspGoToDefinitionDisabled
 import com.intellij.platform.dartlsp.api.customization.LspGoToDefinitionSupport
-import com.intellij.platform.dartlsp.api.customization.LspGoToTypeDefinitionDisabled
+import com.intellij.platform.dartlsp.api.customization.LspGoToTypeDefinitionSupport
 import com.intellij.platform.dartlsp.api.customization.LspHoverCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspHoverDisabled
 import com.intellij.platform.dartlsp.api.customization.LspHoverSupport
@@ -115,7 +115,7 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
             } else {
                 LspGoToDefinitionDisabled
             }
-        override val goToTypeDefinitionCustomizer = LspGoToTypeDefinitionDisabled
+        override val goToTypeDefinitionCustomizer = LspGoToTypeDefinitionSupport()
         override val completionCustomizer = LspCompletionDisabled
         override val semanticTokensCustomizer = LspSemanticTokensDisabled
         override val diagnosticsCustomizer = LspDiagnosticsDisabled

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -15,7 +15,8 @@ enum class LspMethod(
     DOCUMENT_HIGHLIGHT("textDocument/documentHighlight", isExperimental = true, presentableName = "read/write highlighting"),
     HOVER("textDocument/hover", isExperimental = true, presentableName = "hover"),
     INITIALIZE("initialize"),
-    SHUTDOWN("shutdown");
+    SHUTDOWN("shutdown"),
+    TYPE_DEFINITION("textDocument/typeDefinition");
 
     companion object {
         fun fromMethod(method: String): LspMethod? = entries.find { it.method == method }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -16,7 +16,7 @@ enum class LspMethod(
     HOVER("textDocument/hover", isExperimental = true, presentableName = "hover"),
     INITIALIZE("initialize"),
     SHUTDOWN("shutdown"),
-    TYPE_DEFINITION("textDocument/typeDefinition");
+    TYPE_DEFINITION("textDocument/typeDefinition", isExperimental = false);
 
     companion object {
         fun fromMethod(method: String): LspMethod? = entries.find { it.method == method }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TypeDefinitionParams
 import org.eclipse.lsp4j.services.LanguageClient
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
@@ -353,6 +354,49 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         // Also check that DartAnalysisServerService processed the diagnostic
         val errorsHash = DartAnalysisServerService.getInstance(project).getFilePathsWithErrorsHash()
         assertNotSame(0, errorsHash)
+    }
+
+    fun testTypeDefinitionRequest() {
+        val params = TypeDefinitionParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(1, 2)
+        }
+
+        val future = bridgeServer.typeDefinition(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("textDocument/typeDefinition", lspMessage.get("method").asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": [
+                    {
+                      "targetUri": "file://target.dart",
+                      "targetRange": {"start": {"line": 0, "character": 0}, "end": {"line": 10, "character": 0}},
+                      "targetSelectionRange": {"start": {"line": 0, "character": 6}, "end": {"line": 0, "character": 9}}
+                    }
+                  ]
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertTrue(result.isRight)
+        assertEquals(1, result.right.size)
+        assertEquals("file://target.dart", result.right[0].targetUri)
     }
 
     private class MockLanguageClient : LanguageClient {


### PR DESCRIPTION
Go to type definition is not implemented with legacy communication with the DAS, so this is a new feature enabled by LSP. Because there is no legacy equivalent and the endpoint used (`textDocument/typeDefinition`) has already been in place for over two years, we should enable this globally (i.e. it does not need to be gated as an experimental LSP feature, since there is no legacy implementation to switch back to).

Sample code for testing:
```
class OrderInfo {
  void cancel() {}
}

OrderInfo fetchOrder(String id) => OrderInfo();

void main() {
  final myOrder = fetchOrder("123");

  // 1. Place caret on `myOrder` here and hit Cmd+Shift+B
  myOrder.cancel();
}
```

Cmd+Shift+B should move the cursor to OrderInfo on the first line.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
