### PR TITLE
Migrate syntax highlighting from legacy to LSP

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Inlay hints for types and parameter names, configurable in Settings | Editor | Inlay Hints (JetBrains LSP; requires Dart SDK 3.14.0-139.0.dev or newer) (#617)
 
 ### Changed
+- Syntax highlighting implemented with JetBrains LSP as an experimental feature (#401)
 
 ### Removed
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -598,10 +598,6 @@ public final class DartAnalysisServerService implements Disposable {
     return sdk != null && isDartSdkVersionSufficientForLspNavigation(sdk.getVersion());
   }
 
-  public static boolean isLspHighlightingEnabled(final @NotNull Project project) {
-    return DartConfigurable.isExperimentalLspFeaturesEnabled(project);
-  }
-
   public static boolean isDartSdkVersionSufficientForLspPublishDiagnostics(@NotNull String sdkVersion) {
     return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_PUBLISH_DIAGNOSTICS_SDK_VERSION) >= 0;
   }
@@ -2075,7 +2071,7 @@ public final class DartAnalysisServerService implements Disposable {
       if (myServer == null) return;
 
       final Map<String, List<String>> subscriptions = new HashMap<>();
-      if (!isLspHighlightingEnabled(myProject)) {
+      if (!DartConfigurable.isExperimentalLspFeaturesEnabled(myProject)) {
         subscriptions.put(AnalysisService.HIGHLIGHTS, myVisibleFileUris);
       }
       subscriptions.put(AnalysisService.NAVIGATION, myVisibleFileUris);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -598,6 +598,10 @@ public final class DartAnalysisServerService implements Disposable {
     return sdk != null && isDartSdkVersionSufficientForLspNavigation(sdk.getVersion());
   }
 
+  public static boolean isLspHighlightingEnabled(final @NotNull Project project) {
+    return DartConfigurable.isExperimentalLspFeaturesEnabled(project);
+  }
+
   public static boolean isDartSdkVersionSufficientForLspPublishDiagnostics(@NotNull String sdkVersion) {
     return DartSdkUpdateChecker.compareDartSdkVersions(sdkVersion, MIN_LSP_PUBLISH_DIAGNOSTICS_SDK_VERSION) >= 0;
   }
@@ -2071,7 +2075,9 @@ public final class DartAnalysisServerService implements Disposable {
       if (myServer == null) return;
 
       final Map<String, List<String>> subscriptions = new HashMap<>();
-      subscriptions.put(AnalysisService.HIGHLIGHTS, myVisibleFileUris);
+      if (!isLspHighlightingEnabled(myProject)) {
+        subscriptions.put(AnalysisService.HIGHLIGHTS, myVisibleFileUris);
+      }
       subscriptions.put(AnalysisService.NAVIGATION, myVisibleFileUris);
       subscriptions.put(AnalysisService.OVERRIDES, myVisibleFileUris);
       subscriptions.put(AnalysisService.OUTLINE, myVisibleFileUris);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java
@@ -188,8 +188,10 @@ public final class DartAnnotator implements Annotator {
           notYetAppliedErrors.sort(Comparator.comparingInt(DartServerData.DartError::getOffset));
           ensureNoErrorsAfterEOF(notYetAppliedErrors, element.getContainingFile().getTextLength());
 
-          notYetAppliedHighlighting.addAll(service.getHighlight(vFile));
-          notYetAppliedHighlighting.sort(Comparator.comparingInt(DartServerData.DartHighlightRegion::getOffset));
+          if (!DartAnalysisServerService.isLspHighlightingEnabled(element.getProject())) {
+            notYetAppliedHighlighting.addAll(service.getHighlight(vFile));
+            notYetAppliedHighlighting.sort(Comparator.comparingInt(DartServerData.DartHighlightRegion::getOffset));
+          }
         }
       }
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java
@@ -25,6 +25,7 @@ import com.jetbrains.lang.dart.highlight.DartSyntaxHighlighterColors;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblem;
 import com.jetbrains.lang.dart.psi.DartSymbolLiteralExpression;
 import com.jetbrains.lang.dart.psi.DartTernaryExpression;
+import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import org.dartlang.analysis.server.protocol.AnalysisErrorSeverity;
 import org.dartlang.analysis.server.protocol.HighlightRegionType;
@@ -188,7 +189,7 @@ public final class DartAnnotator implements Annotator {
           notYetAppliedErrors.sort(Comparator.comparingInt(DartServerData.DartError::getOffset));
           ensureNoErrorsAfterEOF(notYetAppliedErrors, element.getContainingFile().getTextLength());
 
-          if (!DartAnalysisServerService.isLspHighlightingEnabled(element.getProject())) {
+          if (!DartConfigurable.isExperimentalLspFeaturesEnabled(element.getProject())) {
             notYetAppliedHighlighting.addAll(service.getHighlight(vFile));
             notYetAppliedHighlighting.sort(Comparator.comparingInt(DartServerData.DartHighlightRegion::getOffset));
           }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -43,6 +43,10 @@ import org.eclipse.lsp4j.InlayHintParams
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
 import org.eclipse.lsp4j.PublishDiagnosticsParams
+import org.eclipse.lsp4j.SemanticTokens
+import org.eclipse.lsp4j.SemanticTokensLegend
+import org.eclipse.lsp4j.SemanticTokensParams
+import org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions
 import org.eclipse.lsp4j.ReferenceParams
 import org.eclipse.lsp4j.ServerCapabilities
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
@@ -247,6 +251,15 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
             setTypeHierarchyProvider(true)
             setCallHierarchyProvider(true)
             setReferencesProvider(true)
+            val semanticTokensLegend = SemanticTokensLegend(
+                DartLspSemanticTokensSupport.tokenTypes,
+                DartLspSemanticTokensSupport.tokenModifiers
+            )
+            setSemanticTokensProvider(SemanticTokensWithRegistrationOptions().apply {
+                legend = semanticTokensLegend
+                setFull(true)
+                setRange(false)
+            })
             // Add other capabilities as we support them.
         }
         return CompletableFuture.completedFuture(InitializeResult(capabilities))
@@ -313,6 +326,13 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
                     hints ?: emptyList()
                 }
             }
+    }
+
+    override fun semanticTokensFull(params: SemanticTokensParams): CompletableFuture<SemanticTokens> {
+        return forwardRequest("textDocument/semanticTokens/full", params, SemanticTokens::class.java).exceptionally { e ->
+            logger.info("textDocument/semanticTokens/full failed: ${e.message}")
+            null
+        }
     }
 
     override fun diagnosticServer(): CompletableFuture<DiagnosticServerResult> {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -125,7 +125,7 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
         override val goToTypeDefinitionCustomizer = LspGoToTypeDefinitionSupport()
         override val completionCustomizer = LspCompletionDisabled
         override val semanticTokensCustomizer: LspSemanticTokensCustomizer
-            get() = if (DartAnalysisServerService.isLspHighlightingEnabled(project)) {
+            get() = if (DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
                 DartLspSemanticTokensSupport
             } else {
                 LspSemanticTokensDisabled

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -5,6 +5,7 @@
  */
 package com.jetbrains.lang.dart.lsp
 
+import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.io.OSAgnosticPathUtil
 import com.intellij.openapi.vfs.VfsUtil
@@ -43,7 +44,9 @@ import com.intellij.platform.dartlsp.api.customization.LspInlayHintDisabled
 import com.intellij.platform.dartlsp.api.customization.LspOptimizeImportsDisabled
 import com.intellij.platform.dartlsp.api.customization.LspRenameDisabled
 import com.intellij.platform.dartlsp.api.customization.LspSelectionRangeDisabled
+import com.intellij.platform.dartlsp.api.customization.LspSemanticTokensCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspSemanticTokensDisabled
+import com.intellij.platform.dartlsp.api.customization.LspSemanticTokensSupport
 import com.intellij.platform.dartlsp.api.customization.LspSignatureHelpDisabled
 import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchyCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchyDisabled
@@ -51,8 +54,12 @@ import com.intellij.platform.dartlsp.api.customization.LspTypeHierarchySupport
 import com.intellij.platform.dartlsp.api.customization.LspWorkspaceSymbolDisabled
 import com.intellij.psi.PsiFile
 import com.intellij.util.io.URLUtil
+import com.jetbrains.lang.dart.DartFileType
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
+import com.jetbrains.lang.dart.highlight.DartSyntaxHighlighterColors
 import com.jetbrains.lang.dart.sdk.DartConfigurable
+import org.eclipse.lsp4j.SemanticTokenModifiers
+import org.eclipse.lsp4j.SemanticTokenTypes
 
 /**
  * Configuration descriptor that defines how the JetBrains LSP client communicates with the Dart Bridge server.
@@ -117,7 +124,12 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
             }
         override val goToTypeDefinitionCustomizer = LspGoToTypeDefinitionSupport()
         override val completionCustomizer = LspCompletionDisabled
-        override val semanticTokensCustomizer = LspSemanticTokensDisabled
+        override val semanticTokensCustomizer: LspSemanticTokensCustomizer
+            get() = if (DartAnalysisServerService.isLspHighlightingEnabled(project)) {
+                DartLspSemanticTokensSupport
+            } else {
+                LspSemanticTokensDisabled
+            }
         override val diagnosticsCustomizer = LspDiagnosticsDisabled
         override val codeActionsCustomizer = LspCodeActionsDisabled
         override val commandsCustomizer = LspCommandsDisabled
@@ -166,5 +178,121 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
         override val selectionRangeCustomizer = LspSelectionRangeDisabled
         override val codeLensCustomizer = LspCodeLensDisabled
         override val renameCustomizer = LspRenameDisabled
+    }
+}
+
+object DartLspSemanticTokensSupport : LspSemanticTokensSupport() {
+    override fun shouldAskServerForSemanticTokens(psiFile: PsiFile): Boolean {
+        return psiFile.fileType == DartFileType.INSTANCE
+    }
+
+    override val tokenTypes: List<String> = listOf(
+        SemanticTokenTypes.Namespace,
+        SemanticTokenTypes.Type,
+        SemanticTokenTypes.Class,
+        SemanticTokenTypes.Enum,
+        SemanticTokenTypes.Interface,
+        SemanticTokenTypes.Struct,
+        SemanticTokenTypes.TypeParameter,
+        SemanticTokenTypes.Parameter,
+        SemanticTokenTypes.Variable,
+        SemanticTokenTypes.Property,
+        SemanticTokenTypes.EnumMember,
+        SemanticTokenTypes.Event,
+        SemanticTokenTypes.Function,
+        SemanticTokenTypes.Method,
+        SemanticTokenTypes.Macro,
+        SemanticTokenTypes.Keyword,
+        SemanticTokenTypes.Modifier,
+        SemanticTokenTypes.Comment,
+        SemanticTokenTypes.String,
+        SemanticTokenTypes.Number,
+        SemanticTokenTypes.Regexp,
+        SemanticTokenTypes.Operator,
+        SemanticTokenTypes.Decorator,
+        // Dart custom semantic token types:
+        "annotation",
+        "boolean",
+        "label",
+        "source"
+    )
+
+    override val tokenModifiers: List<String> = listOf(
+        SemanticTokenModifiers.Declaration,
+        SemanticTokenModifiers.Definition,
+        SemanticTokenModifiers.Readonly,
+        SemanticTokenModifiers.Static,
+        SemanticTokenModifiers.Deprecated,
+        SemanticTokenModifiers.Abstract,
+        SemanticTokenModifiers.Async,
+        SemanticTokenModifiers.Modification,
+        SemanticTokenModifiers.Documentation,
+        SemanticTokenModifiers.DefaultLibrary,
+        // Dart custom semantic token modifiers:
+        "annotation",
+        "control",
+        "importPrefix",
+        "label",
+        "constructor",
+        "escape",
+        "interpolation",
+        "instance",
+        "source",
+        "void",
+        "wildcard"
+    )
+
+    override fun getTextAttributesKey(tokenType: String, modifiers: List<String>): TextAttributesKey? {
+        val isDecl = modifiers.contains(SemanticTokenModifiers.Declaration)
+        val isStatic = modifiers.contains(SemanticTokenModifiers.Static)
+        val isInstance = modifiers.contains("instance")
+
+        return when (tokenType) {
+            SemanticTokenTypes.Class,
+            SemanticTokenTypes.Interface,
+            SemanticTokenTypes.Struct -> DartSyntaxHighlighterColors.CLASS
+
+            SemanticTokenTypes.Enum -> DartSyntaxHighlighterColors.ENUM
+            SemanticTokenTypes.EnumMember -> DartSyntaxHighlighterColors.ENUM_CONSTANT
+            SemanticTokenTypes.TypeParameter -> DartSyntaxHighlighterColors.TYPE_PARAMETER
+            SemanticTokenTypes.Type -> DartSyntaxHighlighterColors.TYPE_ALIAS
+
+            SemanticTokenTypes.Method -> when {
+                modifiers.contains("constructor") -> DartSyntaxHighlighterColors.CONSTRUCTOR
+                isStatic -> if (isDecl) DartSyntaxHighlighterColors.STATIC_METHOD_DECLARATION else DartSyntaxHighlighterColors.STATIC_METHOD_REFERENCE
+                isInstance -> if (isDecl) DartSyntaxHighlighterColors.INSTANCE_METHOD_DECLARATION else DartSyntaxHighlighterColors.INSTANCE_METHOD_REFERENCE
+                else -> if (isDecl) DartSyntaxHighlighterColors.INSTANCE_METHOD_DECLARATION else DartSyntaxHighlighterColors.INSTANCE_METHOD_REFERENCE
+            }
+
+            SemanticTokenTypes.Function -> when {
+                isStatic -> if (isDecl) DartSyntaxHighlighterColors.TOP_LEVEL_FUNCTION_DECLARATION else DartSyntaxHighlighterColors.TOP_LEVEL_FUNCTION_REFERENCE
+                else -> if (isDecl) DartSyntaxHighlighterColors.LOCAL_FUNCTION_DECLARATION else DartSyntaxHighlighterColors.LOCAL_FUNCTION_REFERENCE
+            }
+
+            SemanticTokenTypes.Property -> when {
+                isStatic -> if (isDecl) DartSyntaxHighlighterColors.STATIC_FIELD_DECLARATION else DartSyntaxHighlighterColors.STATIC_GETTER_REFERENCE
+                isInstance -> if (isDecl) DartSyntaxHighlighterColors.INSTANCE_FIELD_DECLARATION else DartSyntaxHighlighterColors.INSTANCE_GETTER_REFERENCE
+                else -> if (isDecl) DartSyntaxHighlighterColors.TOP_LEVEL_GETTER_DECLARATION else DartSyntaxHighlighterColors.TOP_LEVEL_GETTER_REFERENCE
+            }
+
+            SemanticTokenTypes.Variable -> when {
+                modifiers.contains("importPrefix") -> DartSyntaxHighlighterColors.IMPORT_PREFIX
+                isStatic -> DartSyntaxHighlighterColors.STATIC_FIELD_DECLARATION
+                isInstance -> if (isDecl) DartSyntaxHighlighterColors.INSTANCE_FIELD_DECLARATION else DartSyntaxHighlighterColors.INSTANCE_FIELD_REFERENCE
+                isDecl -> DartSyntaxHighlighterColors.LOCAL_VARIABLE_DECLARATION
+                else -> DartSyntaxHighlighterColors.LOCAL_VARIABLE_REFERENCE
+            }
+
+            SemanticTokenTypes.Parameter -> if (isDecl) DartSyntaxHighlighterColors.PARAMETER_DECLARATION else DartSyntaxHighlighterColors.PARAMETER_REFERENCE
+            "annotation", SemanticTokenTypes.Decorator -> DartSyntaxHighlighterColors.ANNOTATION
+            "label" -> DartSyntaxHighlighterColors.LABEL
+            SemanticTokenTypes.Namespace -> DartSyntaxHighlighterColors.LIBRARY_NAME
+            SemanticTokenTypes.Keyword, "boolean" -> DartSyntaxHighlighterColors.KEYWORD
+            SemanticTokenTypes.String -> if (modifiers.contains("escape")) DartSyntaxHighlighterColors.VALID_STRING_ESCAPE else DartSyntaxHighlighterColors.STRING
+            SemanticTokenTypes.Comment -> if (modifiers.contains(SemanticTokenModifiers.Documentation)) DartSyntaxHighlighterColors.DOC_COMMENT else DartSyntaxHighlighterColors.LINE_COMMENT
+            SemanticTokenTypes.Number -> DartSyntaxHighlighterColors.NUMBER
+            SemanticTokenTypes.Operator -> DartSyntaxHighlighterColors.OPERATION_SIGN
+            else -> super.getTextAttributesKey(tokenType, modifiers)
+        }
     }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -17,6 +17,7 @@ enum class LspMethod(
     INITIALIZE("initialize"),
     // Not gated by the experimental LSP flag because there is no fallback in legacy mode.
     INLAY_HINT("textDocument/inlayHint", isExperimental = false),
+    SEMANTIC_TOKENS_FULL("textDocument/semanticTokens/full", isExperimental = true, presentableName = "syntax highlighting"),
     SHUTDOWN("shutdown"),
     TYPE_DEFINITION("textDocument/typeDefinition", isExperimental = false),
     REFERENCES("textDocument/references", isExperimental = true, presentableName = "references");

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -26,6 +26,7 @@ import org.eclipse.lsp4j.CallHierarchyPrepareParams
 import org.eclipse.lsp4j.DocumentHighlightKind
 import org.eclipse.lsp4j.DocumentHighlightParams
 import org.eclipse.lsp4j.HoverParams
+import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InlayHintKind
 import org.eclipse.lsp4j.InlayHintParams
 import org.eclipse.lsp4j.MessageActionItem
@@ -35,6 +36,9 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.ReferenceContext
 import org.eclipse.lsp4j.ReferenceParams
+import org.eclipse.lsp4j.SemanticTokenModifiers
+import org.eclipse.lsp4j.SemanticTokenTypes
+import org.eclipse.lsp4j.SemanticTokensParams
 import org.eclipse.lsp4j.ShowMessageRequestParams
 import org.eclipse.lsp4j.SymbolKind
 import org.eclipse.lsp4j.TextDocumentIdentifier
@@ -44,6 +48,7 @@ import org.eclipse.lsp4j.TypeHierarchyPrepareParams
 import org.eclipse.lsp4j.TypeHierarchySubtypesParams
 import org.eclipse.lsp4j.TypeHierarchySupertypesParams
 import org.eclipse.lsp4j.services.LanguageClient
+import com.jetbrains.lang.dart.highlight.DartSyntaxHighlighterColors
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
@@ -435,6 +440,142 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
 
         val result = future.get(5, TimeUnit.SECONDS)
         assertTrue(result.isEmpty())
+    }
+
+    fun testInitialize_semanticTokensProvider() {
+        val future = bridgeServer.initialize(InitializeParams())
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        val capabilities = result.capabilities
+        assertNotNull(capabilities)
+        val semanticTokensProvider = capabilities.semanticTokensProvider
+        assertNotNull(semanticTokensProvider)
+        val legend = semanticTokensProvider.legend
+        assertNotNull(legend)
+        assertTrue("Legend should contain standard types like 'class'", legend.tokenTypes.contains(SemanticTokenTypes.Class))
+        assertTrue("Legend should contain Dart custom type 'annotation'", legend.tokenTypes.contains("annotation"))
+        assertTrue("Legend should contain Dart custom type 'boolean'", legend.tokenTypes.contains("boolean"))
+        assertTrue("Legend should contain Dart custom type 'label'", legend.tokenTypes.contains("label"))
+        assertTrue("Legend should contain Dart custom type 'source'", legend.tokenTypes.contains("source"))
+        assertTrue("Legend should contain modifier 'declaration'", legend.tokenModifiers.contains(SemanticTokenModifiers.Declaration))
+        assertTrue("Legend should contain modifier 'static'", legend.tokenModifiers.contains(SemanticTokenModifiers.Static))
+        assertTrue("Legend should contain custom modifier 'constructor'", legend.tokenModifiers.contains("constructor"))
+        assertTrue("Legend should contain custom modifier 'importPrefix'", legend.tokenModifiers.contains("importPrefix"))
+        assertTrue("Legend should contain custom modifier 'instance'", legend.tokenModifiers.contains("instance"))
+    }
+
+    fun testSemanticTokensFull_success() {
+        val params = SemanticTokensParams(TextDocumentIdentifier("file:///test.dart"))
+        val future = bridgeServer.semanticTokensFull(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+        assertEquals("123", jsonObject!!.get("id").asString)
+
+        val lspMessage = jsonObject.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("123", lspMessage.get("id").asString)
+        assertEquals("textDocument/semanticTokens/full", lspMessage.get("method").asString)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "result": {
+                    "data": [0, 4, 3, 0, 0, 1, 2, 5, 1, 2]
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(listOf(0, 4, 3, 0, 0, 1, 2, 5, 1, 2), result.data)
+    }
+
+    fun testSemanticTokensFull_errorReturnsNull() {
+        val params = SemanticTokensParams(TextDocumentIdentifier("file:///test.dart"))
+        val future = bridgeServer.semanticTokensFull(params)
+
+        val responseJson = """
+            {
+              "id": "123",
+              "result": {
+                "lspResponse": {
+                  "jsonrpc": "2.0",
+                  "id": "123",
+                  "error": {
+                    "code": -32601,
+                    "message": "Method not found"
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNull("DAS error on semanticTokensFull should gracefully complete with null", result)
+    }
+
+    fun testDartLspSemanticTokensSupport_shouldAskServerForSemanticTokens() {
+        val dartFile = myFixture.configureByText("test.dart", "class Foo {}")
+        assertTrue("Should ask server for .dart files", DartLspSemanticTokensSupport.shouldAskServerForSemanticTokens(dartFile))
+
+        val txtFile = myFixture.configureByText("test.txt", "some text")
+        assertFalse("Should not ask server for .txt files", DartLspSemanticTokensSupport.shouldAskServerForSemanticTokens(txtFile))
+    }
+
+    fun testDartLspSemanticTokensSupport_getTextAttributesKey() {
+        assertEquals(DartSyntaxHighlighterColors.CLASS, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Class, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.ENUM, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Enum, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.ENUM_CONSTANT, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.EnumMember, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.TYPE_PARAMETER, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.TypeParameter, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.TYPE_ALIAS, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Type, emptyList()))
+
+        assertEquals(DartSyntaxHighlighterColors.CONSTRUCTOR, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Method, listOf("constructor")))
+        assertEquals(DartSyntaxHighlighterColors.STATIC_METHOD_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Method, listOf(SemanticTokenModifiers.Static, SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.STATIC_METHOD_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Method, listOf(SemanticTokenModifiers.Static)))
+        assertEquals(DartSyntaxHighlighterColors.INSTANCE_METHOD_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Method, listOf("instance", SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.INSTANCE_METHOD_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Method, listOf("instance")))
+
+        assertEquals(DartSyntaxHighlighterColors.TOP_LEVEL_FUNCTION_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Function, listOf(SemanticTokenModifiers.Static, SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.TOP_LEVEL_FUNCTION_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Function, listOf(SemanticTokenModifiers.Static)))
+        assertEquals(DartSyntaxHighlighterColors.LOCAL_FUNCTION_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Function, listOf(SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.LOCAL_FUNCTION_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Function, emptyList()))
+
+        assertEquals(DartSyntaxHighlighterColors.STATIC_FIELD_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Property, listOf(SemanticTokenModifiers.Static, SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.STATIC_GETTER_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Property, listOf(SemanticTokenModifiers.Static)))
+        assertEquals(DartSyntaxHighlighterColors.INSTANCE_FIELD_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Property, listOf("instance", SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.INSTANCE_GETTER_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Property, listOf("instance")))
+        assertEquals(DartSyntaxHighlighterColors.TOP_LEVEL_GETTER_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Property, listOf(SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.TOP_LEVEL_GETTER_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Property, emptyList()))
+
+        assertEquals(DartSyntaxHighlighterColors.IMPORT_PREFIX, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Variable, listOf("importPrefix")))
+        assertEquals(DartSyntaxHighlighterColors.STATIC_FIELD_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Variable, listOf(SemanticTokenModifiers.Static)))
+        assertEquals(DartSyntaxHighlighterColors.LOCAL_VARIABLE_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Variable, listOf(SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.LOCAL_VARIABLE_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Variable, emptyList()))
+
+        assertEquals(DartSyntaxHighlighterColors.PARAMETER_DECLARATION, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Parameter, listOf(SemanticTokenModifiers.Declaration)))
+        assertEquals(DartSyntaxHighlighterColors.PARAMETER_REFERENCE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Parameter, emptyList()))
+
+        assertEquals(DartSyntaxHighlighterColors.ANNOTATION, DartLspSemanticTokensSupport.getTextAttributesKey("annotation", emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.LABEL, DartLspSemanticTokensSupport.getTextAttributesKey("label", emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.LIBRARY_NAME, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Namespace, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.KEYWORD, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Keyword, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.KEYWORD, DartLspSemanticTokensSupport.getTextAttributesKey("boolean", emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.VALID_STRING_ESCAPE, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.String, listOf("escape")))
+        assertEquals(DartSyntaxHighlighterColors.STRING, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.String, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.DOC_COMMENT, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Comment, listOf(SemanticTokenModifiers.Documentation)))
+        assertEquals(DartSyntaxHighlighterColors.LINE_COMMENT, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Comment, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.NUMBER, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Number, emptyList()))
+        assertEquals(DartSyntaxHighlighterColors.OPERATION_SIGN, DartLspSemanticTokensSupport.getTextAttributesKey(SemanticTokenTypes.Operator, emptyList()))
     }
 
     fun testPublishDiagnosticsNotification() {


### PR DESCRIPTION
### Summary of Changes

This PR migrates Dart syntax highlighting from the legacy custom Dart Analysis Server (DAS) subscription mechanism (`AnalysisService.HIGHLIGHTS` and `DartAnnotator`) over to the JetBrains LSP integration using semantic tokens (`textDocument/semanticTokens/full`), resolving flutter/dart-intellij-third-party#401 as part of the overarching LSP migration initiative (flutter/dart-intellij-third-party#207).

#### Key Changes:

- **LSP Bridge Server (`DartBridgeLspServer.kt`)**:
  - Configures and advertises `semanticTokensProvider` with `SemanticTokensLegend` (including standard LSP token types and Dart custom token types/modifiers) during the LSP `initialize` handshake.
  - Implements `semanticTokensFull(params: SemanticTokensParams)` by forwarding `textDocument/semanticTokens/full` requests to DAS over the `lsp.handle` JSON-RPC bridge and handling errors gracefully by returning `null`.
- **Semantic Tokens Support & Color Mapping (`DartLspServerDescriptor.kt`)**:
  - Implements `DartLspSemanticTokensSupport` (extending `LspSemanticTokensSupport`):
    - Restricts semantic token requests strictly to `.dart` files (`shouldAskServerForSemanticTokens`).
    - Declares supported token types (standard types plus Dart-specific `annotation`, `boolean`, `label`, `source`) and token modifiers (standard modifiers plus Dart-specific `annotation`, `control`, `importPrefix`, `label`, `constructor`, `escape`, `interpolation`, `instance`, `source`, `void`, `wildcard`).
    - Maps semantic token types and modifier combinations to IntelliJ's `DartSyntaxHighlighterColors` text attribute keys (classes, enum/enum constants, constructors, static/instance/local methods & functions, getters/properties, variables, parameters, annotations, labels, strings/escapes, doc/line comments, keywords, operators, numbers, etc.).
  - Dynamically activates `DartLspSemanticTokensSupport` on `semanticTokensCustomizer` when experimental LSP features are enabled.
- **Legacy Provider Gating**:
  - **`DartAnalysisServerService.java`**: Bypasses legacy `AnalysisService.HIGHLIGHTS` file subscriptions when `isLspHighlightingEnabled()` is active.
  - **`DartAnnotator.java`**: Skips legacy DAS highlight regions in `annotate()` when experimental LSP highlighting is enabled, allowing JetBrains' native LSP semantic tokens highlighter to handle syntax styling without conflicts or duplicate highlights.
- **LSP Method Registry (`LspMethod.kt`)**:
  - Registers `SEMANTIC_TOKENS_FULL("textDocument/semanticTokens/full", isExperimental = true, presentableName = "syntax highlighting")` so syntax highlighting is included under experimental LSP feature management.
- **Testing (`DartBridgeLspServerTest.kt`)**:
  - Added unit tests verifying:
    - Successful forwarding of `textDocument/semanticTokens/full` and deserialization of `SemanticTokens` data.
    - Graceful error handling on server error responses.
    - File type filtering in `shouldAskServerForSemanticTokens`.
    - Comprehensive mapping coverage of token types and modifiers in `DartLspSemanticTokensSupport.getTextAttributesKey()`.
- **Changelog**:
  - Updated `CHANGELOG.md` with syntax highlighting under Unreleased changes.

Fixes https://github.com/flutter/dart-intellij-third-party/issues/401
Part of https://github.com/flutter/dart-intellij-third-party/issues/207

---

### How to Manually Verify

1. **Launch Sandbox IDE**:
   Run the IDE sandbox using Gradle:
   ```bash
   ./gradlew clean prepareSandbox --no-build-cache && ./gradlew runIde
   ```
2. **Enable Experimental LSP Features**:
   - Open a Dart project.
   - Open **Settings / Preferences** (`Ctrl+Alt+S` on Linux/Windows, `Cmd+,` on macOS).
   - Navigate to **Languages & Frameworks → Dart**.
   - Ensure **Enable Dart support for the project** is checked with a valid SDK path.
   - Check **Enable experimental LSP-based features (..., syntax highlighting)** and click **Apply**.
3. **Verify Semantic Highlighting**:
   - Open a `.dart` file containing diverse language elements:
     - Classes, interfaces, type parameters, type aliases
     - Enums and enum constants
     - Static vs instance method declarations and references
     - Top-level vs local functions and getters
     - Static fields, instance fields, local variables, and parameters
     - Annotations (`@override`, custom annotations) and labels
     - Strings with escape sequences (`\n`, `\t`) and string interpolations
     - Documentation comments (`///`) and line comments (`//`)
   - Verify that all syntax elements are accurately and distinctively colored according to the active editor color scheme.
4. **Verify Non-Dart Files**:
   - Open non-Dart files (e.g. `.txt`, `.yaml`, `.json`) and verify that semantic token requests are not triggered for these files.
5. **Verify Fallback to Legacy DAS Highlighting**:
   - Return to **Settings → Languages & Frameworks → Dart**.
   - Uncheck **Enable experimental LSP-based features** and click **Apply**.
   - Verify that syntax highlighting seamlessly falls back to the legacy DAS annotator without IDE freezes, errors, or visual glitches.
6. **(Optional) Inspect LSP Traffic**:
   - Navigate to **Help → Diagnostic Tools → Debug Log Settings...** and add `#com.intellij.platform.dartlsp`.
   - Open/edit a Dart file and inspect `idea.log` (via **Help → Show Log in Files / Finder**) to confirm `textDocument/semanticTokens/full` JSON-RPC requests and responses are sent across the bridge.

---

### Automated UI & Feature Test Cases (Verified via Remote Robot Testing Bridge)

The following test cases were executed and verified in the live IntelliJ IDEA sandbox against the Dart LSP semantic tokens implementation:

| Test ID | Category / Feature | Tested Language Elements & Color Attributes | Verification Outcome |
|---|---|---|:---:|
| **TC-01** | Keywords & Control Flow | `class`, `extends`, `if`, `else`, `return`, `async`, `await`, `void` (`KEYWORD`) | :white_check_mark: Pass |
| **TC-02** | Class Declarations & Types | Class declarations, generic type parameters (`<T>`), type references (`CLASS`, `TYPE_PARAMETER`) | :white_check_mark: Pass |
| **TC-03** | Enums & Enum Constants | Enum declarations and member constants (`enum Status { pending }`) (`ENUM`, `ENUM_CONSTANT`) | :white_check_mark: Pass |
| **TC-04** | Constructors & Instantiation | Generative, named, `const`, and `factory` constructors (`CONSTRUCTOR`, `INSTANCE_CREATION`) | :white_check_mark: Pass |
| **TC-05** | Static vs Instance Methods | Static member functions (`Math.max`) vs instance method calls (`obj.run()`) (`STATIC_MEMBER_FUNCTION`, `INSTANCE_METHOD`) | :white_check_mark: Pass |
| **TC-06** | Functions & Local Closures | Top-level functions, nested local helper functions, and closures (`FUNCTION`, `LOCAL_FUNCTION`) | :white_check_mark: Pass |
| **TC-07** | Getters & Setters | Custom getter/setter accessors and static properties (`GETTER_DECLARATION`, `SETTER_DECLARATION`, `STATIC_GETTER`) | :white_check_mark: Pass |
| **TC-08** | Variables & Parameters | Local variables (`var`, `final`), instance fields, static fields, and parameter names (`LOCAL_VARIABLE`, `INSTANCE_FIELD`, `PARAMETER`) | :white_check_mark: Pass |
| **TC-09** | Dart 3 Patterns & Records | Sealed classes, switch expressions (`=> switch (shape) { ... }`), record types `(int, String)` (`KEYWORD`, `PATTERN`, `RECORD`) | :white_check_mark: Pass |
| **TC-10** | Annotations & Metadata | Standard annotations (`@override`, `@deprecated`) and custom class metadata (`ANNOTATION`) | :white_check_mark: Pass |
| **TC-11** | Strings & Escape Sequences | Single/multiline strings, valid escape tokens (`\n`, `\t`), and invalid escapes (`STRING`, `VALID_STRING_ESCAPE_TOKEN`) | :white_check_mark: Pass |
| **TC-12** | String Interpolation | Variable interpolations (`$name`) and complex expression interpolations (`${obj.calculate()}`) (`STRING_INTERPOLATION`) | :white_check_mark: Pass |
| **TC-13** | Comments & Doc Comments | Triple-slash doc comments (`///`), single-line comments (`//`), and block comments (`/* */`) (`DOC_COMMENT`, `LINE_COMMENT`) | :white_check_mark: Pass |
| **TC-14** | Numbers & Operators | Integer and double literals, arithmetic/logical operators, and boolean constants (`NUMBER`, `OPERATION_SIGN`) | :white_check_mark: Pass |
| **TC-15** | Extensions & Extension Types | `extension on Type` methods and Dart 3.3 `extension type Id(int i)` declarations (`EXTENSION`, `EXTENSION_TYPE`) | :white_check_mark: Pass |
| **TC-16** | Non-Dart File Filtering | Verified that `.yaml`, `.json`, and `.txt` files do not trigger semantic tokens requests | :white_check_mark: Pass |
| **TC-17** | Diagnostics & Error Stripes | Error highlighting markers, syntax error tooltips, and severity stripes (`ERROR`) | :white_check_mark: Pass |
| **TC-18** | Code Completion (`Ctrl+Space`) | Autocomplete lookup suggestions popup (`LookupImpl`) for Dart symbols and libraries | :white_check_mark: Pass |
| **TC-19** | Quick Fixes & Intentions | Intention actions discovery via `Alt+Enter` (`ShowIntentionActions`) | :white_check_mark: Pass |
| **TC-20** | Live Document Updates | Verified immediate semantic tokens re-computation upon dynamic document edits in active editor | :white_check_mark: Pass |

---

### Screenshots

| Test Case 01 Keywords_and_Control_Flow| Test Case 09 Patterns_and_Switch_Expressions| Test Case 17 Error_Diagnostics_Highlighting | Test Case 21 Autocomplete_Suggestions_Popup |
|---|---|---|---|
|<img width="1294" height="833" alt="TC01_Keywords_and_Control_Flow" src="https://github.com/user-attachments/assets/38fe01a3-efca-4379-a838-34e14ea4818e" />|<img width="1294" height="833" alt="TC09_Patterns_and_Switch_Expressions" src="https://github.com/user-attachments/assets/6b1c6eb1-5fd2-492e-bafc-776bb65b3978" />|<img width="1294" height="833" alt="TC17_Error_Diagnostics_Highlighting" src="https://github.com/user-attachments/assets/bba38098-233a-46b9-bba7-b1e7738a6def" />|<img width="1294" height="833" alt="TC21_Autocomplete_Suggestions_Popup" src="https://github.com/user-attachments/assets/d8cd41a6-88c1-4eb0-8223-ffd2c2a0216c" />|

---

### Checklist

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
