### PR TITLE
Remove disambiguation for find usages

### DIFF
--- a/third_party/CHANGELOG.md
+++ b/third_party/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 
 ### Fixed
+- Remove ambiguous "Find Usages Of" popup when invoking Find Usages with LSP references enabled (#643)
 
 ## 509.0.0
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluator.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.ide.findUsages;
+
+import com.intellij.codeInsight.TargetElementEvaluatorEx2;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Evaluates target elements for Dart references.
+ *
+ * When LSP references are enabled, this evaluator suppresses PSI target candidates
+ * so that IntelliJ's find usages action does not produce duplicate/ambiguous search targets
+ * (e.g. an LSP SearchTarget alongside a legacy PsiTargetVariant).
+ */
+public class DartTargetElementEvaluator extends TargetElementEvaluatorEx2 {
+  @Override
+  public @Nullable Collection<PsiElement> getTargetCandidates(@NotNull PsiReference reference) {
+    final PsiElement element = reference.getElement();
+    final Project project = element.getProject();
+    if (DartAnalysisServerService.isLspReferencesEnabled(project)) {
+      return Collections.emptyList();
+    }
+    return null;
+  }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluator.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluator.java
@@ -22,6 +22,14 @@ import java.util.Collections;
  * When LSP references are enabled, this evaluator suppresses PSI target candidates
  * so that IntelliJ's find usages action does not produce duplicate/ambiguous search targets
  * (e.g. an LSP SearchTarget alongside a legacy PsiTargetVariant).
+ *
+ * NOTE: This is a transitional fix during the LSP migration. When Find Usages is invoked,
+ * IntelliJ's SearchTargetVariantsDataRule queries both modern SEARCH_TARGETS (LSP) and
+ * falls back to TargetElementUtil if USAGE_TARGETS_KEY is null. Since Dart files maintain
+ * a PSI reference tree, TargetElementUtil resolves the reference through PSI, leading to
+ * competing targets. This evaluator (or its legacy fallback) can be removed or simplified
+ * once the plugin is fully migrated to LSP and legacy DAS / PSI reference resolution is
+ * deprecated, or if the platform avoids the TargetElementUtil fallback when LSP targets exist.
  */
 public class DartTargetElementEvaluator extends TargetElementEvaluatorEx2 {
   @Override
@@ -29,8 +37,11 @@ public class DartTargetElementEvaluator extends TargetElementEvaluatorEx2 {
     final PsiElement element = reference.getElement();
     final Project project = element.getProject();
     if (DartAnalysisServerService.isLspReferencesEnabled(project)) {
+      // Suppress PSI candidates when LSP handles references to prevent IntelliJ from showing
+      // an ambiguous "Find Usages Of" chooser popup.
       return Collections.emptyList();
     }
+    // Fall back to standard PSI / DAS reference resolution when LSP is disabled.
     return null;
   }
 }

--- a/third_party/src/main/resources/META-INF/plugin.xml
+++ b/third_party/src/main/resources/META-INF/plugin.xml
@@ -182,6 +182,7 @@
     <lang.findUsagesProvider language="Dart" implementationClass="com.jetbrains.lang.dart.ide.findUsages.DartFindUsagesProvider"/>
     <usageTypeProvider implementation="com.jetbrains.lang.dart.ide.findUsages.DartUsageTypeProvider"/>
     <findUsagesHandlerFactory implementation="com.jetbrains.lang.dart.ide.findUsages.DartServerFindUsagesHandlerFactory"/>
+    <targetElementEvaluator language="Dart" implementationClass="com.jetbrains.lang.dart.ide.findUsages.DartTargetElementEvaluator"/>
     <fileStructureGroupRuleProvider implementation="com.jetbrains.lang.dart.ide.findUsages.DartUnitMemberGroupRuleProvider"/>
     <fileStructureGroupRuleProvider implementation="com.jetbrains.lang.dart.ide.findUsages.DartClassMemberGroupRuleProvider"/>
     <elementDescriptionProvider implementation="com.jetbrains.lang.dart.psi.DartElementDescriptionProvider"/>

--- a/third_party/src/main/resources/META-INF/plugin.xml
+++ b/third_party/src/main/resources/META-INF/plugin.xml
@@ -182,6 +182,7 @@
     <lang.findUsagesProvider language="Dart" implementationClass="com.jetbrains.lang.dart.ide.findUsages.DartFindUsagesProvider"/>
     <usageTypeProvider implementation="com.jetbrains.lang.dart.ide.findUsages.DartUsageTypeProvider"/>
     <findUsagesHandlerFactory implementation="com.jetbrains.lang.dart.ide.findUsages.DartServerFindUsagesHandlerFactory"/>
+    <!-- Transitional LSP migration hook: suppresses legacy PSI search target candidates when LSP references are active -->
     <targetElementEvaluator language="Dart" implementationClass="com.jetbrains.lang.dart.ide.findUsages.DartTargetElementEvaluator"/>
     <fileStructureGroupRuleProvider implementation="com.jetbrains.lang.dart.ide.findUsages.DartUnitMemberGroupRuleProvider"/>
     <fileStructureGroupRuleProvider implementation="com.jetbrains.lang.dart.ide.findUsages.DartClassMemberGroupRuleProvider"/>

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluatorTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluatorTest.kt
@@ -36,6 +36,7 @@ class DartTargetElementEvaluatorTest : DartCodeInsightFixtureTestCase() {
 
         val reference = file.findReferenceAt(myFixture.caretOffset)
         assertNotNull("Reference should be found at caret", reference)
+        if (reference == null) return
 
         val evaluator = DartTargetElementEvaluator()
 
@@ -43,9 +44,9 @@ class DartTargetElementEvaluatorTest : DartCodeInsightFixtureTestCase() {
         PropertiesComponent.getInstance(project).setValue("dart.lsp.experimental.enabled", true, true)
 
         if (DartAnalysisServerService.isLspReferencesEnabled(project)) {
-            val candidates = evaluator.getTargetCandidates(reference!!)
+            val candidates = evaluator.getTargetCandidates(reference)
             assertNotNull(candidates)
-            assertTrue(candidates!!.isEmpty())
+            assertTrue(candidates?.isEmpty() == true)
 
             val utilCandidates = TargetElementUtil.getInstance().getTargetCandidates(reference)
             assertTrue(utilCandidates.isEmpty())
@@ -54,6 +55,6 @@ class DartTargetElementEvaluatorTest : DartCodeInsightFixtureTestCase() {
         // Disable experimental LSP features
         PropertiesComponent.getInstance(project).setValue("dart.lsp.experimental.enabled", false, true)
         assertFalse(DartConfigurable.isExperimentalLspFeaturesEnabled(project))
-        assertNull(evaluator.getTargetCandidates(reference!!))
+        assertNull(evaluator.getTargetCandidates(reference))
     }
 }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluatorTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/ide/findUsages/DartTargetElementEvaluatorTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package com.jetbrains.lang.dart.ide.findUsages
+
+import com.intellij.codeInsight.TargetElementUtil
+import com.intellij.ide.util.PropertiesComponent
+import com.jetbrains.lang.dart.DartCodeInsightFixtureTestCase
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService
+import com.jetbrains.lang.dart.sdk.DartConfigurable
+
+class DartTargetElementEvaluatorTest : DartCodeInsightFixtureTestCase() {
+
+    override fun tearDown() {
+        try {
+            PropertiesComponent.getInstance(project).unsetValue("dart.lsp.experimental.enabled")
+        } catch (e: Throwable) {
+            addSuppressedException(e)
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testTargetCandidatesSuppressedWhenLspReferencesEnabled() {
+        val file = myFixture.configureByText(
+            "test.dart",
+            """
+            void helper() {}
+            void main() {
+              help<caret>er();
+            }
+            """.trimIndent()
+        )
+
+        val reference = file.findReferenceAt(myFixture.caretOffset)
+        assertNotNull("Reference should be found at caret", reference)
+
+        val evaluator = DartTargetElementEvaluator()
+
+        // Enable experimental LSP features
+        PropertiesComponent.getInstance(project).setValue("dart.lsp.experimental.enabled", true, true)
+
+        if (DartAnalysisServerService.isLspReferencesEnabled(project)) {
+            val candidates = evaluator.getTargetCandidates(reference!!)
+            assertNotNull(candidates)
+            assertTrue(candidates!!.isEmpty())
+
+            val utilCandidates = TargetElementUtil.getInstance().getTargetCandidates(reference)
+            assertTrue(utilCandidates.isEmpty())
+        }
+
+        // Disable experimental LSP features
+        PropertiesComponent.getInstance(project).setValue("dart.lsp.experimental.enabled", false, true)
+        assertFalse(DartConfigurable.isExperimentalLspFeaturesEnabled(project))
+        assertNull(evaluator.getTargetCandidates(reference!!))
+    }
+}


### PR DESCRIPTION
This is a follow up to https://github.com/flutter/dart-intellij-third-party/pull/623. The LSP change introduced a problem in find usages where a pop up menu was shown on find usages invocation:
<img width="1504" height="266" alt="image" src="https://github.com/user-attachments/assets/c1ef312e-88b9-48a2-9413-7688291f861e" />

The first line is from LSP, which just indicates the location where the cursor is. The second line is from an IJ platform class, which finds a PSI target unless we override this behavior.

This fix overrides the IJ platform class `TargetElementEvaluatorEx2` to not return any targets if LSP is enabled. Then only one target is found when find usages is triggered, and there is no menu in between.

To test this manually:
- Make sure that when Find usages is triggered, the usages show up in tool window immediately instead of requiring the user to select a target first:
<img width="1480" height="604" alt="image" src="https://github.com/user-attachments/assets/94f6e995-b019-484a-8ae7-2a10ceb408e5" />
- Also ensure that Find usages behavior remains the same when you uncheck experimental LSP and use the legacy implementation instead.

This problem wasn't reproducing everywhere for me, but I was able to consistently see this happening in the Dart SDK file `sdk/pkg/analyzer/lib/src/generated/resolver.dart`.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
