### PR TITLE
+ root-cause-regression skill

### DIFF
--- a/.agents/skills/root-cause-regression/SKILL.md
+++ b/.agents/skills/root-cause-regression/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: root-cause-regression
+description: >-
+  Investigates a GitHub issue reporting a regression, analyzes recent commits, and identifies possible root cause culprits. Use this when the user asks to find the cause of a regression or bug from an issue.
+---
+
+# Root Cause Regression Analysis
+
+This skill guides you through investigating a GitHub issue to find the likely commit that caused a regression.
+
+## Steps
+
+1.  **Read the Issue**:
+    *   **Primary**: Use the `github` MCP server (`issue_read` or equivalent) to fetch the details of the issue.
+    *   **Fallback**: If the `github` MCP server is not available, try using the `gh` CLI (e.g., `gh issue view <number>`) or ask the user to paste the issue description into the chat.
+    *   Understand the symptoms of the regression and when it started happening.
+2.  **Identify the Timeframe**: Determine the approximate timeframe when the regression was introduced based on the issue description, comments, and reported version. If the timeframe isn't clear, ask the user or look at the repository's recent releases.
+3.  **Fetch Recent Commits**: Use `search_commits` or `list_commits` from the `github` MCP server. If unavailable, fall back to local git commands (e.g., `git log --since="<date>" --until="<date>"`), to fetch commits within the suspected timeframe.
+4.  **Analyze Commits**: Review the commit messages, changed files, and diffs for the suspected commits.
+    *   Look for changes related to the systems, files, or components mentioned in the regression issue.
+    *   Use `get_commit` (MCP) or `git show` (local) to view the details of specific commits.
+5.  **Synthesize Findings**: Compile a list of the top suspect commits. For each suspect, explain *why* it is a potential culprit based on the code changes and how they relate to the regression symptoms.
+6.  **Report Findings**: Generate a clean, well-formatted markdown Artifact containing your analysis. Present the findings clearly so the user can easily review the information and paste it into the GitHub issue UI if they choose to. Do not post the comment directly to GitHub.

--- a/.agents/skills/root-cause-regression/SKILL.md
+++ b/.agents/skills/root-cause-regression/SKILL.md
@@ -15,7 +15,7 @@ This skill guides you through investigating a GitHub issue to find the likely co
     *   **Fallback**: If the `github` MCP server is not available, try using the `gh` CLI (e.g., `gh issue view <number>`) or ask the user to paste the issue description into the chat.
     *   Understand the symptoms of the regression and when it started happening.
 2.  **Identify the Timeframe**: Determine the approximate timeframe when the regression was introduced based on the issue description, comments, and reported version. If the timeframe isn't clear, ask the user or look at the repository's recent releases.
-3.  **Fetch Recent Commits**: Use `search_commits` or `list_commits` from the `github` MCP server. If unavailable, fall back to local git commands (e.g., `git log --since="<date>" --until="<date>"`), to fetch commits within the suspected timeframe.
+3.  **Fetch Recent Commits**: Use `search_commits` or `list_commits` from the `github` MCP server. If unavailable, fall back to local git commands (e.g., `git log --since="<date>" --until="<date>"`) to fetch commits within the suspected timeframe.
 4.  **Analyze Commits**: Review the commit messages, changed files, and diffs for the suspected commits.
     *   Look for changes related to the systems, files, or components mentioned in the regression issue.
     *   Use `get_commit` (MCP) or `git show` (local) to view the details of specific commits.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ These skills are located in the [.agents/skills/](.agents/skills/) directory. Th
 * **[Patch Copied LSP Sources](.agents/skills/patch-copied-lsp-sources/SKILL.md):** Automates copying and patching of JetBrains LSP sources.
 * **[Plugin Issue Triage](.agents/skills/plugin-issue-triage/SKILL.md):** (Experimental) Automates the triage of GitHub issues in the Dart and Flutter IntelliJ plugins.
 * **[Port PR](.agents/skills/port-pr/SKILL.md):** Fetches a Pull Request from either the dart-intellij-third-party or flutter-intellij repository and conceptually ports its changes to the other repository.
