### PR TITLE
Restore class and method grouping for LSP Find Usages

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartClassMemberGroupingRule.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartClassMemberGroupingRule.java
@@ -19,6 +19,9 @@ public final class DartClassMemberGroupingRule extends SingleParentUsageGrouping
   protected @Nullable UsageGroup getParentGroupFor(@NotNull Usage usage, UsageTarget @NotNull [] targets) {
     PsiElement psiElement = usage instanceof PsiElementUsage ? ((PsiElementUsage)usage).getElement() : null;
     if (psiElement == null || psiElement.getLanguage() != DartLanguage.INSTANCE) return null;
+    if (psiElement instanceof com.intellij.psi.PsiFile && usage instanceof com.intellij.usages.UsageInfo2UsageAdapter adapter) {
+      psiElement = psiElement.findElementAt(adapter.getUsageInfo().getNavigationOffset());
+    }
 
     // todo Docs are not parsed perfectly and doc comment may be not a child of the corresponding function. Related to comment for DartDocUtil.getDocumentationText
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartClassMemberGroupingRule.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartClassMemberGroupingRule.java
@@ -3,8 +3,10 @@ package com.jetbrains.lang.dart.ide.findUsages;
 
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.usages.Usage;
 import com.intellij.usages.UsageGroup;
+import com.intellij.usages.UsageInfo2UsageAdapter;
 import com.intellij.usages.UsageTarget;
 import com.intellij.usages.rules.PsiElementUsage;
 import com.intellij.usages.rules.SingleParentUsageGroupingRule;
@@ -19,7 +21,7 @@ public final class DartClassMemberGroupingRule extends SingleParentUsageGrouping
   protected @Nullable UsageGroup getParentGroupFor(@NotNull Usage usage, UsageTarget @NotNull [] targets) {
     PsiElement psiElement = usage instanceof PsiElementUsage ? ((PsiElementUsage)usage).getElement() : null;
     if (psiElement == null || psiElement.getLanguage() != DartLanguage.INSTANCE) return null;
-    if (psiElement instanceof com.intellij.psi.PsiFile && usage instanceof com.intellij.usages.UsageInfo2UsageAdapter adapter) {
+    if (psiElement instanceof PsiFile && usage instanceof UsageInfo2UsageAdapter adapter) {
       psiElement = psiElement.findElementAt(adapter.getUsageInfo().getNavigationOffset());
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartUnitMemberUsageGroupingRule.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartUnitMemberUsageGroupingRule.java
@@ -3,8 +3,10 @@ package com.jetbrains.lang.dart.ide.findUsages;
 
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.usages.Usage;
 import com.intellij.usages.UsageGroup;
+import com.intellij.usages.UsageInfo2UsageAdapter;
 import com.intellij.usages.UsageTarget;
 import com.intellij.usages.rules.PsiElementUsage;
 import com.intellij.usages.rules.SingleParentUsageGroupingRule;
@@ -19,7 +21,7 @@ public class DartUnitMemberUsageGroupingRule extends SingleParentUsageGroupingRu
   protected @Nullable UsageGroup getParentGroupFor(@NotNull Usage usage, UsageTarget @NotNull [] targets) {
     PsiElement psiElement = usage instanceof PsiElementUsage ? ((PsiElementUsage)usage).getElement() : null;
     if (psiElement == null || psiElement.getLanguage() != DartLanguage.INSTANCE) return null;
-    if (psiElement instanceof com.intellij.psi.PsiFile && usage instanceof com.intellij.usages.UsageInfo2UsageAdapter adapter) {
+    if (psiElement instanceof PsiFile && usage instanceof UsageInfo2UsageAdapter adapter) {
       psiElement = psiElement.findElementAt(adapter.getUsageInfo().getNavigationOffset());
     }
 

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartUnitMemberUsageGroupingRule.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/findUsages/DartUnitMemberUsageGroupingRule.java
@@ -19,6 +19,9 @@ public class DartUnitMemberUsageGroupingRule extends SingleParentUsageGroupingRu
   protected @Nullable UsageGroup getParentGroupFor(@NotNull Usage usage, UsageTarget @NotNull [] targets) {
     PsiElement psiElement = usage instanceof PsiElementUsage ? ((PsiElementUsage)usage).getElement() : null;
     if (psiElement == null || psiElement.getLanguage() != DartLanguage.INSTANCE) return null;
+    if (psiElement instanceof com.intellij.psi.PsiFile && usage instanceof com.intellij.usages.UsageInfo2UsageAdapter adapter) {
+      psiElement = psiElement.findElementAt(adapter.getUsageInfo().getNavigationOffset());
+    }
 
     // todo Docs are not parsed perfectly and doc comment may be not a child of the corresponding function. Related to comment for DartDocUtil.getDocumentationText
 


### PR DESCRIPTION
Restores the class, method, and function grouping hierarchy in the **Find tool window (`Alt+F7`)** and **Show Usages popup (`Ctrl+Alt+F7`)** when LSP Find Usages (`textDocument/references`) is enabled.

Issue: #651 Find usages no longer shows details of class, methods

## Root Cause
When `LspUsageSearcher` emits references via `PsiUsage.textUsage(resultPsiFile, resultRange)`, IntelliJ's `PsiUsage2UsageInfo` constructs `UsageInfo` with `element = resultPsiFile` (the top-level `DartFile`) rather than the leaf `PsiElement` at the reference offset.
    
When `DartClassMemberGroupingRule` and `DartUnitMemberUsageGroupingRule` inspect each usage:
```java
PsiElement psiElement = usage instanceof PsiElementUsage ? ((PsiElementUsage)usage).getElement() : null;
```
psiElement evaluates to DartFile. Because the parent of DartFile is PsiDirectory, walking up `psiElement.getParent()` never visits the enclosing `DartComponent` (class or method), causing usages to appear flat under the file name without their enclosing class or method name.

## Solution

Since Dart files still maintain a local PSI tree in IntelliJ when LSP is active, resolve the leaf `PsiElement` at `adapter.getUsageInfo().getNavigationOffset()` when `psiElement instanceof PsiFile` in both `DartClassMemberGroupingRule` and `DartUnitMemberUsageGroupingRule`:
```java
if (psiElement instanceof com.intellij.psi.PsiFile && usage instanceof com.intellij.usages.UsageInfo2UsageAdapter adapter) {
  psiElement = psiElement.findElementAt(adapter.getUsageInfo().getNavigationOffset());
}
```
## Verification
- Tested with `./gradlew runIde`.
- Open/Create a Dart project with classes/subclasses (optional: download attached project - [DartConsoleTest.zip](https://github.com/user-attachments/files/31982165/DartConsoleTest.zip))
- Invoked Find Usages (Alt+F7) on method call sites and confirmed usages are grouped under their enclosing Class ((c) Dog) and Method/Function ((m) speak / (λ) main).


## Screenshots
<img width="640" height="360" alt="Screenshot From 2026-09-09 00-00-58" src="https://github.com/user-attachments/assets/b4d29b85-6592-4ef1-ad98-e496d15bd289" />


---

Review the contribution guidelines below:

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [X] I've included the required information in the description above.
- [ ] I've updated `CHANGELOG.md` if appropriate (i.e. user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See the [Flutter organization contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
