### PR TITLE
Go to Type Declaration via LSP typeDefinition

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Added
+- Go to Type Declaration for Dart via LSP textDocument/typeDefinition (JetBrains LSP, experimental feature) (#618)
 
 ### Changed
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -32,6 +32,7 @@ import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.ServerCapabilities
+import org.eclipse.lsp4j.TypeDefinitionParams
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
 import org.eclipse.lsp4j.jsonrpc.messages.Either
@@ -215,6 +216,7 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
             setHoverProvider(true)
             setDefinitionProvider(true)
             setDocumentHighlightProvider(true)
+            setTypeDefinitionProvider(true)
             // Add other capabilities as we support them.
         }
         return CompletableFuture.completedFuture(InitializeResult(capabilities))
@@ -244,6 +246,15 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
     override fun definition(params: DefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
         val type = object : TypeToken<List<LocationLink>>() {}.type
         return forwardRequest<List<LocationLink>>("textDocument/definition", params, type).thenApply { links ->
+            Either.forRight(links ?: emptyList())
+        }
+    }
+
+    // Note: We advertise linkSupport: true for typeDefinition in server.setClientCapabilities
+    // (see DartAnalysisServerService.buildLspCapabilities) so DAS returns List<LocationLink>.
+    override fun typeDefinition(params: TypeDefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
+        val type = object : TypeToken<List<LocationLink>>() {}.type
+        return forwardRequest<List<LocationLink>>("textDocument/typeDefinition", params, type).thenApply { links ->
             Either.forRight(links ?: emptyList())
         }
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -250,12 +250,32 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
         }
     }
 
-    // Note: We advertise linkSupport: true for typeDefinition in server.setClientCapabilities
-    // (see DartAnalysisServerService.buildLspCapabilities) so DAS returns List<LocationLink>.
+    // Note: DAS only returns List<LocationLink> for textDocument/typeDefinition when the client advertises
+    // typeDefinition.linkSupport; otherwise it answers with a single Location or a List<Location> (LSP
+    // `Definition`). Accept all of these shapes so the feature does not depend on that capability.
     override fun typeDefinition(params: TypeDefinitionParams): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
-        val type = object : TypeToken<List<LocationLink>>() {}.type
-        return forwardRequest<List<LocationLink>>("textDocument/typeDefinition", params, type).thenApply { links ->
-            Either.forRight(links ?: emptyList())
+        return forwardRequest("textDocument/typeDefinition", params, JsonElement::class.java).thenApply { json ->
+            toDefinitionResult(json)
+        }
+    }
+
+    private fun toDefinitionResult(json: JsonElement?): Either<List<Location>, List<LocationLink>> {
+        if (json == null || json.isJsonNull) {
+            return Either.forRight(emptyList())
+        }
+        if (json.isJsonObject) {
+            return Either.forLeft(listOf(GSON.fromJson(json, Location::class.java)))
+        }
+        if (!json.isJsonArray || json.asJsonArray.isEmpty) {
+            return Either.forRight(emptyList())
+        }
+        val first = json.asJsonArray[0]
+        return if (first.isJsonObject && first.asJsonObject.has("targetUri")) {
+            val type = object : TypeToken<List<LocationLink>>() {}.type
+            Either.forRight(GSON.fromJson(json, type))
+        } else {
+            val type = object : TypeToken<List<Location>>() {}.type
+            Either.forLeft(GSON.fromJson(json, type))
         }
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -32,7 +32,9 @@ import com.intellij.platform.dartlsp.api.customization.LspFormattingDisabled
 import com.intellij.platform.dartlsp.api.customization.LspGoToDefinitionCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspGoToDefinitionDisabled
 import com.intellij.platform.dartlsp.api.customization.LspGoToDefinitionSupport
+import com.intellij.platform.dartlsp.api.customization.LspGoToTypeDefinitionCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspGoToTypeDefinitionDisabled
+import com.intellij.platform.dartlsp.api.customization.LspGoToTypeDefinitionSupport
 import com.intellij.platform.dartlsp.api.customization.LspHoverCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspHoverDisabled
 import com.intellij.platform.dartlsp.api.customization.LspHoverSupport
@@ -115,7 +117,12 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
             } else {
                 LspGoToDefinitionDisabled
             }