+* **[Root Cause Regression](.agents/skills/root-cause-regression/SKILL.md):** Investigates a GitHub issue reporting a regression, analyzes recent commits, and identifies possible culprits.
 
 ### How to use:
 Tell your AI assistant to run the desired skill (e.g. by typing `/code-review` or asking *"Run the code-review skill on my changes"*). The agent will automatically find, load, and follow the instructions in the corresponding `SKILL.md` file.


### PR DESCRIPTION
Adds a root cause regression (finding) skill. 

Fixes #628.

---

# Sample outputs


# Root Cause Analysis: Issue #9090

**Issue**: [Flutter Plugin 95.0.0] "No Flutter SDK configured" in Android Studio Rabbit 1 (2026.2.1 Canary 1)

Based on the git history between version 94.0.0 and 95.0.0, the most highly suspect commit is:
**`cb41add305516c5f45b210d7c0071d05e8fe484a` Sdk cache (#9074)**

### Why this is the culprit:

1. **Direct overlap with symptoms**: The issue specifically describes that the Flutter SDK settings panel combo box fails to load/recognize the Flutter SDK path. Commit `cb41add30` was introduced explicitly to change "how the combo box that contains SDK file locations is refreshed so that the chosen SDK displays correctly after updates."
2. **Asynchronous UI modification**: The commit reordered how `FlutterSdkUtil.addKnownSDKPathsToCombo(mySdkCombo)` is invoked in `resetSdkSelection()`. It now triggers a background thread that later modifies the combo box model and sets the active editor item (`combo.getEditor().setItem(activePath)`) on the EDT. Because this occurs asynchronously *after* `ignoringSdkChanges` is set to `false`, it inadvertently triggers a `DocumentEvent` which calls `onVersionChanged()` unexpectedly, potentially wiping out or invalidating the SDK configuration state.
3. **FlutterSdk.java changes**: The commit also modified `FlutterSdk.getFlutterSdk(project)`, which is the exact method the IDE uses to determine whether to show the "No Flutter SDK configured" banner. It added `FileUtil.toSystemIndependentName(homePath)` and `null` checks to the Dart SDK path resolution, which may be failing to match `DART_SDK_SUFFIX` (`/bin/cache/dart-sdk`) under certain IDE platform conditions in Android Studio 2026.2 Canary 1.

### Secondary Suspect:

- **`c66073335` Remove semaphore and instead use cancelable process (#9058)**: This commit also modified `FlutterSettingsConfigurable` and how the `flutter --version` process is launched to populate the version label. However, it's less likely to cause the global SDK configuration banner to trigger than `cb41add30`.

### Recommendation

I recommend reverting or debugging `cb41add305516c5f45b210d7c0071d05e8fe484a` to fix the combo box initialization and SDK path resolution.

# Root Cause Analysis: Issue #9093

**Issue**: [IDE deadlocks permanently on project open when the Flutter SDK path is invalid](https://github.com/flutter/flutter-intellij/issues/9093)

## Culprit Commit
**Commit**: `e965bb8d9c339811484643aa2e94a54d698464ab` ("Fix IDEA project open hang #8903")
**Author**: Helin Shiah
**Date**: April 16, 2026

## Analysis

The deadlock during project open is directly caused by changes introduced in `e965bb8d9`. 

In this commit, the logic to fix missing Flutter module configurations was migrated from `FlutterProjectOpenProcessor.kt` to `FlutterInitializer.java`. Specifically, it added the following block that runs on every project startup:

```java
if (!FlutterModuleUtils.isFlutterModule(module)) {
  log().info("Fixing Flutter module configuration for " + module.getName());
  FlutterModuleUtils.setFlutterModuleWithoutReload(module, project);
}
```

When a project has an invalid Flutter SDK path, the module fails to be recognized as a Flutter module, triggering this fallback path. 

The deadlock happens because `FlutterModuleUtils.setFlutterModuleWithoutReload` wraps its execution in `invokeLater` (placing it on the Event Dispatch Thread) and synchronously calls `project.save()`:

```java
ApplicationManager.getApplication().invokeLater(() -> {
  ApplicationManager.getApplication().runWriteAction(() -> setFlutterModuleType(module));
  enableDartSDK(module);

  project.save(); // <-- Deadlock trigger on 2026.2+

  EditorNotifications.getInstance(project).updateAllNotifications();
});
```

Starting in IntelliJ 2026.2, calling `project.save()` from the EDT results in a permanent deadlock. The save operation is dispatched to a background worker thread, which then parks the EDT in a nested modal pump. However, the worker thread must call back into the EDT to fire `beforeAllDocumentsSaving` (which requires the EDT to be free). This creates a circular wait where neither thread can progress.

## Recommendation

To resolve this issue, `project.save()` should not be invoked from the EDT. 

*   **Option 1**: Remove the `project.save()` call entirely from `setFlutterModuleWithoutReload` and rely on the IntelliJ platform to persist module configuration changes organically.
*   **Option 2**: If an immediate save is strictly necessary, it must be scheduled off the EDT or handled asynchronously so that it doesn't block the UI thread during project initialization.

*(Note: Removing `project.save()` here aligns with how similar EDT/Semaphore deadlocks were addressed in `#9013` and `#9055`)*

# Root Cause Analysis: Issue #9083 (Missing Run/Debug Gutter Icons)

## Culprit
**Commit:** [`55d8b9f36e925d3100294177831cc523f0648eea`](file:///Users/pquitslund/src/repos/flutter-intellij) (PR #9036: "Remove bazel run and test")

## Mechanics of the Regression

The removal of Bazel run/test support unintentionally broke the run line markers for standard Flutter projects due to two interconnected reasons:

### 1. Missing `main()` Icon
Historically, the plugin had two contributors running simultaneously: `FlutterTestLineMarkerContributor` and `FlutterBazelTestLineMarkerContributor`. 

Years ago (in PR #5459), a duplicate menu entry for `main()` was noticed. To fix this, developers explicitly suppressed the `main()` icon in the standard `FlutterTestLineMarkerContributor` (by adding `if (testConfigUtils instanceof TestConfigUtils) return null;`). They left the Bazel contributor untouched. However, because the Bazel contributor did not verify if the project was actually a Bazel workspace when evaluating `main()`, it unknowingly became the sole provider of the `main()` run icon for **all** Flutter projects.

When PR #9036 deleted `FlutterBazelTestLineMarkerContributor`, the `main()` icon completely disappeared because the standard contributor was still suppressing it.

### 2. Missing Test Icons (Intermittent Timing Issue)
The deleted `main()` block in `TestLineMarkerContributor.java` contained a crucial cache-priming mechanism:

```java
if ("main".equals(dartId.getText())) {
  // There seems to be an intermittent timing issue that causes the first test call to not get marked.
  // Priming the cache here solves it.
  testConfigUtils.refreshOutline(element);
```

Because `main()` is physically higher in the AST (e.g., at the top of `test/widget_test.dart`), the IDE visits it first during its top-down parsing pass. By calling `refreshOutline()`, it ensured the Dart Analysis Server outline was loaded and cached *before* the IDE reached the individual test functions further down the file.

With the `main()` block completely removed in PR #9036, the cache is no longer primed. When the IDE visits the test functions, the outline is often not yet ready. While the contributor does register a listener to restart the `DaemonCodeAnalyzer` when the outline eventually arrives, IntelliJ often optimizes away the second line-marker pass because the document hasn't been modified, leaving the tests permanently unmarked.

## Recommendation
To fix this regression:
1. Re-add the `main()` evaluation block to `TestLineMarkerContributor.java`.
2. Remove the `testConfigUtils instanceof TestConfigUtils` suppression check, allowing the standard `FlutterTestLineMarkerContributor` to provide the `main()` marker directly.
3. Keep the `testConfigUtils.refreshOutline(element);` call to ensure the outline cache is properly primed for subsequent test functions in the file.






---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
