### PR TITLE
Show quick doc with legacy path from completion

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Removed
 
 ### Fixed
+- Quick Documentation from code completion popup window (#632)
 
 ## 508.1.0
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/documentation/DartDocumentationProvider.java
@@ -1,6 +1,9 @@
 // Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 package com.jetbrains.lang.dart.ide.documentation;
 
+import com.intellij.codeInsight.lookup.Lookup;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupManager;
 import com.intellij.lang.documentation.DocumentationProvider;
 import com.intellij.navigation.NavigationItem;
 import com.intellij.openapi.project.Project;
@@ -29,6 +32,12 @@ public final class DartDocumentationProvider implements DocumentationProvider {
 
   @Override
   public @Nls String generateDoc(final @NotNull PsiElement element, final @Nullable PsiElement originalElement) {
+    final Lookup activeLookup = LookupManager.getInstance(element.getProject()).getActiveLookup();
+    final LookupElement item = activeLookup != null ? activeLookup.getCurrentItem() : null;
+    final boolean isFromCompletion = item != null && item.getObject() instanceof DartLookupObject;
+    if (isFromCompletion) {
+      return DartDocUtil.generateDoc(element);
+    }
     return null;
   }
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
@@ -1,6 +1,9 @@
 // Copyright 2000-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 package com.jetbrains.lang.dart.documentation;
 
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.codeInsight.lookup.LookupManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
@@ -9,6 +12,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
+import com.jetbrains.lang.dart.ide.completion.DartLookupObject;
 import com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider;
 import com.jetbrains.lang.dart.psi.DartComponent;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
@@ -100,27 +104,27 @@ public class DartDocumentationProviderTest extends DartCodeInsightFixtureTestCas
     assertNull("Expected null doc without active lookup", myProvider.generateDoc(element, null));
 
     // 2. With an active lookup containing DartLookupObject, generateDoc generates doc
-    com.intellij.codeInsight.lookup.LookupElement lookupElement =
-      com.intellij.codeInsight.lookup.LookupElementBuilder.create(new com.jetbrains.lang.dart.ide.completion.DartLookupObject(getProject(), null, 0), "A");
-    com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).showLookup(myFixture.getEditor(), lookupElement);
+    LookupElement lookupElement =
+      LookupElementBuilder.create(new DartLookupObject(getProject(), null, 0), "A");
+    LookupManager.getInstance(getProject()).showLookup(myFixture.getEditor(), lookupElement);
     try {
       final String doc = myProvider.generateDoc(element, null);
       assertNotNull("Expected non-null doc with active DartLookupObject", doc);
       assertTrue("Expected doc to contain class documentation", doc.contains("Documentation for class A"));
     }
     finally {
-      com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).hideActiveLookup();
+      LookupManager.getInstance(getProject()).hideActiveLookup();
     }
 
     // 3. With an active lookup containing a non-DartLookupObject, generateDoc returns null
-    com.intellij.codeInsight.lookup.LookupElement plainLookupElement =
-      com.intellij.codeInsight.lookup.LookupElementBuilder.create("plain");
-    com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).showLookup(myFixture.getEditor(), plainLookupElement);
+    LookupElement plainLookupElement =
+      LookupElementBuilder.create("plain");
+    LookupManager.getInstance(getProject()).showLookup(myFixture.getEditor(), plainLookupElement);
     try {
       assertNull("Expected null doc with non-DartLookupObject", myProvider.generateDoc(element, null));
     }
     finally {
-      com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).hideActiveLookup();
+      LookupManager.getInstance(getProject()).hideActiveLookup();
     }
   }
 }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/documentation/DartDocumentationProviderTest.java
@@ -11,6 +11,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase;
 import com.jetbrains.lang.dart.ide.documentation.DartDocumentationProvider;
 import com.jetbrains.lang.dart.psi.DartComponent;
+import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.jetbrains.annotations.NotNull;
 
@@ -85,5 +86,41 @@ public class DartDocumentationProviderTest extends DartCodeInsightFixtureTestCas
     doTestDocUrl("https://api.dart.dev/stable/dart-core/List/length.html",
                  "core/list.dart",
                  "set length(int newLength);");
+  }
+
+  public void testGenerateDocWithAndWithoutActiveLookup() {
+    DartConfigurable.setExperimentalLspFeaturesEnabled(getProject(), true);
+
+    final PsiFile psiFile = myFixture.addFileToProject("test.dart", "/// Documentation for class A\nclass A {}");
+    myFixture.configureFromExistingVirtualFile(psiFile.getVirtualFile());
+    final PsiElement element = PsiTreeUtil.getParentOfType(psiFile.findElementAt(psiFile.getText().indexOf("A {}")), DartComponent.class);
+    assertNotNull(element);
+
+    // 1. Without an active lookup, generateDoc returns null when experimental LSP features is enabled
+    assertNull("Expected null doc without active lookup", myProvider.generateDoc(element, null));
+
+    // 2. With an active lookup containing DartLookupObject, generateDoc generates doc
+    com.intellij.codeInsight.lookup.LookupElement lookupElement =
+      com.intellij.codeInsight.lookup.LookupElementBuilder.create(new com.jetbrains.lang.dart.ide.completion.DartLookupObject(getProject(), null, 0), "A");
+    com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).showLookup(myFixture.getEditor(), lookupElement);
+    try {
+      final String doc = myProvider.generateDoc(element, null);
+      assertNotNull("Expected non-null doc with active DartLookupObject", doc);
+      assertTrue("Expected doc to contain class documentation", doc.contains("Documentation for class A"));
+    }
+    finally {
+      com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).hideActiveLookup();
+    }
+
+    // 3. With an active lookup containing a non-DartLookupObject, generateDoc returns null
+    com.intellij.codeInsight.lookup.LookupElement plainLookupElement =
+      com.intellij.codeInsight.lookup.LookupElementBuilder.create("plain");
+    com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).showLookup(myFixture.getEditor(), plainLookupElement);
+    try {
+      assertNull("Expected null doc with non-DartLookupObject", myProvider.generateDoc(element, null));
+    }
+    finally {
+      com.intellij.codeInsight.lookup.LookupManager.getInstance(getProject()).hideActiveLookup();
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/dart-intellij-third-party/issues/621

### Problem

The problem originated because the legacy class `DartDocumentationProvider` requests documentation information from the DAS, and this is invoked from two places:
- Hover over a variable/class/etc, which is now taken care of by LSP
- From the menu that shows up on completion, when you go to the three dots and then select "Quick documentation"

When I turned off responses from `DartDocumentationProvider` to not interfere with LSP hover, I made it always return null, which means the completion menu's quick documentation also returned "null".

### Solution

In the issue I discussed potentially reverting LSP hover experimental status or waiting for LSP completion, but this is a workaround. We are now checking the source of the documentation request, and returning null unless this is coming from the completion menu.

### For the future

I expect that once completion is converted to LSP, we will no longer need this workaround and will delete the `DartDocumentationProvider` class.

### How to test

The completion menu can be invoked by typing a variable and then `.`. Then go to the three dots in the bottom right > "Quick documentation". This should open up some documentation on the selected completion:

<img width="1099" height="375" alt="Screenshot 2026-08-27 at 9 18 31 AM" src="https://github.com/user-attachments/assets/679751e3-4fd9-45fa-8944-cb696bacc819" />

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
