### PR TITLE
Add UserTag Support in VM Service Drivers

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/VmService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/VmService.java
@@ -82,7 +82,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 3;
+  public static final int versionMinor = 4;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/Instance.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/Instance.java
@@ -279,6 +279,18 @@ public class Instance extends Obj {
   }
 
   /**
+   * The label associated with a UserTag.
+   *
+   * Provided for instance kinds:
+   *  - UserTag
+   *
+   * Can return <code>null</code>.
+   */
+  public String getLabel() {
+    return getAsString("label");
+  }
+
+  /**
    * The number of (non-static) fields of a PlainInstance, or the length of a List, or the number
    * of associations in a Map, or the number of codeunits in a String, or the total number of
    * fields (positional and named) in a Record.

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/InstanceKind.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/InstanceKind.java
@@ -168,6 +168,11 @@ public enum InstanceKind {
   Uint8List,
 
   /**
+   * An instance of the Dart class UserTag.
+   */
+  UserTag,
+
+  /**
    * An instance of the Dart class WeakProperty.
    */
   WeakProperty,

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/InstanceRef.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/InstanceRef.java
@@ -119,6 +119,18 @@ public class InstanceRef extends ObjRef {
   }
 
   /**
+   * The label associated with a UserTag.
+   *
+   * Provided for instance kinds:
+   *  - UserTag
+   *
+   * Can return <code>null</code>.
+   */
+  public String getLabel() {
+    return getAsString("label");
+  }
+
+  /**
    * The number of (non-static) fields of a PlainInstance, or the length of a List, or the number
    * of associations in a Map, or the number of codeunits in a String, or the total number of
    * fields (positional and named) in a Record.

--- a/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverElementTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverElementTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package com.jetbrains.dart.vmService
+
+import com.google.gson.JsonObject
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.Instance
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.InstanceKind
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.InstanceRef
+import junit.framework.TestCase
+
+class VmServiceDriverElementTest : TestCase() {
+
+  fun testUserTagKindAndLabel() {
+    val json = JsonObject().apply {
+      addProperty("kind", "UserTag")
+      addProperty("label", "manual-test-tag")
+    }
+
+    val instanceRef = InstanceRef(json)
+    assertEquals(InstanceKind.UserTag, instanceRef.kind)
+    assertEquals("manual-test-tag", instanceRef.label)
+
+    val instance = Instance(json)
+    assertEquals(InstanceKind.UserTag, instance.kind)
+    assertEquals("manual-test-tag", instance.label)
+  }
+}


### PR DESCRIPTION


## Summary

  Upgrades the VM Service drivers from protocol 4.3 to 4.4 by:

  - Adding UserTag to InstanceKind.
  - Exposing the UserTag label through Instance and InstanceRef.
  - Updating the supported protocol version to 4.4.

  ## Testing

  - Added a unit test verifying that both Instance and InstanceRef decode the UserTag kind and label from VM Service JSON.
  - Existing VmServiceTest passes.
  - Manually debugged a Dart UserTag in the sandbox IDE and confirmed the VM payload contains kind: UserTag and label: manual-test-tag.

