### PR TITLE
Type/Call hierarchy LSP Migration (#403)

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 - Populate Dart Analysis tool window errors and warnings using Language Server Protocol (LSP) publishDiagnostics notifications (#520)
 - Go to Type Declaration implemented with JetBrains LSP (#615)
-- Navigate to Type and Call Hierarchy implemented with Jetbrains LSP (#403)
+- Type and Call Hierarchy navigation implemented with JetBrains LSP (#403)
 
 ### Changed
 

--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Populate Dart Analysis tool window errors and warnings using Language Server Protocol (LSP) publishDiagnostics notifications (#520)
 - Go to Type Declaration implemented with JetBrains LSP (#615)
+- Navigate to Type and Call Hierarchy implemented with Jetbrains LSP (#403)
 
 ### Changed
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -183,8 +183,6 @@ public final class DartAnalysisServerService implements Disposable {
   private static final String MIN_WORKSPACE_APPLY_EDITS_SDK_VERSION = "3.8";
   public static final String MIN_LSP_NAVIGATION_SDK_VERSION = "3.14.0-65.0.dev";
   public static final String MIN_LSP_PUBLISH_DIAGNOSTICS_SDK_VERSION = "3.14.0-137.0.dev";
-  public static final String MIN_LSP_TYPE_HIERARCHY_SDK_VERSION = "3.3.0";
-  public static final String MIN_LSP_CALL_HIERARCHY_SDK_VERSION = "3.3.0";
 
   private static final long UPDATE_FILES_TIMEOUT = 300;
 
@@ -611,14 +609,6 @@ public final class DartAnalysisServerService implements Disposable {
     }
     final DartSdk sdk = DartSdk.getDartSdk(project);
     return sdk != null && isDartSdkVersionSufficientForLspPublishDiagnostics(sdk.getVersion());
-  }
-
-  public static boolean isLspTypeHierarchyEnabled(@NotNull Project project) {
-      return DartConfigurable.isExperimentalLspFeaturesEnabled(project);
-  }
-
-  public static boolean isLspCallHierarchyEnabled(@NotNull Project project) {
-      return DartConfigurable.isExperimentalLspFeaturesEnabled(project);
   }
 
   public boolean shouldUseCompletion2() {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -613,28 +613,12 @@ public final class DartAnalysisServerService implements Disposable {
     return sdk != null && isDartSdkVersionSufficientForLspPublishDiagnostics(sdk.getVersion());
   }
 
-  public static boolean isDartSdkVersionSufficientForLspTypeHierarchy(@NotNull String sdkVersion) {
-      return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_TYPE_HIERARCHY_SDK_VERSION) >= 0;
-  }
-
   public static boolean isLspTypeHierarchyEnabled(@NotNull Project project) {
-      if (!DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
-        return false;
-      }
-      final DartSdk sdk = DartSdk.getDartSdk(project);
-      return sdk != null && isDartSdkVersionSufficientForLspTypeHierarchy(sdk.getVersion());
-  }
-
-  public static boolean isDartSdkVersionSufficientForLspCallHierarchy(@NotNull String sdkVersion) {
-      return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_CALL_HIERARCHY_SDK_VERSION) >= 0;
+      return DartConfigurable.isExperimentalLspFeaturesEnabled(project);
   }
 
   public static boolean isLspCallHierarchyEnabled(@NotNull Project project) {
-      if (!DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
-          return false;
-      }
-      final DartSdk sdk = DartSdk.getDartSdk(project);
-      return sdk != null && isDartSdkVersionSufficientForLspCallHierarchy(sdk.getVersion());
+      return DartConfigurable.isExperimentalLspFeaturesEnabled(project);
   }
 
   public boolean shouldUseCompletion2() {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -183,6 +183,8 @@ public final class DartAnalysisServerService implements Disposable {
   private static final String MIN_WORKSPACE_APPLY_EDITS_SDK_VERSION = "3.8";
   public static final String MIN_LSP_NAVIGATION_SDK_VERSION = "3.14.0-65.0.dev";
   public static final String MIN_LSP_PUBLISH_DIAGNOSTICS_SDK_VERSION = "3.14.0-137.0.dev";
+  public static final String MIN_LSP_TYPE_HIERARCHY_SDK_VERSION = "3.3.0";
+  public static final String MIN_LSP_CALL_HIERARCHY_SDK_VERSION = "3.3.0";
 
   private static final long UPDATE_FILES_TIMEOUT = 300;
 
@@ -609,6 +611,30 @@ public final class DartAnalysisServerService implements Disposable {
     }
     final DartSdk sdk = DartSdk.getDartSdk(project);
     return sdk != null && isDartSdkVersionSufficientForLspPublishDiagnostics(sdk.getVersion());
+  }
+
+  public static boolean isDartSdkVersionSufficientForLspTypeHierarchy(@NotNull String sdkVersion) {
+      return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_TYPE_HIERARCHY_SDK_VERSION) >= 0;
+  }
+
+  public static boolean isLspTypeHierarchyEnabled(@NotNull Project project) {
+      if (!DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
+        return false;
+      }
+      final DartSdk sdk = DartSdk.getDartSdk(project);
+      return sdk != null && isDartSdkVersionSufficientForLspTypeHierarchy(sdk.getVersion());
+  }
+
+  public static boolean isDartSdkVersionSufficientForLspCallHierarchy(@NotNull String sdkVersion) {
+      return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_CALL_HIERARCHY_SDK_VERSION) >= 0;
+  }
+
+  public static boolean isLspCallHierarchyEnabled(@NotNull Project project) {
+      if (!DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
+          return false;
+      }
+      final DartSdk sdk = DartSdk.getDartSdk(project);
+      return sdk != null && isDartSdkVersionSufficientForLspCallHierarchy(sdk.getVersion());
   }
 
   public boolean shouldUseCompletion2() {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyProvider.java
@@ -12,6 +12,7 @@ import com.intellij.platform.dartlsp.impl.features.hierarchy.call.LspCallHierarc
 import com.intellij.psi.PsiElement;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.hierarchy.DartHierarchyUtil;
+import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,7 +34,7 @@ public final class DartCallHierarchyProvider implements HierarchyProvider {
   @Override
   public @Nullable PsiElement getTarget(@NotNull DataContext dataContext) {
     final Project project = CommonDataKeys.PROJECT.getData(dataContext);
-    if (project != null && DartAnalysisServerService.isLspCallHierarchyEnabled(project)) {
+    if (project != null && DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
       return myLspProvider.getTarget(dataContext);
     }
     return DartHierarchyUtil.getResolvedElementAtCursor(dataContext);
@@ -41,7 +42,7 @@ public final class DartCallHierarchyProvider implements HierarchyProvider {
 
   @Override
   public @NotNull HierarchyBrowser createHierarchyBrowser(@NotNull PsiElement target) {
-    if (DartAnalysisServerService.isLspCallHierarchyEnabled(target.getProject())) {
+    if (DartConfigurable.isExperimentalLspFeaturesEnabled(target.getProject())) {
       return myLspProvider.createHierarchyBrowser(target);
     }
     return new DartCallHierarchyBrowser(target.getProject(), target);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyProvider.java
@@ -15,6 +15,18 @@ import com.jetbrains.lang.dart.ide.hierarchy.DartHierarchyUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Call hierarchy provider for Dart.
+ *
+ * <p>While LSP features are experimental, this class acts as a proxy: delegating to
+ * {@link LspCallHierarchyProvider} when LSP is enabled, and falling back to legacy DAS
+ * when disabled or on unsupported SDK versions.
+ *
+ * <p>TODO(lsp): When LSP is enabled by default and legacy DAS hierarchy is retired,
+ * remove the &lt;callHierarchyProvider language="Dart"&gt; registration from plugin.xml
+ * and delete this class so the platform's LspCallHierarchyProvider handles Dart directly.
+ */
+
 public final class DartCallHierarchyProvider implements HierarchyProvider {
   private final HierarchyProvider myLspProvider = new LspCallHierarchyProvider();
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/call/DartCallHierarchyProvider.java
@@ -4,25 +4,43 @@ package com.jetbrains.lang.dart.ide.hierarchy.call;
 import com.intellij.ide.hierarchy.CallHierarchyBrowserBase;
 import com.intellij.ide.hierarchy.HierarchyBrowser;
 import com.intellij.ide.hierarchy.HierarchyProvider;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.platform.dartlsp.impl.features.hierarchy.call.LspCallHierarchyBrowser;
+import com.intellij.platform.dartlsp.impl.features.hierarchy.call.LspCallHierarchyProvider;
 import com.intellij.psi.PsiElement;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.hierarchy.DartHierarchyUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class DartCallHierarchyProvider implements HierarchyProvider {
+  private final HierarchyProvider myLspProvider = new LspCallHierarchyProvider();
+
   @Override
   public @Nullable PsiElement getTarget(@NotNull DataContext dataContext) {
+    final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+    if (project != null && DartAnalysisServerService.isLspCallHierarchyEnabled(project)) {
+      return myLspProvider.getTarget(dataContext);
+    }
     return DartHierarchyUtil.getResolvedElementAtCursor(dataContext);
   }
 
   @Override
   public @NotNull HierarchyBrowser createHierarchyBrowser(@NotNull PsiElement target) {
+    if (DartAnalysisServerService.isLspCallHierarchyEnabled(target.getProject())) {
+      return myLspProvider.createHierarchyBrowser(target);
+    }
     return new DartCallHierarchyBrowser(target.getProject(), target);
   }
 
   @Override
   public void browserActivated(@NotNull HierarchyBrowser hierarchyBrowser) {
+    if (hierarchyBrowser instanceof LspCallHierarchyBrowser) {
+      myLspProvider.browserActivated(hierarchyBrowser);
+      return;
+    }
     ((DartCallHierarchyBrowser)hierarchyBrowser).changeView(CallHierarchyBrowserBase.getCallerType());
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
@@ -20,6 +20,17 @@ import com.jetbrains.lang.dart.psi.DartReference;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Type hierarchy provider for Dart.
+ *
+ * <p>While LSP features are experimental, this class acts as a proxy: delegating to
+ * {@link LspTypeHierarchyProvider} when LSP is enabled, and falling back to legacy DAS
+ * when disabled or on unsupported SDK versions.
+ *
+ * <p>TODO(lsp): When LSP is enabled by default and legacy DAS hierarchy is retired,
+ * remove the &lt;typeHierarchyProvider language="Dart"&gt; registration from plugin.xml
+ * and delete this class so the platform's LspTypeHierarchyProvider handles Dart directly.
+ */
 public final class DartTypeHierarchyProvider implements HierarchyProvider {
   private final HierarchyProvider myLspProvider = new LspTypeHierarchyProvider();
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
@@ -17,6 +17,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartReference;
+import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,7 +38,7 @@ public final class DartTypeHierarchyProvider implements HierarchyProvider {
   @Override
   public @Nullable PsiElement getTarget(final @NotNull DataContext dataContext) {
     final Project project = CommonDataKeys.PROJECT.getData(dataContext);
-    if (project != null && DartAnalysisServerService.isLspTypeHierarchyEnabled(project)) {
+    if (project != null && DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
       return myLspProvider.getTarget(dataContext);
     }
     final Editor editor = CommonDataKeys.EDITOR.getData(dataContext);
@@ -54,7 +55,7 @@ public final class DartTypeHierarchyProvider implements HierarchyProvider {
 
   @Override
   public @NotNull HierarchyBrowser createHierarchyBrowser(@NotNull PsiElement target) {
-      if (DartAnalysisServerService.isLspTypeHierarchyEnabled(target.getProject())) {
+      if (DartConfigurable.isExperimentalLspFeaturesEnabled(target.getProject())) {
           return myLspProvider.createHierarchyBrowser(target);
       }
       final DartClass dartClass = target instanceof DartClass ? (DartClass) target : PsiTreeUtil.getParentOfType(target, DartClass.class);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
@@ -8,19 +8,27 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
+import com.intellij.platform.dartlsp.impl.features.hierarchy.type.LspTypeHierarchyBrowser;
+import com.intellij.platform.dartlsp.impl.features.hierarchy.type.LspTypeHierarchyProvider;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.psi.DartClass;
 import com.jetbrains.lang.dart.psi.DartReference;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class DartTypeHierarchyProvider implements HierarchyProvider {
+  private final HierarchyProvider myLspProvider = new LspTypeHierarchyProvider();
+
   @Override
-  public @Nullable DartClass getTarget(final @NotNull DataContext dataContext) {
+  public @Nullable PsiElement getTarget(final @NotNull DataContext dataContext) {
     final Project project = CommonDataKeys.PROJECT.getData(dataContext);
+    if (project != null && DartAnalysisServerService.isLspTypeHierarchyEnabled(project)) {
+      return myLspProvider.getTarget(dataContext);
+    }
     final Editor editor = CommonDataKeys.EDITOR.getData(dataContext);
     if (project == null || editor == null) return null;
 
@@ -35,11 +43,18 @@ public final class DartTypeHierarchyProvider implements HierarchyProvider {
 
   @Override
   public @NotNull HierarchyBrowser createHierarchyBrowser(@NotNull PsiElement target) {
+    if (DartAnalysisServerService.isLspTypeHierarchyEnabled(target.getProject())) {
+      return myLspProvider.createHierarchyBrowser(target);
+    }
     return new DartTypeHierarchyBrowser(target.getProject(), (DartClass)target);
   }
 
   @Override
   public void browserActivated(final @NotNull HierarchyBrowser hierarchyBrowser) {
+    if (hierarchyBrowser instanceof LspTypeHierarchyBrowser) {
+      myLspProvider.browserActivated(hierarchyBrowser);
+      return;
+    }
     ((DartTypeHierarchyBrowser)hierarchyBrowser).changeView(TypeHierarchyBrowserBase.getTypeHierarchyType());
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/hierarchy/type/DartTypeHierarchyProvider.java
@@ -43,10 +43,14 @@ public final class DartTypeHierarchyProvider implements HierarchyProvider {
 
   @Override
   public @NotNull HierarchyBrowser createHierarchyBrowser(@NotNull PsiElement target) {
-    if (DartAnalysisServerService.isLspTypeHierarchyEnabled(target.getProject())) {
-      return myLspProvider.createHierarchyBrowser(target);
-    }
-    return new DartTypeHierarchyBrowser(target.getProject(), (DartClass)target);
+      if (DartAnalysisServerService.isLspTypeHierarchyEnabled(target.getProject())) {
+          return myLspProvider.createHierarchyBrowser(target);
+      }
+      final DartClass dartClass = target instanceof DartClass ? (DartClass) target : PsiTreeUtil.getParentOfType(target, DartClass.class);
+      if (dartClass == null) {
+          throw new IllegalArgumentException("Target element must be a DartClass or inside one");
+      }
+      return new DartTypeHierarchyBrowser(target.getProject(), dartClass);
   }
 
   @Override

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -17,6 +17,12 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import com.jetbrains.lang.dart.logging.PluginLogger
 import org.dartlang.analysis.server.protocol.AnalysisError
 import org.dartlang.analysis.server.protocol.DiagnosticMessage
+import org.eclipse.lsp4j.CallHierarchyIncomingCall
+import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams
+import org.eclipse.lsp4j.CallHierarchyItem
+import org.eclipse.lsp4j.CallHierarchyOutgoingCall
+import org.eclipse.lsp4j.CallHierarchyOutgoingCallsParams
+import org.eclipse.lsp4j.CallHierarchyPrepareParams
 import org.eclipse.lsp4j.DefinitionParams
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DiagnosticSeverity
@@ -45,6 +51,10 @@ import org.eclipse.lsp4j.services.LanguageClientAware
 import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
 import org.eclipse.lsp4j.TypeDefinitionParams
+import org.eclipse.lsp4j.TypeHierarchyItem
+import org.eclipse.lsp4j.TypeHierarchyPrepareParams
+import org.eclipse.lsp4j.TypeHierarchySubtypesParams
+import org.eclipse.lsp4j.TypeHierarchySupertypesParams
 import java.lang.reflect.Type
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -230,6 +240,8 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
             setDefinitionProvider(true)
             setTypeDefinitionProvider(true)
             setDocumentHighlightProvider(true)
+            setTypeHierarchyProvider(true)
+            setCallHierarchyProvider(true)
             // Add other capabilities as we support them.
         }
         return CompletableFuture.completedFuture(InitializeResult(capabilities))
@@ -306,6 +318,41 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
     override fun didChangeWatchedFiles(params: DidChangeWatchedFilesParams) {
         // Ignored. File watching is handled by the legacy plugin.
     }
+
+    // --- Type Hierarchy ---
+
+    override fun prepareTypeHierarchy(params: TypeHierarchyPrepareParams): CompletableFuture<List<TypeHierarchyItem>> {
+        val type = object : TypeToken<List<TypeHierarchyItem>>() {}.type
+        return forwardRequest("textDocument/prepareTypeHierarchy", params, type)
+    }
+
+    override fun typeHierarchySupertypes(params: TypeHierarchySupertypesParams): CompletableFuture<List<TypeHierarchyItem>> {
+        val type = object : TypeToken<List<TypeHierarchyItem>>() {}.type
+        return forwardRequest("typeHierarchy/supertypes", params, type)
+    }
+
+    override fun typeHierarchySubtypes(params: TypeHierarchySubtypesParams): CompletableFuture<List<TypeHierarchyItem>> {
+        val type = object : TypeToken<List<TypeHierarchyItem>>() {}.type
+        return forwardRequest("typeHierarchy/subtypes", params, type)
+    }
+
+    // --- Call Hierarchy ---
+
+    override fun prepareCallHierarchy(params: CallHierarchyPrepareParams): CompletableFuture<List<CallHierarchyItem>> {
+        val type = object : TypeToken<List<CallHierarchyItem>>() {}.type
+        return forwardRequest("textDocument/prepareCallHierarchy", params, type)
+    }
+
+    override fun callHierarchyIncomingCalls(params: CallHierarchyIncomingCallsParams): CompletableFuture<List<CallHierarchyIncomingCall>> {
+        val type = object : TypeToken<List<CallHierarchyIncomingCall>>() {}.type
+        return forwardRequest("callHierarchy/incomingCalls", params, type)
+    }
+
+    override fun callHierarchyOutgoingCalls(params: CallHierarchyOutgoingCallsParams): CompletableFuture<List<CallHierarchyOutgoingCall>> {
+        val type = object : TypeToken<List<CallHierarchyOutgoingCall>>() {}.type
+        return forwardRequest("callHierarchy/outgoingCalls", params, type)
+    }
+
 
     // --- Helper Methods for Forwarding ---
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -13,7 +13,9 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.platform.dartlsp.api.Lsp4jServer
 import com.intellij.platform.dartlsp.api.LspCommunicationChannel
 import com.intellij.platform.dartlsp.api.ProjectWideLspServerDescriptor
+import com.intellij.platform.dartlsp.api.customization.LspCallHierarchyCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspCallHierarchyDisabled
+import com.intellij.platform.dartlsp.api.customization.LspCallHierarchySupport
 import com.intellij.platform.dartlsp.api.customization.LspCodeActionsDisabled
 import com.intellij.platform.dartlsp.api.customization.LspCodeLensDisabled
 import com.intellij.platform.dartlsp.api.customization.LspCommandsDisabled
@@ -42,7 +44,9 @@ import com.intellij.platform.dartlsp.api.customization.LspRenameDisabled
 import com.intellij.platform.dartlsp.api.customization.LspSelectionRangeDisabled
 import com.intellij.platform.dartlsp.api.customization.LspSemanticTokensDisabled
 import com.intellij.platform.dartlsp.api.customization.LspSignatureHelpDisabled
+import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchyCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchyDisabled
+import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchySupport
 import com.intellij.platform.dartlsp.api.customization.LspWorkspaceSymbolDisabled
 import com.intellij.psi.PsiFile
 import com.intellij.util.io.URLUtil
@@ -140,8 +144,19 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
         override val signatureHelpCustomizer = LspSignatureHelpDisabled
         override val documentSymbolCustomizer = LspDocumentSymbolDisabled
         override val workspaceSymbolCustomizer = LspWorkspaceSymbolDisabled
-        override val callHierarchyCustomizer = LspCallHierarchyDisabled
-        override val typeHierarchyCustomizer = LspTypeHierarchyDisabled
+        override val callHierarchyCustomizer: LspCallHierarchyCustomizer
+            get() = if (DartAnalysisServerService.isLspCallHierarchyEnabled(project)) {
+                LspCallHierarchySupport()
+            } else {
+                LspCallHierarchyDisabled
+            }
+        override val typeHierarchyCustomizer: LspTypeHierarchyCustomizer
+            get() = if (DartAnalysisServerService.isLspTypeHierarchyEnabled(project)) {
+                LspTypeHierarchySupport()
+            } else {
+                LspTypeHierarchyDisabled
+            }
+
         override val selectionRangeCustomizer = LspSelectionRangeDisabled
         override val codeLensCustomizer = LspCodeLensDisabled
         override val renameCustomizer = LspRenameDisabled

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -145,13 +145,13 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
         override val documentSymbolCustomizer = LspDocumentSymbolDisabled
         override val workspaceSymbolCustomizer = LspWorkspaceSymbolDisabled
         override val callHierarchyCustomizer: LspCallHierarchyCustomizer
-            get() = if (DartAnalysisServerService.isLspCallHierarchyEnabled(project)) {
+            get() = if (DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
                 LspCallHierarchySupport()
             } else {
                 LspCallHierarchyDisabled
             }
         override val typeHierarchyCustomizer: LspTypeHierarchyCustomizer
-            get() = if (DartAnalysisServerService.isLspTypeHierarchyEnabled(project)) {
+            get() = if (DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
                 LspTypeHierarchySupport()
             } else {
                 LspTypeHierarchyDisabled

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -19,6 +19,10 @@ import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
 import org.dartlang.analysis.server.protocol.DartLspApplyWorkspaceEditParams
 import org.dartlang.analysis.server.protocol.MessageAction
+import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams
+import org.eclipse.lsp4j.CallHierarchyItem
+import org.eclipse.lsp4j.CallHierarchyOutgoingCallsParams
+import org.eclipse.lsp4j.CallHierarchyPrepareParams
 import org.eclipse.lsp4j.DocumentHighlightKind
 import org.eclipse.lsp4j.DocumentHighlightParams
 import org.eclipse.lsp4j.HoverParams
@@ -26,9 +30,15 @@ import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.ShowMessageRequestParams
+import org.eclipse.lsp4j.SymbolKind
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TypeDefinitionParams
+import org.eclipse.lsp4j.TypeHierarchyItem
+import org.eclipse.lsp4j.TypeHierarchyPrepareParams
+import org.eclipse.lsp4j.TypeHierarchySubtypesParams
+import org.eclipse.lsp4j.TypeHierarchySupertypesParams
 import org.eclipse.lsp4j.services.LanguageClient
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
@@ -397,6 +407,339 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertTrue(result.isRight)
         assertEquals(1, result.right.size)
         assertEquals("file://target.dart", result.right[0].targetUri)
+    }
+
+    // --- Hierarchy ---
+
+    fun testIsDartSdkVersionSufficientForLspTypeHierarchy() {
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.3.0"))
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.4.0"))
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.14.0-65.0.dev"))
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("4.0.0"))
+
+        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.2.0"))
+        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.0.0"))
+        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("2.19.0"))
+    }
+
+    fun testIsDartSdkVersionSufficientForLspCallHierarchy() {
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.3.0"))
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.4.0"))
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.14.0-65.0.dev"))
+        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("4.0.0"))
+
+        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.2.0"))
+        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.0.0"))
+        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("2.19.0"))
+    }
+
+    fun testPrepareTypeHierarchyRequest() {
+        val params = TypeHierarchyPrepareParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(1, 2)
+        }
+
+        val future = bridgeServer.prepareTypeHierarchy(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("textDocument/prepareTypeHierarchy", lspMessage.get("method").asString)
+
+        val responseJson = """
+                {
+                  "id": "123",
+                  "result": {
+                    "lspResponse": {
+                      "jsonrpc": "2.0",
+                      "id": "123",
+                      "result": [
+                        {
+                          "name": "Dog",
+                          "kind": 5,
+                          "uri": "file://test.dart",
+                          "range": {"start": {"line": 1, "character": 0}, "end": {"line": 5, "character": 1}},
+                          "selectionRange": {"start": {"line": 1, "character": 6}, "end": {"line": 1, "character": 9}}
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("Dog", result[0].name)
+        assertEquals(SymbolKind.Class, result[0].kind)
+        assertEquals("file://test.dart", result[0].uri)
+    }
+
+    fun testTypeHierarchySupertypesRequest() {
+        val item = TypeHierarchyItem(
+            "Dog",
+            SymbolKind.Class,
+            "file://test.dart",
+            Range(Position(1, 0), Position(5, 1)),
+            Range(Position(1, 6), Position(1, 9))
+        )
+        val params = TypeHierarchySupertypesParams().apply {
+            this.item = item
+        }
+
+        val future = bridgeServer.typeHierarchySupertypes(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("typeHierarchy/supertypes", lspMessage.get("method").asString)
+
+        val responseJson = """
+                {
+                  "id": "123",
+                  "result": {
+                    "lspResponse": {
+                      "jsonrpc": "2.0",
+                      "id": "123",
+                      "result": [
+                        {
+                          "name": "Animal",
+                          "kind": 5,
+                          "uri": "file://test.dart",
+                          "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 24}},
+                          "selectionRange": {"start": {"line": 0, "character": 15}, "end": {"line": 0, "character": 21}}
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("Animal", result[0].name)
+    }
+
+    fun testTypeHierarchySubtypesRequest() {
+        val item = TypeHierarchyItem(
+            "Dog",
+            SymbolKind.Class,
+            "file://test.dart",
+            Range(Position(1, 0), Position(5, 1)),
+            Range(Position(1, 6), Position(1, 9))
+        )
+        val params = TypeHierarchySubtypesParams().apply {
+            this.item = item
+        }
+
+        val future = bridgeServer.typeHierarchySubtypes(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("typeHierarchy/subtypes", lspMessage.get("method").asString)
+
+        val responseJson = """
+                {
+                  "id": "123",
+                  "result": {
+                    "lspResponse": {
+                      "jsonrpc": "2.0",
+                      "id": "123",
+                      "result": [
+                        {
+                          "name": "Labrador",
+                          "kind": 5,
+                          "uri": "file://test.dart",
+                          "range": {"start": {"line": 7, "character": 0}, "end": {"line": 7, "character": 27}},
+                          "selectionRange": {"start": {"line": 7, "character": 6}, "end": {"line": 7, "character": 14}}
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("Labrador", result[0].name)
+    }
+
+    fun testPrepareCallHierarchyRequest() {
+        val params = CallHierarchyPrepareParams().apply {
+            textDocument = TextDocumentIdentifier("file://test.dart")
+            position = Position(1, 2)
+        }
+
+        val future = bridgeServer.prepareCallHierarchy(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("textDocument/prepareCallHierarchy", lspMessage.get("method").asString)
+
+        val responseJson = """
+                {
+                  "id": "123",
+                  "result": {
+                    "lspResponse": {
+                      "jsonrpc": "2.0",
+                      "id": "123",
+                      "result": [
+                        {
+                          "name": "bark",
+                          "kind": 6,
+                          "uri": "file://test.dart",
+                          "range": {"start": {"line": 2, "character": 2}, "end": {"line": 4, "character": 3}},
+                          "selectionRange": {"start": {"line": 2, "character": 7}, "end": {"line": 2, "character": 11}}
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("bark", result[0].name)
+        assertEquals(SymbolKind.Method, result[0].kind)
+    }
+
+    fun testCallHierarchyIncomingCallsRequest() {
+        val item = CallHierarchyItem().apply {
+            name = "bark"
+            kind = SymbolKind.Method
+            uri = "file://test.dart"
+            range = Range(Position(2, 2), Position(4, 3))
+            selectionRange = Range(Position(2, 7), Position(2, 11))
+        }
+        val params = CallHierarchyIncomingCallsParams().apply {
+            this.item = item
+        }
+
+        val future = bridgeServer.callHierarchyIncomingCalls(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("callHierarchy/incomingCalls", lspMessage.get("method").asString)
+
+        val responseJson = """
+                {
+                  "id": "123",
+                  "result": {
+                    "lspResponse": {
+                      "jsonrpc": "2.0",
+                      "id": "123",
+                      "result": [
+                        {
+                          "from": {
+                            "name": "speak",
+                            "kind": 6,
+                            "uri": "file://test.dart",
+                            "range": {"start": {"line": 0, "character": 2}, "end": {"line": 1, "character": 3}},
+                            "selectionRange": {"start": {"line": 0, "character": 7}, "end": {"line": 0, "character": 12}}
+                          },
+                          "fromRanges": [
+                            {"start": {"line": 1, "character": 4}, "end": {"line": 1, "character": 10}}
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("speak", result[0].from.name)
+        assertEquals(1, result[0].fromRanges.size)
+    }
+
+    fun testCallHierarchyOutgoingCallsRequest() {
+        val item = CallHierarchyItem().apply {
+            name = "bark"
+            kind = SymbolKind.Method
+            uri = "file://test.dart"
+            range = Range(Position(2, 2), Position(4, 3))
+            selectionRange = Range(Position(2, 7), Position(2, 11))
+        }
+        val params = CallHierarchyOutgoingCallsParams().apply {
+            this.item = item
+        }
+
+        val future = bridgeServer.callHierarchyOutgoingCalls(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("callHierarchy/outgoingCalls", lspMessage.get("method").asString)
+
+        val responseJson = """
+                {
+                  "id": "123",
+                  "result": {
+                    "lspResponse": {
+                      "jsonrpc": "2.0",
+                      "id": "123",
+                      "result": [
+                        {
+                          "to": {
+                            "name": "print",
+                            "kind": 12,
+                            "uri": "file://core.dart",
+                            "range": {"start": {"line": 10, "character": 0}, "end": {"line": 12, "character": 1}},
+                            "selectionRange": {"start": {"line": 10, "character": 5}, "end": {"line": 10, "character": 10}}
+                          },
+                          "fromRanges": [
+                            {"start": {"line": 3, "character": 4}, "end": {"line": 3, "character": 17}}
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        assertEquals("print", result[0].to.name)
+        assertEquals(1, result[0].fromRanges.size)
     }
 
     private class MockLanguageClient : LanguageClient {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -411,28 +411,6 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
 
     // --- Hierarchy ---
 
-    fun testIsDartSdkVersionSufficientForLspTypeHierarchy() {
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.3.0"))
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.4.0"))
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.14.0-65.0.dev"))
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("4.0.0"))
-
-        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.2.0"))
-        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("3.0.0"))
-        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspTypeHierarchy("2.19.0"))
-    }
-
-    fun testIsDartSdkVersionSufficientForLspCallHierarchy() {
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.3.0"))
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.4.0"))
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.14.0-65.0.dev"))
-        assertTrue(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("4.0.0"))
-
-        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.2.0"))
-        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("3.0.0"))
-        assertFalse(DartAnalysisServerService.isDartSdkVersionSufficientForLspCallHierarchy("2.19.0"))
-    }
-
     fun testPrepareTypeHierarchyRequest() {
         val params = TypeHierarchyPrepareParams().apply {
             textDocument = TextDocumentIdentifier("file://test.dart")


### PR DESCRIPTION
## Summary

Migrates Type Hierarchy (Ctrl+H / Cmd+H) and Call Hierarchy (Ctrl+Alt+H / Cmd+Alt+H) from legacy DAS requests to the JetBrains LSP platform using the `DartBridgeLspServer`.

## Key Changes

1. Provider Delegation & Migration Architecture:
      • Updated DartTypeHierarchyProvider and DartCallHierarchyProvider to delegate getTarget, createHierarchyBrowser, and browserActivated to the platform's LspTypeHierarchyProvider and
      LspCallHierarchyProvider when experimental LSP features are enabled (DartConfigurable.isExperimentalLspFeaturesEnabled(project)).
      • Preserved seamless fallback to the legacy DAS hierarchy implementation when experimental LSP is disabled.
      • Added TODO(lsp) comments documenting the delegation rationale and the future retirement of the language="Dart" XML registrations once LSP becomes the default.
  2. Customizers & Capabilities:
      • Enabled LspTypeHierarchySupport and LspCallHierarchySupport customizers dynamically in DartLspServerDescriptor when experimental LSP is active.
      • Advertised typeHierarchyProvider and callHierarchyProvider capabilities during initialize() in DartBridgeLspServer.
  3. LSP Protocol Endpoints:
      • Implemented and forwarded the 6 standard LSP hierarchy methods in DartBridgeLspServer:
	  • textDocument/prepareTypeHierarchy
	  • typeHierarchy/supertypes
	  • typeHierarchy/subtypes
	  • textDocument/prepareCallHierarchy
	  • callHierarchy/incomingCalls
	  • callHierarchy/outgoingCalls

  4. Method Hierarchy:
      • Retained DartMethodHierarchyProvider on legacy DAS as standard LSP 3.17 does not define a method hierarchy protocol.

## Screenshots
<details>
<summary>Click to see screenshots</summary>
Type Hierarchy (Ctrl + H) 
<img width="2226" height="1117" alt="0q45nmd76tkro" src="https://github.com/user-attachments/assets/712c56dd-f596-48a9-8e87-9250a3da3960" />
<br>
Call Hierarchy (Ctrl + Alt + H)
<img width="2226" height="1117" alt="1201hpv9e0tfo" src="https://github.com/user-attachments/assets/1ede3791-67e7-4664-9ffc-5a00320431ec" />
</details>

## Verification & Testing

### Automated Tests:

• Ran the LSP test suite (`./gradlew test --tests "com.jetbrains.lang.dart.lsp.*"`): 17/17 passed (100%).
• Added unit tests in `DartBridgeLspServerTest.kt`:
    • `testPrepareTypeHierarchyRequest`
    • `testTypeHierarchySupertypesRequest`
    • `testTypeHierarchySubtypesRequest`
    • `testPrepareCallHierarchyRequest`
    • `testCallHierarchyIncomingCallsRequest`
    • `testCallHierarchyOutgoingCallsRequest`


### Manual Verification:

• Verified live in sandbox IDE (`./gradlew runIde`):
    • Type Hierarchy: Navigated on class declarations; verified supertypes, subtypes, and lazy node expansion via LSP.
    • Call Hierarchy: Navigated on function/method declarations; verified caller (incoming) and callee (outgoing) hierarchy trees.
    • Fallback: Toggled experimental LSP off / switched SDK versions to verify seamless fallback to legacy DAS handlers.

Fixes #403


Review the contribution guidelines below:

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] I've included the required information in the description above.
- [X] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
