### PR TITLE
[ai] ignore provisioned dart-sdk

### DIFF
--- a/.aiconfig
+++ b/.aiconfig
@@ -7,4 +7,4 @@ project:
   generation_rules:
     - "When the user asks for a 'code review', always follow the instructions specified in `.agents/skills/code-review/SKILL.md`."
     - "NEVER edit or propose edits to upstream-synced files in `third_party/thirdPartySrc/platform-lsp/` or `third_party/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/` without an automated patch script. Custom client wrapper code under `third_party/thirdPartySrc/analysisServer/com/google/dart/server/` (such as `RequestUtilities.java`) is locally maintained and may be edited directly."
-    - "NEVER read, search, or index files inside `/dart-sdk/`."
+    - "NEVER read, search, or index files inside `dart-sdk/`."

--- a/.aiconfig
+++ b/.aiconfig
@@ -7,3 +7,4 @@ project:
   generation_rules:
     - "When the user asks for a 'code review', always follow the instructions specified in `.agents/skills/code-review/SKILL.md`."
     - "NEVER edit or propose edits to upstream-synced files in `third_party/thirdPartySrc/platform-lsp/` or `third_party/thirdPartySrc/analysisServer/org/dartlang/analysis/server/protocol/` without an automated patch script. Custom client wrapper code under `third_party/thirdPartySrc/analysisServer/com/google/dart/server/` (such as `RequestUtilities.java`) is locally maintained and may be edited directly."
+    - "NEVER read, search, or index files inside `/dart-sdk/`."

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -19,4 +19,5 @@ code_review:
     code_review: true
     # (DEFAULT) -- Note that this is disabled for flutter
     include_drafts: true
-ignore_patterns: []
+ignore_patterns:
+  - "dart-sdk/**"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 
 /.vscode
+/dart-sdk/


### PR DESCRIPTION
We provision a Dart SDK for testing but we don't want it confusing LLMs. These changes should ensure that agents steer clear and don't needlessly fill their context windows with the test SDK.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
