### PR TITLE
Migrate Structure View mapping to LSP documentSymbol (#633)

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/analyzer/DartAnalysisServerService.java
@@ -557,6 +557,10 @@ public final class DartAnalysisServerService implements Disposable {
 
     JsonObject textDocument = new JsonObject();
 
+    JsonObject documentSymbol = new JsonObject();
+    documentSymbol.addProperty("hierarchicalDocumentSymbolSupport", true);
+    textDocument.add("documentSymbol", documentSymbol);
+
     JsonObject definition = new JsonObject();
     definition.addProperty("linkSupport", true);
     textDocument.add("definition", definition);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/structure/DartLspStructureViewElement.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/structure/DartLspStructureViewElement.java
@@ -1,0 +1,87 @@
+package com.jetbrains.lang.dart.ide.structure;
+
+import com.intellij.ide.structureView.StructureViewTreeElement;
+import com.intellij.ide.structureView.impl.common.PsiTreeElementBase;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.platform.dartlsp.impl.features.documentSymbol.LspStructureViewSupport;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.containers.ContainerUtil;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Range;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+
+import javax.swing.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class DartLspStructureViewElement extends PsiTreeElementBase<PsiElement> {
+    private final @NotNull PsiFile myPsiFile;
+    private final @NotNull LspStructureViewSupport mySupport;
+    private final @NotNull DocumentSymbol mySymbol;
+    private final @NotNull String myPresentableText;
+
+    DartLspStructureViewElement(@NotNull PsiFile psiFile,
+                                @NotNull LspStructureViewSupport support,
+                                @NotNull DocumentSymbol symbol) {
+        super(findBestPsiElementForSymbol(psiFile, symbol));
+        myPsiFile = psiFile;
+        mySupport = support;
+        mySymbol = symbol;
+        myPresentableText = buildPresentableText(symbol);
+    }
+
+
+    @Override
+    public @NotNull Collection<StructureViewTreeElement> getChildrenBase() {
+        List<DocumentSymbol> children = mySymbol.getChildren();
+        if (children == null || children.isEmpty()) return Collections.emptyList();
+        return ContainerUtil.map(children, child -> new DartLspStructureViewElement(myPsiFile, mySupport, child));
+    }
+
+    @Override
+    public void navigate(boolean requestFocus) {
+        mySupport.navigate(mySymbol.getSelectionRange().getStart(), requestFocus);
+    }
+
+    @Override
+    public @NotNull String getPresentableText() {
+        return myPresentableText;
+    }
+
+    @Override
+    public @Nullable Icon getIcon(boolean open) {
+        return mySupport.getIcon(mySymbol);
+    }
+
+    private static @NotNull String buildPresentableText(@NotNull DocumentSymbol symbol) {
+        String detail = symbol.getDetail();
+        return symbol.getName() + (StringUtil.isNotEmpty(detail) ? detail : "" );
+    }
+
+    static @Nullable PsiElement findBestPsiElementForSymbol(@NotNull PsiFile psiFile, @NotNull DocumentSymbol symbol) {
+        TextRange range = getTextRange(psiFile, symbol.getRange());
+        if (range == null) return null;
+        return DartStructureViewElement.findBestPsiElementForRange(psiFile, range);
+    }
+
+    static @Nullable TextRange getTextRange(@NotNull PsiFile psiFile, @NotNull Range range) {
+        Document document = psiFile.getViewProvider().getDocument();
+        if (document == null) return null;
+        int startLine = range.getStart().getLine();
+        int endLine = range.getEnd().getLine();
+        if (startLine < 0 || startLine >= document.getLineCount() || endLine < 0 || endLine >= document.getLineCount()) {
+            return null;
+        }
+        int startOffset = Math.min(document.getLineStartOffset(startLine) + range.getStart().getCharacter(), document.getLineEndOffset(startLine));
+        int endOffset = Math.min(document.getLineStartOffset(endLine) + range.getEnd().getCharacter(), document.getLineEndOffset(endLine));
+        if (startOffset > endOffset) return null;
+        return TextRange.create(startOffset, endOffset);
+    }
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/structure/DartStructureViewElement.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/structure/DartStructureViewElement.java
@@ -137,25 +137,29 @@ final class DartStructureViewElement extends PsiTreeElementBase<PsiElement> {
     DartAnalysisServerService das = DartAnalysisServerService.getInstance(psiFile.getProject());
     int startOffset = das.getConvertedOffset(psiFile.getVirtualFile(), outline.getCodeOffset());
     int endOffset = das.getConvertedOffset(psiFile.getVirtualFile(), outline.getCodeOffset() + outline.getCodeLength());
-    TextRange outlineRange = TextRange.create(startOffset, endOffset);
+    return findBestPsiElementForRange(psiFile, TextRange.create(startOffset, endOffset));
+  }
 
-    PsiElement element = psiFile.findElementAt(startOffset);
-    while ((element instanceof PsiComment || element instanceof PsiWhiteSpace) && element.getTextRange().getEndOffset() < endOffset) {
-      PsiElement next = element.getNextSibling();
-      if (next != null) {
-        element = PsiTreeUtil.getDeepestFirst(next);
-      }
-      else {
-        break;
-      }
-    }
+  static @Nullable PsiElement findBestPsiElementForRange(@NotNull PsiFile psiFile, @NotNull TextRange outlineRange) {
+      int startOffset = outlineRange.getStartOffset();
+      int endOffset = outlineRange.getEndOffset();
+      PsiElement element = psiFile.findElementAt(startOffset);
 
-    if (element != null) {
-      while (!(element instanceof PsiFile) && element.getParent() != null && outlineRange.contains(element.getParent().getTextRange())) {
-        element = element.getParent();
+      while ((element instanceof PsiComment || element instanceof PsiWhiteSpace) && element.getTextRange().getEndOffset() < endOffset) {
+          PsiElement next = element.getNextSibling();
+          if (next != null) {
+              element = PsiTreeUtil.getDeepestFirst(next);
+          } else {
+              break;
+          }
       }
-    }
 
-    return element;
+      if (element != null) {
+          while (!(element instanceof PsiFile) && element.getParent() != null && outlineRange.contains(element.getParent().getTextRange())) {
+              element = element.getParent();
+          }
+      }
+
+      return element;
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/structure/DartStructureViewModel.java
@@ -7,12 +7,16 @@ import com.intellij.ide.structureView.TextEditorBasedStructureViewModel;
 import com.intellij.ide.structureView.impl.common.PsiTreeElementBase;
 import com.intellij.ide.util.treeView.smartTree.Sorter;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.dartlsp.impl.features.documentSymbol.LspStructureViewSupport;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.analyzer.DartServerData;
 import org.dartlang.analysis.server.protocol.Outline;
+import org.eclipse.lsp4j.DocumentSymbol;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -52,15 +56,20 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
 
   @Override
   public @Nullable PsiElement getCurrentEditorElement() {
-    // Note: this should return an object of type PsiElement to be compatible with the Context Info (alt+q) action.
-    if (getEditor() == null) return null;
+      // Note: this should return an object of type PsiElement to be compatible with the Context Info (alt+q) action.
+      if (getEditor() == null) return null;
+      final LspStructureViewSupport support = LspStructureViewSupport.find(getPsiFile().getProject(), getPsiFile().getVirtualFile());
+      if (support != null) {
+          final DocumentSymbol result = findDeepestSymbolForOffset(getEditor().getCaretModel().getOffset(), support.getDocumentSymbols());
+          return result != null ? DartLspStructureViewElement.findBestPsiElementForSymbol(getPsiFile(), result) : null;
+      }
 
-    final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getPsiFile().getProject());
-    final Outline outline = service.getOutline(getPsiFile().getVirtualFile());
-    if (outline == null) return null;
+      final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getPsiFile().getProject());
+      final Outline outline = service.getOutline(getPsiFile().getVirtualFile());
+      if (outline == null) return null;
 
-    final Outline result = findDeepestOutlineForOffset(getEditor().getCaretModel().getOffset(), outline);
-    return DartStructureViewElement.findBestPsiElementForOutline(getPsiFile(), result);
+      final Outline result = findDeepestOutlineForOffset(getEditor().getCaretModel().getOffset(), outline);
+      return DartStructureViewElement.findBestPsiElementForOutline(getPsiFile(), result);
   }
 
   private @NotNull Outline findDeepestOutlineForOffset(final int offset, final @NotNull Outline outline) {
@@ -88,7 +97,30 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
     return outline;
   }
 
-  @Override
+    private @Nullable DocumentSymbol findDeepestSymbolForOffset(final int offset, final @Nullable List<DocumentSymbol> symbols) {
+        if (symbols == null || symbols.isEmpty()) return null;
+        for (int i = 0; i < symbols.size(); i++) {
+            DocumentSymbol symbol = symbols.get(i);
+            TextRange range = DartLspStructureViewElement.getTextRange(getPsiFile(), symbol.getRange());
+            if (range != null) {
+                if (offset >= range.getStartOffset() && offset <= range.getEndOffset()) {
+                    DocumentSymbol childResult = findDeepestSymbolForOffset(offset, symbol.getChildren());
+                    return childResult != null ? childResult : symbol;
+                }
+                if (offset > range.getEndOffset() && i != symbols.size() - 1) {
+                    DocumentSymbol next = symbols.get(i + 1);
+                    TextRange nextRange = DartLspStructureViewElement.getTextRange(getPsiFile(), next.getRange());
+                    if (nextRange != null && offset < nextRange.getStartOffset()) {
+                        return next;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+
+    @Override
   public boolean isAlwaysShowsPlus(StructureViewTreeElement element) {
     return false;
   }
@@ -114,10 +146,15 @@ class DartStructureViewModel extends TextEditorBasedStructureViewModel implement
 
     @Override
     public @NotNull Collection<StructureViewTreeElement> getChildrenBase() {
-      final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getValue().getProject());
-      final Outline outline = service.getOutline(getValue().getVirtualFile());
-      return outline != null ? Arrays.asList(new DartStructureViewElement(getValue(), outline).getChildren())
-                             : Collections.emptyList();
+        final LspStructureViewSupport support = LspStructureViewSupport.find(getValue().getProject(), getValue().getVirtualFile());
+        if (support != null) {
+            return ContainerUtil.map(support.getDocumentSymbols(),
+                    documentSymbol -> new DartLspStructureViewElement(getValue(), support, documentSymbol));
+        }
+        final DartAnalysisServerService service = DartAnalysisServerService.getInstance(getValue().getProject());
+        final Outline outline = service.getOutline(getValue().getVirtualFile());
+        return outline != null ? Arrays.asList(new DartStructureViewElement(getValue(), outline).getChildren())
+                : Collections.emptyList();
     }
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServer.kt
@@ -34,6 +34,8 @@ import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.DocumentHighlightParams
+import org.eclipse.lsp4j.DocumentSymbol
+import org.eclipse.lsp4j.DocumentSymbolParams
 import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.HoverParams
 import org.eclipse.lsp4j.InitializeParams
@@ -43,6 +45,7 @@ import org.eclipse.lsp4j.LocationLink
 import org.eclipse.lsp4j.PublishDiagnosticsParams
 import org.eclipse.lsp4j.ReferenceParams
 import org.eclipse.lsp4j.ServerCapabilities
+import org.eclipse.lsp4j.SymbolInformation
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
 import org.eclipse.lsp4j.jsonrpc.messages.Either
@@ -244,6 +247,7 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
             setTypeHierarchyProvider(true)
             setCallHierarchyProvider(true)
             setReferencesProvider(true)
+            setDocumentSymbolProvider(true)
             // Add other capabilities as we support them.
         }
         return CompletableFuture.completedFuture(InitializeResult(capabilities))
@@ -297,6 +301,15 @@ class DartBridgeLspServer(private val project: Project) : DartLanguageServer, Te
 
     override fun diagnosticServer(): CompletableFuture<DiagnosticServerResult> {
         return forwardRequest("dart/diagnosticServer", null, DiagnosticServerResult::class.java)
+    }
+
+    override fun documentSymbol(
+        params: DocumentSymbolParams
+    ): CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> {
+        val type = object: TypeToken<List<DocumentSymbol>>() {}.type
+        return forwardRequest<List<DocumentSymbol>>("textDocument/documentSymbol", params, type).thenApply { symbols ->
+            symbols?.map { Either.forRight<SymbolInformation, DocumentSymbol>(it) } ?: emptyList()
+        }
     }
 
     // Implement other TextDocumentService methods as needed, returning unsupported or forwarding.

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/DartLspServerDescriptor.kt
@@ -27,7 +27,9 @@ import com.intellij.platform.dartlsp.api.customization.LspDocumentHighlightsCust
 import com.intellij.platform.dartlsp.api.customization.LspDocumentHighlightsDisabled
 import com.intellij.platform.dartlsp.api.customization.LspDocumentHighlightsSupport
 import com.intellij.platform.dartlsp.api.customization.LspDocumentLinkDisabled
+import com.intellij.platform.dartlsp.api.customization.LspDocumentSymbolCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspDocumentSymbolDisabled
+import com.intellij.platform.dartlsp.api.customization.LspDocumentSymbolSupport
 import com.intellij.platform.dartlsp.api.customization.LspFindReferencesCustomizer
 import com.intellij.platform.dartlsp.api.customization.LspFindReferencesDisabled
 import com.intellij.platform.dartlsp.api.customization.LspFindReferencesSupport
@@ -142,7 +144,12 @@ class DartLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor
                 LspDocumentHighlightsDisabled
             }
         override val signatureHelpCustomizer = LspSignatureHelpDisabled
-        override val documentSymbolCustomizer = LspDocumentSymbolDisabled
+        override val documentSymbolCustomizer: LspDocumentSymbolCustomizer
+            get() = if (DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {
+                LspDocumentSymbolSupport()
+            } else {
+                LspDocumentSymbolDisabled
+            }
         override val workspaceSymbolCustomizer = LspWorkspaceSymbolDisabled
         override val callHierarchyCustomizer: LspCallHierarchyCustomizer
             get() = if (DartConfigurable.isExperimentalLspFeaturesEnabled(project)) {

--- a/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/lsp/LspMethod.kt
@@ -17,7 +17,8 @@ enum class LspMethod(
     INITIALIZE("initialize"),
     SHUTDOWN("shutdown"),
     TYPE_DEFINITION("textDocument/typeDefinition", isExperimental = false),
-    REFERENCES("textDocument/references", isExperimental = true, presentableName = "references");
+    REFERENCES("textDocument/references", isExperimental = true, presentableName = "references"),
+    DOCUMENT_SYMBOL("textDocument/documentSymbol", isExperimental = true, presentableName = "document symbols");
 
     companion object {
         fun fromMethod(method: String): LspMethod? = entries.find { it.method == method }

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartBridgeLspServerTest.kt
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.CallHierarchyOutgoingCallsParams
 import org.eclipse.lsp4j.CallHierarchyPrepareParams
 import org.eclipse.lsp4j.DocumentHighlightKind
 import org.eclipse.lsp4j.DocumentHighlightParams
+import org.eclipse.lsp4j.DocumentSymbolParams
 import org.eclipse.lsp4j.HoverParams
 import org.eclipse.lsp4j.MessageActionItem
 import org.eclipse.lsp4j.MessageParams
@@ -769,6 +770,70 @@ class DartBridgeLspServerTest : DartCodeInsightFixtureTestCase() {
         assertEquals(4, result[0].range.start.character)
         assertEquals(0, result[0].range.end.line)
         assertEquals(10, result[0].range.end.character)
+    }
+
+    fun testDocumentSymbolRequest() {
+        val params = DocumentSymbolParams(TextDocumentIdentifier("file:///test.dart"))
+        val future = bridgeServer.documentSymbol(params)
+
+        val jsonObject = capturedRequests.find { it.get("method")?.asString == "lsp.handle" }
+        assertNotNull("An lsp.handle request should be sent to DAS", jsonObject)
+
+        val lspMessage = jsonObject!!.getAsJsonObject("params").getAsJsonObject("lspMessage")
+        assertEquals("textDocument/documentSymbol", lspMessage.get("method").asString)
+
+        val responseJson = """
+                {
+                  "id": "123",
+                  "result": {
+                    "lspResponse": {
+                      "jsonrpc": "2.0",
+                      "id": "123",
+                      "result": [
+                        {
+                          "name": "MyClass",
+                          "kind": 5,
+                          "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 4, "character": 1 }
+                          },
+                          "selectionRange": {
+                            "start": { "line": 0, "character": 6 },
+                            "end": { "line": 0, "character": 13 }
+                          },
+                          "children": [
+                            {
+                              "name": "myMethod",
+                              "detail": "(String name)",
+                              "kind": 6,
+                              "range": {
+                                "start": { "line": 1, "character": 2 },
+                                "end": { "line": 3, "character": 3 }
+                              },
+                              "selectionRange": {
+                                "start": { "line": 1, "character": 7 },
+                                "end": { "line": 1, "character": 15 }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+            """.trimIndent()
+
+        capturedListener.onResponse(responseJson)
+
+        val result = future.get(5, TimeUnit.SECONDS)
+        assertNotNull(result)
+        assertEquals(1, result.size)
+        val rootSymbol = result[0].right
+        assertEquals("MyClass", rootSymbol.name)
+        assertEquals(SymbolKind.Class, rootSymbol.kind)
+        assertEquals(1, rootSymbol.children.size)
+        assertEquals("myMethod", rootSymbol.children[0].name)
+        assertEquals("(String name)", rootSymbol.children[0].detail)
     }
 
     fun testIsDartSdkVersionSufficientForLspReferences() {

--- a/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartLspExperimentalFeaturesTest.java
+++ b/third_party/src/test/java/com/jetbrains/lang/dart/lsp/DartLspExperimentalFeaturesTest.java
@@ -40,6 +40,7 @@ public class DartLspExperimentalFeaturesTest extends CodeInsightFixtureTestCase 
     assertFalse(LspMethod.TYPE_DEFINITION.isExperimental());
     assertTrue(LspMethod.DEFINITION.isExperimental());
     assertTrue(LspMethod.DOCUMENT_HIGHLIGHT.isExperimental());
+    assertTrue(LspMethod.DOCUMENT_SYMBOL.isExperimental());
 
     assertFalse(LspMethod.Companion.getExperimentalFeatures().contains(LspMethod.DIAGNOSTIC_SERVER));
     assertFalse(LspMethod.Companion.getExperimentalFeatures().contains(LspMethod.HOVER));


### PR DESCRIPTION
Migrates the Dart Structure View (`Alt+7` / **View > Tool Windows > Structure**) from the legacy Dart Analysis Server `Outline` notification to LSP
  `textDocument/documentSymbol` when experimental LSP features are enabled.

This fixes #633

## Key Changes
- **DAS Handshake Capability (`DartAnalysisServerService.java`)**:
- Added `textDocument.documentSymbol.hierarchicalDocumentSymbolSupport: true` in `buildLspCapabilities()`. Without this capability advertised, the Dart Analysis Server returns flat `SymbolInformation[]` instead of nested hierarchical `DocumentSymbol[]` trees.
- **LSP Bridge & Descriptor (`DartBridgeLspServer.kt`, `DartLspServerDescriptor.kt`, `LspMethod.kt`)**:
  - Registered `DOCUMENT_SYMBOL` (`textDocument/documentSymbol`) in `LspMethod` as an experimental feature.
  - Declared `setDocumentSymbolProvider(true)` in `DartBridgeLspServer.initialize()` and forwarded `textDocument/documentSymbol` requests to DAS.
  - Enabled `LspDocumentSymbolSupport()` in `DartLspServerDescriptor.documentSymbolCustomizer` when experimental LSP features are enabled.
  - *(Bonus)*: Enabling `documentSymbolCustomizer` also activates `LspFileBreadcrumbsCollector`, providing LSP-backed **Breadcrumbs** and **Sticky Lines** in the editor.
- **Structure View Mapping (`DartStructureViewModel.java`, `DartLspStructureViewElement.java`, `DartStructureViewElement.java`)**:
  - Created `DartLspStructureViewElement` to map `DocumentSymbol` trees into IntelliJ `StructureViewTreeElement` nodes (preserving presentable names, parameter signatures
  from `detail`, icons, navigation, and `PsiElement` resolution for `Alt+Q` / editor selection sync).
  - Updated `DartStructureViewModel` (`getChildrenBase()` and `getCurrentEditorElement()`) to use `LspStructureViewSupport` when available and fall back to legacy `Outline` otherwise.

## Testing
- **Automated Tests**:
  - Added `testDocumentSymbolRequest()` in `DartBridgeLspServerTest.kt` verifying `textDocument/documentSymbol` request forwarding and hierarchical `DocumentSymbol` deserialization.
  - Updated `DartLspExperimentalFeaturesTest.java` to assert `LspMethod.DOCUMENT_SYMBOL.isExperimental()`.
- **Manual Verification**:
  - Verified the Structure tool window (`Alt+7`) renders classes, constructors, fields, and methods with parameter signatures.
  - Verified double-clicking nodes navigates to the symbol in the editor.
  - Verified "Always Select Opened Element" (Autoscroll from Source) highlights the active element in the Structure tree as the editor caret moves.

## Manual Testing
Here is how you can manually verify the LSP Structure View in the sandbox IDE:
1. **Launch the Sandbox IDE** (`./gradlew runIde`)
2. **Verify Experimental LSP is Enabled**
    1. Open a Dart project (like your dart_console_test project) and open a .dart file.
    2. Go to Settings (Ctrl+Alt+S) > Languages & Frameworks > Dart.
    3. Ensure "Use experimental LSP features" is checked.

3. **Open the Structure Tool Window**
    1. Press Alt+7 (or go to __View > Tool Windows > Structure__).
    2. Check the tree displayed for your .dart file:
        • Tree Hierarchy: Classes should appear as root nodes, with their constructors, fields, and methods (including parameter signatures like calculate() or speak()) nested underneath.
        • Navigation (__Tree → Editor__): Double-click (or single-click with Autoscroll to Source enabled) any method or field in the Structure tool window and confirm the editor caret jumps straight to that declaration's name.
        • Editor Sync (__Editor → Tree__): Enable "Always Select Opened Element" (the target/crosshair icon in the Structure window toolbar), move your cursor between different methods or classes in the editor, and verify the Structure tree automatically highlights the active element.
4. **Bonus Visual Confirmation (Breadcrumbs & Sticky Lines)**
    Because enabling `documentSymbolCustomizer` in `DartLspServerDescriptor` also activates LspFileBreadcrumbsCollector:
    • Look at the Breadcrumbs bar at the bottom of the editor as you place your caret inside a class or method (e.g., Animal > speak)—it is now powered by LSP textDocument/documentSymbol.
    • If you scroll down inside a long class or function, IntelliJ's Sticky Lines at the top of the editor will also use the LSP document symbols.

---

Review the contribution guidelines below:

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