-        override val goToTypeDefinitionCustomizer = LspGoToTypeDefinitionDisabled
+        override val goToTypeDefinitionCustomizer: LspGoToTypeDefinitionCustomizer
+            get() = if (DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
+                LspGoToTypeDefinitionSupport()
+            } else {
+                LspGoToTypeDefinitionDisabled
+            }
         override val completionCustomizer = LspCompletionDisabled
         override val semanticTokensCustomizer = LspSemanticTokensDisabled
         override val diagnosticsCustomizer = LspDiagnosticsDisabled

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -15,7 +15,8 @@ enum class LspMethod(
     DOCUMENT_HIGHLIGHT("textDocument/documentHighlight", isExperimental = true, presentableName = "read/write highlighting"),
     HOVER("textDocument/hover", isExperimental = true, presentableName = "hover"),
     INITIALIZE("initialize"),
-    SHUTDOWN("shutdown");
+    SHUTDOWN("shutdown"),
+    TYPE_DEFINITION("textDocument/typeDefinition", isExperimental = true, presentableName = "go to type declaration");
 
     companion object {
         fun fromMethod(method: String): LspMethod? = entries.find { it.method == method }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -308,6 +308,11 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertEquals("123", lspMessage.get("id").asString)
         assertEquals("textDocument/typeDefinition", lspMessage.get("method").asString)
 
+        val sentParams = lspMessage.getAsJsonObject("params")
+        assertEquals("file://test.dart", sentParams.getAsJsonObject("textDocument").get("uri").asString)
+        assertEquals(3, sentParams.getAsJsonObject("position").get("line").asInt)
+        assertEquals(7, sentParams.getAsJsonObject("position").get("character").asInt)
+
         val responseJson = """
             {
               "id": "123",
@@ -335,6 +340,38 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertEquals(1, result.right.size)
         assertEquals("file:///lib/foo.dart", result.right[0].targetUri)
         assertEquals(10, result.right[0].targetSelectionRange.start.line)
+    }
+
+    fun testTypeDefinitionRequestWithNullResult() {
+        val params = TypeDefinitionParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(3, 7)
+        }
+
+        val future = bridgeServer.typeDefinition(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": null
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertTrue(result.isRight)
+        assertTrue(result.right.isEmpty())
     }
 
     private class MockLanguageClient : LanguageClient {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -376,6 +376,108 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertTrue(result.right.isEmpty())
     }
 
+    fun testTypeDefinitionRequestWithSingleLocationResult() {
+        val params = TypeDefinitionParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(3, 7)
+        }
+
+        val future = bridgeServer.typeDefinition(params)
+
+        val jsonObject = requireNotNull(capturedRequests.find { it.get("method")?.asString == "lsp.handle" }) {
+            "An lsp.handle request should be sent to DAS"
+        }
+        assertEquals("123", jsonObject.get("id")?.asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": {"uri": "file:///lib/foo.dart", "range": {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 9}}}
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertTrue(result.isLeft)
+        assertEquals(1, result.left.size)
+        assertEquals("file:///lib/foo.dart", result.left[0].uri)
+        assertEquals(10, result.left[0].range.start.line)
+    }
+
+    fun testTypeDefinitionRequestWithLocationListResult() {
+        val params = TypeDefinitionParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(3, 7)
+        }
+
+        val future = bridgeServer.typeDefinition(params)
+
+        val jsonObject = requireNotNull(capturedRequests.find { it.get("method")?.asString == "lsp.handle" }) {
+            "An lsp.handle request should be sent to DAS"
+        }
+        assertEquals("123", jsonObject.get("id")?.asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": [{"uri": "file:///lib/foo.dart", "range": {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 9}}}, {"uri": "file:///lib/bar.dart", "range": {"start": {"line": 2, "character": 0}, "end": {"line": 2, "character": 3}}}]
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertTrue(result.isLeft)
+        assertEquals(2, result.left.size)
+        assertEquals("file:///lib/bar.dart", result.left[1].uri)
+    }
+
+    fun testTypeDefinitionRequestWithEmptyResult() {
+        val params = TypeDefinitionParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(3, 7)
+        }
+
+        val future = bridgeServer.typeDefinition(params)
+
+        val jsonObject = requireNotNull(capturedRequests.find { it.get("method")?.asString == "lsp.handle" }) {
+            "An lsp.handle request should be sent to DAS"
+        }
+        assertEquals("123", jsonObject.get("id")?.asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": []
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertTrue(result.isRight)
+        assertTrue(result.right.isEmpty())
+    }
+
     private class MockLanguageClient : LanguageClient {
         var publishedDiagnostics: PublishDiagnosticsParams? = null
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -300,9 +300,10 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
 
         val future = bridgeServer.typeDefinition(params)
 
-        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
-        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
-        assertEquals("123", jsonObject!!.get("id").asString)
+        val jsonObject = requireNotNull(capturedRequests.find { it.get("method")?.asString == "lsp.handle" }) {
+            "An lsp.handle request should be sent to DAS"
+        }
+        assertEquals("123", jsonObject.get("id")?.asString)
 
         val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
         assertEquals("123", lspMessage.get("id").asString)
@@ -350,9 +351,10 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
 
         val future = bridgeServer.typeDefinition(params)
 
-        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
-        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
-        assertEquals("123", jsonObject!!.get("id").asString)
+        val jsonObject = requireNotNull(capturedRequests.find { it.get("method")?.asString == "lsp.handle" }) {
+            "An lsp.handle request should be sent to DAS"
+        }
+        assertEquals("123", jsonObject.get("id")?.asString)
 
         val responseJson = """
             {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.TypeDefinitionParams
 import org.eclipse.lsp4j.services.LanguageClient
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
@@ -289,6 +290,51 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertEquals(2, result.size)
         assertEquals(DocumentHighlightKind.Write, result[0].kind)
         assertEquals(DocumentHighlightKind.Read, result[1].kind)
+    }
+
+    fun testTypeDefinitionRequest() {
+        val params = TypeDefinitionParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(3, 7)
+        }
+
+        val future = bridgeServer.typeDefinition(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("textDocument/typeDefinition", lspMessage.get("method").asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": [
+                    {
+                      "originSelectionRange": {"start": {"line": 3, "character": 6}, "end": {"line": 3, "character": 9}},
+                      "targetUri": "file:///lib/foo.dart",
+                      "targetRange": {"start": {"line": 10, "character": 0}, "end": {"line": 20, "character": 1}},
+                      "targetSelectionRange": {"start": {"line": 10, "character": 6}, "end": {"line": 10, "character": 9}}
+                    }
+                  ]
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertTrue(result.isRight)
+        assertEquals(1, result.right.size)
+        assertEquals("file:///lib/foo.dart", result.right[0].targetUri)
+        assertEquals(10, result.right[0].targetSelectionRange.start.line)
     }
 
     private class MockLanguageClient : LanguageClient {


### PR DESCRIPTION
Implements #580 with the same pattern as #539/#552 and the inlay-hints PR this is stacked on (#617): the bridge forwards `textDocument/typeDefinition` (advertising `typeDefinitionProvider`), `LspMethod.TYPE_DEFINITION` is added, and `goToTypeDefinitionCustomizer` is enabled behind the experimental-LSP setting. The bundled client's `LspImplicitReferenceProvider`/`LspSymbolTypeProvider` drive *Navigate | Type Declaration*; the PSI path is only consulted when the server returns nothing, so there is nothing to gate.

**Independent of #617** — this branch is based directly on `main` and contains only the three typeDefinition commits. The two PRs overlap textually (capabilities block, `LspMethod`, descriptor imports, CHANGELOG), so whichever merges second gets a trivial rebase. (I first tried to stack this on #617's branch, but GitHub stacked PRs don't support the fork→upstream case yet — github/gh-stack#46 — so the PRs are simply separate.)

**Client capabilities:** the bridge accepts every shape the server can return for `textDocument/typeDefinition` — `List<LocationLink>` (only sent when the client advertises `typeDefinition.linkSupport`), `List<Location>`, or a single `Location` (what DAS returns today without the capability) — so this PR does not depend on the capability JSON. Advertising `linkSupport` for parity with `definition` (it adds the origin range) can follow once #614 has moved the capabilities into `DartAnalysisServerService.buildLspCapabilities`.

**Manual test:** flag on, caret on a variable (not on the type name) → ⌃⇧B / Ctrl+Shift+B (*Navigate | Type Declaration*) jumps to the declaration of the variable's type — verified in the sandbox with a Flutter project, including a type in `.pub-cache` (`GoRouter`). Flag off → unchanged (no Dart implementation existed). No errors in idea.log.

**Functional differences:** none to gate — the plugin never registered a `TypeDeclarationProvider`, so *Go to Type Declaration* did nothing for Dart before. Platform limitation: Ctrl+hover does not underline type-declaration targets for LSP-backed files (`LspImplicitReferenceProvider` only reacts to the explicit action). No SDK version gate: the handler is shared over LSP-over-Legacy since Dart 3.3.0.

**Status:** draft until the remaining sandbox items (file open at startup vs. opened later, `dart:` SDK file, toggle lifecycle) are ticked and screenshots are added. Unit tests (`com.jetbrains.lang.dart.lsp.*`, 11 bridge tests), `verifyPlugin` (no new baseline lines attributable to this change) and the repo code-review skill are done.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
