### PR TITLE
Support documentChanges in LSP workspace edits

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerImpl.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerImpl.kt
@@ -16,8 +16,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.NlsSafe
 import com.intellij.util.concurrency.annotations.RequiresWriteLock
 import com.jetbrains.lang.dart.DartBundle
+import com.jetbrains.lang.dart.logging.PluginLogger
 import kotlinx.coroutines.launch
 import org.dartlang.analysis.server.protocol.*
+
+private val LOG = PluginLogger.createLogger(DartAnalysisServerImpl::class.java)
 
 internal class DartAnalysisServerImpl(private val project: Project, socket: AnalysisServerSocket) : RemoteAnalysisServerImpl(socket) {
 
@@ -71,12 +74,21 @@ internal class DartAnalysisServerImpl(private val project: Project, socket: Anal
 
   @RequiresWriteLock
   private fun applyWorkspaceEdit(workspaceEdit: DartLspWorkspaceEdit): Boolean {
-    val changes = workspaceEdit.changes ?: return false
-    changes.entries.forEach { entry ->
-      val uri = entry.key
-      val virtualFile = getDartFileInfo(project, uri).findFile() ?: return false
-      val document = FileDocumentManager.getInstance().getDocument(virtualFile) ?: return false
-      if (!applyTextEdits(document, entry.value)) return false
+    val documentChanges = workspaceEdit.documentChanges ?: return false
+
+    for (change in documentChanges) {
+      when (change) {
+        is DartLspTextDocumentEdit -> {
+          val uri = change.textDocument.uri
+          val virtualFile = getDartFileInfo(project, uri).findFile() ?: return false
+          val document = FileDocumentManager.getInstance().getDocument(virtualFile) ?: return false
+          if (!applyTextEdits(document, change.edits)) return false
+        }
+        else -> {
+          LOG.warn("Unsupported document change type: ${change::class.java.simpleName}")
+          return false
+        }
+      }
     }
     return true
   }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -549,7 +549,7 @@ public final class DartAnalysisServerService implements Disposable {
       workspace.addProperty("applyEdit", true);
 
       JsonObject workspaceEdit = new JsonObject();
-      workspaceEdit.addProperty("documentChanges", false);
+      workspaceEdit.addProperty("documentChanges", true);
       workspace.add("workspaceEdit", workspaceEdit);
 
       lspCapabilities.add("workspace", workspace);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartFileInfo.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.io.OSAgnosticPathUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
 import java.net.URI
 import java.net.URISyntaxException
 
@@ -24,6 +25,7 @@ data class DartLocalFileInfo(val filePath: String) : DartFileInfo() {
 data class DartNotLocalFileInfo(private val project: Project, val fileUri: String) : DartFileInfo() {
   override fun findFile(): VirtualFile? =
     DartAnalysisServerService.getInstance(project).getNotLocalVirtualFile(fileUri)
+      ?: VirtualFileManager.getInstance().findFileByUrl(fileUri)
 }
 
 

--- a/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/DartLspWorkspaceEditTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/analyzer/DartLspWorkspaceEditTest.kt
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.analyzer
+
+import com.google.dart.server.AnalysisServerSocket
+import com.google.dart.server.DartLspWorkspaceApplyEditRequestConsumer
+import com.google.dart.server.ShowMessageRequestConsumer
+import com.google.dart.server.internal.remote.ByteLineReaderStream
+import com.google.dart.server.internal.remote.RemoteAnalysisServerImpl
+import com.google.dart.server.internal.remote.RequestSink
+import com.google.dart.server.internal.remote.ResponseStream
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.testFramework.PlatformTestUtil
+import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase
+import org.dartlang.analysis.server.protocol.DartLspApplyWorkspaceEditParams
+import org.dartlang.analysis.server.protocol.DartLspApplyWorkspaceEditResult
+import org.dartlang.analysis.server.protocol.DartLspCreateFile
+import org.dartlang.analysis.server.protocol.DartLspPosition
+import org.dartlang.analysis.server.protocol.DartLspRange
+import org.dartlang.analysis.server.protocol.DartLspTextDocumentEdit
+import org.dartlang.analysis.server.protocol.DartLspTextEdit
+import org.dartlang.analysis.server.protocol.DartLspVersionedTextDocumentIdentifier
+import org.dartlang.analysis.server.protocol.DartLspWorkspaceEdit
+import org.dartlang.analysis.server.protocol.MessageAction
+import java.util.concurrent.CompletableFuture
+
+class DartLspWorkspaceEditTest : DartCodeInsightFixtureTestCase() {
+
+    private fun createStubSocket(): AnalysisServerSocket = object : AnalysisServerSocket {
+        override fun getErrorStream(): ByteLineReaderStream? = null
+        override fun getRequestSink(): RequestSink? = null
+        override fun getResponseStream(): ResponseStream? = null
+        override fun isOpen(): Boolean = true
+        override fun start() {}
+        override fun stop() {}
+    }
+
+    private open class TestRemoteAnalysisServer(socket: AnalysisServerSocket) : RemoteAnalysisServerImpl(socket) {
+        override fun isSocketOpen(): Boolean = true
+        override fun server_openUrlRequest(url: String?) {}
+        override fun server_showMessageRequest(
+            type: String?,
+            message: String?,
+            actions: MutableList<MessageAction>?,
+            consumer: ShowMessageRequestConsumer?
+        ) {}
+        override fun lsp_workspaceApplyEdit(
+            params: DartLspApplyWorkspaceEditParams?,
+            consumer: DartLspWorkspaceApplyEditRequestConsumer?
+        ) {}
+        fun testProcessResponse(response: JsonObject) {
+            processResponse(response)
+        }
+    }
+
+    fun testBuildLspCapabilitiesWithDocumentChanges() {
+        val caps38 = DartAnalysisServerService.buildLspCapabilities("3.8.0")
+        val workspace38 = caps38.getAsJsonObject("workspace")
+        assertNotNull("workspace capability should be present for SDK >= 3.8", workspace38)
+        assertTrue(workspace38.get("applyEdit").asBoolean)
+        val workspaceEdit38 = workspace38.getAsJsonObject("workspaceEdit")
+        assertNotNull(workspaceEdit38)
+        assertTrue("documentChanges should be true for SDK >= 3.8", workspaceEdit38.get("documentChanges").asBoolean)
+
+        val caps37 = DartAnalysisServerService.buildLspCapabilities("3.7.0")
+        assertNull("workspace capability should NOT be present for SDK < 3.8", caps37.getAsJsonObject("workspace"))
+    }
+
+    fun testRemoteAnalysisServerParsesDocumentChanges() {
+        var capturedParams: DartLspApplyWorkspaceEditParams? = null
+        val server = object : TestRemoteAnalysisServer(createStubSocket()) {
+            override fun lsp_workspaceApplyEdit(params: DartLspApplyWorkspaceEditParams?, consumer: DartLspWorkspaceApplyEditRequestConsumer?) {
+                capturedParams = params
+            }
+        }
+
+        val json = """
+        {
+          "id": "das_1",
+          "method": "lsp.handle",
+          "params": {
+            "lspMessage": {
+              "id": "lsp_1",
+              "jsonrpc": "2.0",
+              "method": "workspace/applyEdit",
+              "params": {
+                "label": "Organize Imports",
+                "edit": {
+                  "documentChanges": [
+                    {
+                      "textDocument": {
+                        "uri": "file:///path/to/test.dart",
+                        "version": 42
+                      },
+                      "edits": [
+                        {
+                          "range": {
+                            "start": { "line": 1, "character": 2 },
+                            "end": { "line": 3, "character": 4 }
+                          },
+                          "newText": "replacement text"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+        """.trimIndent()
+
+        val jsonObject = JsonParser.parseString(json).asJsonObject
+        server.testProcessResponse(jsonObject)
+
+        val params = checkNotNull(capturedParams) { "capturedParams should not be null" }
+        assertEquals("Organize Imports", params.label)
+        assertNull("legacy changes should be null", params.workspaceEdit.changes)
+
+        val docChanges = checkNotNull(params.workspaceEdit.documentChanges) { "documentChanges should be present" }
+        assertEquals(1, docChanges.size)
+
+        val textDocEdit = docChanges[0] as DartLspTextDocumentEdit
+        assertEquals("file:///path/to/test.dart", textDocEdit.textDocument.uri)
+        assertEquals(42, textDocEdit.textDocument.version)
+        assertEquals(1, textDocEdit.edits.size)
+
+        val edit = textDocEdit.edits[0]
+        assertEquals("replacement text", edit.newText)
+        assertEquals(1, edit.range.start.line)
+        assertEquals(2, edit.range.start.character)
+        assertEquals(3, edit.range.end.line)
+        assertEquals(4, edit.range.end.character)
+    }
+
+    fun testRemoteAnalysisServerIgnoresChangesWithoutDocumentChanges() {
+        var capturedParams: DartLspApplyWorkspaceEditParams? = null
+        val server = object : TestRemoteAnalysisServer(createStubSocket()) {
+            override fun lsp_workspaceApplyEdit(params: DartLspApplyWorkspaceEditParams?, consumer: DartLspWorkspaceApplyEditRequestConsumer?) {
+                capturedParams = params
+            }
+        }
+
+        val json = """
+        {
+          "id": "das_2",
+          "method": "lsp.handle",
+          "params": {
+            "lspMessage": {
+              "id": "lsp_2",
+              "jsonrpc": "2.0",
+              "method": "workspace/applyEdit",
+              "params": {
+                "label": "Legacy QuickFix",
+                "edit": {
+                  "changes": {
+                    "file:///path/to/legacy.dart": []
+                  }
+                }
+              }
+            }
+          }
+        }
+        """.trimIndent()
+
+        val jsonObject = JsonParser.parseString(json).asJsonObject
+        server.testProcessResponse(jsonObject)
+
+        assertNull("capturedParams should be null when edit has no documentChanges", capturedParams)
+    }
+
+    fun testDartAnalysisServerImplAppliesDocumentChanges() {
+        val file = myFixture.addFileToProject("lib/example.dart", "void main() {\n  print('old');\n}\n")
+        val fileUrl = file.virtualFile.url
+
+        val server = DartAnalysisServerImpl(project, createStubSocket())
+
+        val textEdit = DartLspTextEdit(
+            DartLspRange(DartLspPosition(1, 9), DartLspPosition(1, 12)),
+            "new"
+        )
+        val docEdit = DartLspTextDocumentEdit(
+            DartLspVersionedTextDocumentIdentifier(fileUrl, 1),
+            listOf(textEdit)
+        )
+        val workspaceEdit = DartLspWorkspaceEdit(null, listOf(docEdit))
+        val params = DartLspApplyWorkspaceEditParams(workspaceEdit, "Test Document Edit")
+
+        val future = CompletableFuture<DartLspApplyWorkspaceEditResult>()
+        server.lsp_workspaceApplyEdit(params) { result ->
+            future.complete(result)
+        }
+
+        PlatformTestUtil.waitWithEventsDispatching(
+            "Timed out waiting for workspace edit to be applied",
+            { future.isDone },
+            5
+        )
+        val result = future.get()
+        assertTrue("workspaceEdit should report applied = true", result.applied)
+
+        val doc = checkNotNull(FileDocumentManager.getInstance().getDocument(file.virtualFile))
+        assertEquals("void main() {\n  print('new');\n}\n", doc.text)
+    }
+
+    fun testDartAnalysisServerImplAppliesEmptyDocumentChangesAsNoOp() {
+        val server = DartAnalysisServerImpl(project, createStubSocket())
+        val workspaceEdit = DartLspWorkspaceEdit(null, emptyList())
+        val params = DartLspApplyWorkspaceEditParams(workspaceEdit, "No-op Edit")
+
+        val future = CompletableFuture<DartLspApplyWorkspaceEditResult>()
+        server.lsp_workspaceApplyEdit(params) { result ->
+            future.complete(result)
+        }
+
+        PlatformTestUtil.waitWithEventsDispatching(
+            "Timed out waiting for no-op workspace edit",
+            { future.isDone },
+            5
+        )
+        val result = future.get()
+        assertTrue("empty workspaceEdit should report applied = true as a successful no-op", result.applied)
+    }
+
+    fun testDartAnalysisServerImplRejectsUnsupportedDocumentChange() {
+        val server = DartAnalysisServerImpl(project, createStubSocket())
+        val workspaceEdit = DartLspWorkspaceEdit(null, listOf(DartLspCreateFile()))
+        val params = DartLspApplyWorkspaceEditParams(workspaceEdit, "Unsupported CreateFile Edit")
+
+        val future = CompletableFuture<DartLspApplyWorkspaceEditResult>()
+        server.lsp_workspaceApplyEdit(params) { result ->
+            future.complete(result)
+        }
+
+        PlatformTestUtil.waitWithEventsDispatching(
+            "Timed out waiting for workspace edit to complete",
+            { future.isDone },
+            5
+        )
+        val result = future.get()
+        assertFalse("unsupported document change should report applied = false", result.applied)
+    }
+}

--- a/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
+++ b/third_party/thirdPartySrc/analysisServer/com/google/dart/server/internal/remote/RemoteAnalysisServerImpl.java
@@ -13,6 +13,7 @@
  */
 package com.google.dart.server.internal.remote;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.dart.server.AnalysisServerListener;
 import com.google.dart.server.AnalysisServerSocket;
 import com.google.dart.server.AnalysisServerStatusListener;
@@ -130,9 +131,12 @@ import com.google.gson.JsonPrimitive;
 import org.dartlang.analysis.server.protocol.AnalysisOptions;
 import org.dartlang.analysis.server.protocol.DartLspApplyWorkspaceEditParams;
 import org.dartlang.analysis.server.protocol.DartLspApplyWorkspaceEditResult;
+import org.dartlang.analysis.server.protocol.DartLspDocumentChange;
 import org.dartlang.analysis.server.protocol.DartLspPosition;
 import org.dartlang.analysis.server.protocol.DartLspRange;
+import org.dartlang.analysis.server.protocol.DartLspTextDocumentEdit;
 import org.dartlang.analysis.server.protocol.DartLspTextEdit;
+import org.dartlang.analysis.server.protocol.DartLspVersionedTextDocumentIdentifier;
 import org.dartlang.analysis.server.protocol.DartLspWorkspaceEdit;
 import org.dartlang.analysis.server.protocol.FlutterWidgetPropertyValue;
 import org.dartlang.analysis.server.protocol.ImportedElements;
@@ -986,30 +990,33 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     JsonElement editElement = paramsElement.getAsJsonObject().get("edit");
     if (!(editElement instanceof JsonObject)) return null;
 
-    JsonElement changesElement = editElement.getAsJsonObject().get("changes");
-    if (!(changesElement instanceof JsonObject)) return null;
+    JsonElement documentChangesElement = editElement.getAsJsonObject().get("documentChanges");
+    if (!(documentChangesElement instanceof JsonArray)) return null;
 
-    Map<String, List<DartLspTextEdit>> uriToTextEditMap = new LinkedHashMap<>();
-
-    for (Map.Entry<String, JsonElement> entry : changesElement.getAsJsonObject().entrySet()) {
-      String uri = entry.getKey();
-      JsonElement editsElement = entry.getValue();
-      if (!(editsElement instanceof JsonArray)) continue;
-
-      List<DartLspTextEdit> textEdits = new ArrayList<>();
-      for (JsonElement element : editsElement.getAsJsonArray()) {
-        String newText = element.getAsJsonObject().get("newText").getAsString();
-        DartLspRange range = getAsRange(element.getAsJsonObject().get("range"));
-        textEdits.add(new DartLspTextEdit(range, newText));
+    List<DartLspDocumentChange> documentChangesList = new ArrayList<>();
+    for (JsonElement element : documentChangesElement.getAsJsonArray()) {
+      if (!element.isJsonObject()) continue;
+      JsonObject docChangeObj = element.getAsJsonObject();
+      if (docChangeObj.has("textDocument") && docChangeObj.has("edits")) {
+        JsonObject textDoc = docChangeObj.getAsJsonObject("textDocument");
+        String uri = textDoc.get("uri").getAsString();
+        Integer version = textDoc.has("version") && !textDoc.get("version").isJsonNull() ? textDoc.get("version").getAsInt() : null;
+        DartLspVersionedTextDocumentIdentifier versionedId = new DartLspVersionedTextDocumentIdentifier(uri, version);
+        List<DartLspTextEdit> textEdits = new ArrayList<>();
+        JsonElement editsElement = docChangeObj.get("edits");
+        if (editsElement instanceof JsonArray) {
+          for (JsonElement editItem : editsElement.getAsJsonArray()) {
+            String newText = editItem.getAsJsonObject().get("newText").getAsString();
+            DartLspRange range = getAsRange(editItem.getAsJsonObject().get("range"));
+            textEdits.add(new DartLspTextEdit(range, newText));
+          }
+        }
+        documentChangesList.add(new DartLspTextDocumentEdit(versionedId, textEdits));
       }
-
-      uriToTextEditMap.put(uri, textEdits);
     }
 
-    DartLspWorkspaceEdit workspaceEdit = new DartLspWorkspaceEdit(uriToTextEditMap, null);
-    DartLspApplyWorkspaceEditParams workspaceEditParams = new DartLspApplyWorkspaceEditParams(workspaceEdit, label);
-
-    return workspaceEditParams;
+    DartLspWorkspaceEdit workspaceEdit = new DartLspWorkspaceEdit(null, documentChangesList);
+    return new DartLspApplyWorkspaceEditParams(workspaceEdit, label);
   }
 
   private DartLspRange getAsRange(JsonElement rangeElement) {
@@ -1024,7 +1031,8 @@ public abstract class RemoteAnalysisServerImpl implements AnalysisServer {
     return new DartLspPosition(line, character);
   }
 
-  private void processResponse(JsonObject response) throws Exception {
+  @VisibleForTesting
+  protected void processResponse(JsonObject response) throws Exception {
     notifyResponseListeners(response);
     // handle notification
     if (processNotification(response)) {

--- a/third_party/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/DartLspProtocol.kt
+++ b/third_party/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/DartLspProtocol.kt
@@ -10,7 +10,9 @@ class DartLspTextEdit(val range: DartLspRange, val newText: String)
 
 interface DartLspDocumentChange
 
-class DartLspTextDocumentEdit() : DartLspDocumentChange
+class DartLspVersionedTextDocumentIdentifier(val uri: String, val version: Int?)
+
+class DartLspTextDocumentEdit(val textDocument: DartLspVersionedTextDocumentIdentifier, val edits: List<DartLspTextEdit>) : DartLspDocumentChange
 
 class DartLspCreateFile() : DartLspDocumentChange
 


### PR DESCRIPTION
This is to prepare for implementing [willRenameFiles](https://github.com/flutter/dart-intellij-third-party/pull/638). From previous work to enable code changes initialized from DevTools, we were using an old version of receiving DAS edits (edits contain a simple map of "changes"). This changes existing usages of workspace edits to use "documentChanges", which is now the default in LSP; since we have to make a client-side capabilities declaration to DAS of what format we want for all edits, I didn't want to go forward using the old version when we start using this in more places.

Functionality that uses workspace edits:
- DevTools widget inspector actions like wrap, remove, or extract.
- Property editor edits.
- DevTools deep links - generating or updating URLs.
- DevTools extensions that exposes quick actions or code generation buttons.

This is how the plugin implements the functionality:
1. A user initiates an edit from embedded DevTools.
1. DevTools sends a request over DTD to the DAS to make the edit.
1. The DAS sends workspace edit to plugin.
1. Plugin applies edit.

To manually test, trigger a change from DevTools (wrap with container):
<img width="1064" height="468" alt="Screenshot 2026-09-02 at 10 19 21 AM" src="https://github.com/user-attachments/assets/4766f899-4dbb-48ab-8dd8-b1fde7008e16" />

This should result in the change being applied in the editor:
<img width="1041" height="546" alt="Screenshot 2026-09-02 at 10 19 32 AM" src="https://github.com/user-attachments/assets/27e50483-2fb0-4a5b-b30e-f9cee6a27291" />


Example of documentChanges in analysis server log:
```
1788369568483:Req:{"id"::"1","method"::"lsp.handle","params"::{"lspMessage"::{"id"::1,"jsonrpc"::"2.0","method"::"workspace/applyEdit","params"::{"edit"::{"documentChanges"::[{"edits"::[{"newText"::"Container(\n        child:: Center(\n          // Center is a layout widget. It takes a single child and positions it\n          // in the middle of the parent.\n          child:: Column(\n            // Column is also a layout widget. It takes a list of children and\n            // arranges them vertically. By default, it sizes itself to fit its\n            // children horizontally, and tries to be as tall as its parent.\n            //\n            // Column has various properties to control how it sizes itself and\n            // how it positions its children. Here we use mainAxisAlignment to\n            // center the children vertically; the main axis here is the vertical\n            // axis because Columns are vertical (the cross axis would be\n            // horizontal).\n            //\n            // TRY THIS:: Invoke \"debug painting\" (choose the \"Toggle Debug Paint\"\n            // action in the IDE, or press \"p\" in the console), to see the\n            // wireframe for each widget.\n            mainAxisAlignment:: .center,\n            children:: [\n              const Text('You have pushed the button this many time2s::'),\n              Text(\n                '$_counter',\n                style:: Theme.of(context).textTheme.headlineMedium,\n              ),\n            ],\n          ),\n        ),\n      )","range"::{"end"::{"character"::7,"line"::113},"start"::{"character"::12,"line"::87}}}],"textDocument"::{"uri"::"file::///Users/helinx/StudioProjects/test_v96_262/lib/main.dart","version"::null}}]},"label"::"Apply Code Action"}}}}
```

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- ~[] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)~ (no user-facing difference)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
