### PR TITLE
Mark diagnostics server port retrieval as non-experimental LSP feature

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Go to Type Declaration implemented with JetBrains LSP (#615)
 
 ### Changed
+- Diagnostics server port retrieval via LSP has passed the experimental phase and is now enabled for all users with an appropriate SDK
 
 ### Removed
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerDiagnosticsAction.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/errorTreeView/AnalysisServerDiagnosticsAction.java
@@ -16,7 +16,6 @@ import com.jetbrains.lang.dart.analytics.Analytics;
 import com.jetbrains.lang.dart.analytics.AnalyticsData;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.lsp.DartLspService;
-import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdkUpdateChecker;
 
 import org.dartlang.analysis.server.protocol.RequestError;
@@ -53,7 +52,6 @@ public class AnalysisServerDiagnosticsAction extends DumbAwareAction {
   void run(final @NotNull Project project, @Nullable AnActionEvent event) {
     String sdkVersion = DartAnalysisServerService.getInstance(project).getSdkVersion();
     if (!sdkVersion.isEmpty() &&
-        DartConfigurable.isExperimentalLspFeaturesEnabled(project) &&
         DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_DIAGNOSTIC_SERVER_SDK_VERSION) >= 0) {
       useLspOverLegacy(project);
     } else {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -11,7 +11,7 @@ enum class LspMethod(
     val presentableName: String? = null
 ) {
     DEFINITION("textDocument/definition", isExperimental = true, presentableName = "navigation"),
-    DIAGNOSTIC_SERVER("dart/diagnosticServer", isExperimental = true, presentableName = "diagnostic server"),
+    DIAGNOSTIC_SERVER("dart/diagnosticServer", isExperimental = false),
     DOCUMENT_HIGHLIGHT("textDocument/documentHighlight", isExperimental = true, presentableName = "read/write highlighting"),
     HOVER("textDocument/hover", isExperimental = true, presentableName = "hover"),
     INITIALIZE("initialize"),

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartLspExperimentalFeaturesTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartLspExperimentalFeaturesTest.java
@@ -33,4 +33,14 @@ public class DartLspExperimentalFeaturesTest extends CodeInsightFixtureTestCase 
     PropertiesComponent.getInstance(getProject()).setValue("dart.lsp.experimental.enabled", true, true);
     assertTrue(DartConfigurable.isExperimentalLspFeaturesEnabled(getProject()));
   }
+
+  public void testLspMethodsExperimentalStatus() {
+    assertFalse(LspMethod.DIAGNOSTIC_SERVER.isExperimental());
+    assertFalse(LspMethod.TYPE_DEFINITION.isExperimental());
+    assertTrue(LspMethod.DEFINITION.isExperimental());
+    assertTrue(LspMethod.HOVER.isExperimental());
+    assertTrue(LspMethod.DOCUMENT_HIGHLIGHT.isExperimental());
+
+    assertFalse(LspMethod.Companion.getExperimentalFeatures().contains(LspMethod.DIAGNOSTIC_SERVER));
+  }
 }


### PR DESCRIPTION
This removes getting diagnostics server port from the experimental LSP settings checkbox, so that even if a user has turned off experimental LSP features, diagnostics server port will still be retrieved via LSP. There is a very small number of users turning off experimental LSP (about 0.2%) and I think we should move features out of experimental mode with the setting at that level. (We can re-evaluate if many users start turning off experimental LSP on a future release).

Diagnostics port with LSP was added to the plugin in v506.

To test diagnostics port, follow the instructions from https://github.com/flutter/dart-intellij-third-party/pull/493. Check that this also works for dart SDK <= 3.12.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
