### PR TITLE
Add PerfettoTimeline Support in VM Service Drivers

### DIFF
--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/VmService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/VmService.java
@@ -82,7 +82,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 4;
+  public static final int versionMinor = 5;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.
@@ -438,6 +438,30 @@ public class VmService extends VmServiceBase {
   }
 
   /**
+   * The [getPerfettoVMTimeline] RPC is used to retrieve an object which contains a VM timeline
+   * trace represented in Perfetto's proto format. See PerfettoTimeline for a detailed description
+   * of the response.
+   * @param timeOriginMicros This parameter is optional and may be null.
+   * @param timeExtentMicros This parameter is optional and may be null.
+   */
+  public void getPerfettoVMTimeline(Integer timeOriginMicros, Integer timeExtentMicros, PerfettoTimelineConsumer consumer) {
+    final JsonObject params = new JsonObject();
+    if (timeOriginMicros != null) params.addProperty("timeOriginMicros", timeOriginMicros);
+    if (timeExtentMicros != null) params.addProperty("timeExtentMicros", timeExtentMicros);
+    request("getPerfettoVMTimeline", params, consumer);
+  }
+
+  /**
+   * The [getPerfettoVMTimeline] RPC is used to retrieve an object which contains a VM timeline
+   * trace represented in Perfetto's proto format. See PerfettoTimeline for a detailed description
+   * of the response.
+   */
+  public void getPerfettoVMTimeline(PerfettoTimelineConsumer consumer) {
+    final JsonObject params = new JsonObject();
+    request("getPerfettoVMTimeline", params, consumer);
+  }
+
+  /**
    * The [getPorts] RPC is used to retrieve the list of <code>ReceivePort</code>ReceivePort
    * instances for a given isolate.
    */
@@ -551,7 +575,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [getVMTimeline] RPC is used to retrieve an object which contains VM timeline events.
+   * The [getVMTimeline] RPC is used to retrieve an object which contains VM timeline events. See
+   * Timeline for a detailed description of the response.
    * @param timeOriginMicros This parameter is optional and may be null.
    * @param timeExtentMicros This parameter is optional and may be null.
    */
@@ -563,7 +588,8 @@ public class VmService extends VmServiceBase {
   }
 
   /**
-   * The [getVMTimeline] RPC is used to retrieve an object which contains VM timeline events.
+   * The [getVMTimeline] RPC is used to retrieve an object which contains VM timeline events. See
+   * Timeline for a detailed description of the response.
    */
   public void getVMTimeline(TimelineConsumer consumer) {
     final JsonObject params = new JsonObject();
@@ -1259,6 +1285,12 @@ public class VmService extends VmServiceBase {
       }
       if (responseType.equals("Success")) {
         ((PauseConsumer) consumer).received(new Success(json));
+        return;
+      }
+    }
+    if (consumer instanceof PerfettoTimelineConsumer) {
+      if (responseType.equals("PerfettoTimeline")) {
+        ((PerfettoTimelineConsumer) consumer).received(new PerfettoTimeline(json));
         return;
       }
     }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/VmService.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/VmService.java
@@ -444,7 +444,7 @@ public class VmService extends VmServiceBase {
    * @param timeOriginMicros This parameter is optional and may be null.
    * @param timeExtentMicros This parameter is optional and may be null.
    */
-  public void getPerfettoVMTimeline(Integer timeOriginMicros, Integer timeExtentMicros, PerfettoTimelineConsumer consumer) {
+  public void getPerfettoVMTimeline(Long timeOriginMicros, Long timeExtentMicros, PerfettoTimelineConsumer consumer) {
     final JsonObject params = new JsonObject();
     if (timeOriginMicros != null) params.addProperty("timeOriginMicros", timeOriginMicros);
     if (timeExtentMicros != null) params.addProperty("timeExtentMicros", timeExtentMicros);

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/consumer/PerfettoTimelineConsumer.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/consumer/PerfettoTimelineConsumer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.consumer;
+
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.PerfettoTimeline;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface PerfettoTimelineConsumer extends Consumer {
+
+  void received(PerfettoTimeline response);
+}

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/PerfettoTimeline.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/PerfettoTimeline.java
@@ -28,15 +28,15 @@ public class PerfettoTimeline extends Response {
   /**
    * The duration of time covered by the trace.
    */
-  public int getTimeExtentMicros() {
-    return getAsInt("timeExtentMicros");
+  public long getTimeExtentMicros() {
+    return json.get("timeExtentMicros") == null ? -1 : json.get("timeExtentMicros").getAsLong();
   }
 
   /**
    * The start of the period of time covered by the trace.
    */
-  public int getTimeOriginMicros() {
-    return getAsInt("timeOriginMicros");
+  public long getTimeOriginMicros() {
+    return json.get("timeOriginMicros") == null ? -1 : json.get("timeOriginMicros").getAsLong();
   }
 
   /**

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/PerfettoTimeline.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/PerfettoTimeline.java
@@ -16,44 +16,33 @@ package com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.ser
 import com.google.gson.JsonObject;
 
 /**
- * A {@link Flag} represents a single VM command line flag.
+ * See getPerfettoVMTimeline;
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class Flag extends Element {
+public class PerfettoTimeline extends Response {
 
-  public Flag(JsonObject json) {
+  public PerfettoTimeline(JsonObject json) {
     super(json);
   }
 
   /**
-   * A description of the flag.
+   * The duration of time covered by the trace.
    */
-  public String getComment() {
-    return getAsString("comment");
+  public int getTimeExtentMicros() {
+    return getAsInt("timeExtentMicros");
   }
 
   /**
-   * Has this flag been modified from its default setting?
+   * The start of the period of time covered by the trace.
    */
-  public boolean getModified() {
-    return getAsBoolean("modified");
+  public int getTimeOriginMicros() {
+    return getAsInt("timeOriginMicros");
   }
 
   /**
-   * The name of the flag.
+   * A Base64 string representing the requested timeline trace in Perfetto's proto format.
    */
-  public String getName() {
-    return getAsString("name");
-  }
-
-  /**
-   * The value of this flag as a string.
-   *
-   * If this property is absent, then the value of the flag was nullptr.
-   *
-   * Can return <code>null</code>.
-   */
-  public String getValueAsString() {
-    return getAsString("valueAsString");
+  public String getTrace() {
+    return getAsString("trace");
   }
 }

--- a/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/Timeline.java
+++ b/third_party/src/main/java/com/jetbrains/lang/dart/ide/runner/server/vmService/vmServiceDrivers/service/element/Timeline.java
@@ -16,6 +16,9 @@ package com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.ser
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+/**
+ * See getVMTimeline;
+ */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class Timeline extends Response {
 

--- a/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverElementTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverElementTest.kt
@@ -33,13 +33,13 @@ class VmServiceDriverElementTest : TestCase() {
   fun testPerfettoTimeline() {
     val json = JsonObject().apply {
       addProperty("trace", "AA==")
-      addProperty("timeOriginMicros", 100)
-      addProperty("timeExtentMicros", 250)
+      addProperty("timeOriginMicros", 3_000_000_000L)
+      addProperty("timeExtentMicros", 4_000_000_000L)
     }
 
     val timeline = PerfettoTimeline(json)
     assertEquals("AA==", timeline.trace)
-    assertEquals(100, timeline.timeOriginMicros)
-    assertEquals(250, timeline.timeExtentMicros)
+    assertEquals(3_000_000_000L, timeline.timeOriginMicros)
+    assertEquals(4_000_000_000L, timeline.timeExtentMicros)
   }
 }

--- a/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverElementTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverElementTest.kt
@@ -10,6 +10,7 @@ import com.google.gson.JsonObject
 import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.Instance
 import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.InstanceKind
 import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.InstanceRef
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.PerfettoTimeline
 import junit.framework.TestCase
 
 class VmServiceDriverElementTest : TestCase() {
@@ -27,5 +28,18 @@ class VmServiceDriverElementTest : TestCase() {
     val instance = Instance(json)
     assertEquals(InstanceKind.UserTag, instance.kind)
     assertEquals("manual-test-tag", instance.label)
+  }
+
+  fun testPerfettoTimeline() {
+    val json = JsonObject().apply {
+      addProperty("trace", "AA==")
+      addProperty("timeOriginMicros", 100)
+      addProperty("timeExtentMicros", 250)
+    }
+
+    val timeline = PerfettoTimeline(json)
+    assertEquals("AA==", timeline.trace)
+    assertEquals(100, timeline.timeOriginMicros)
+    assertEquals(250, timeline.timeExtentMicros)
   }
 }

--- a/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverRequestTest.kt
+++ b/third_party/src/test/java/com/jetbrains/dart/vmService/VmServiceDriverRequestTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package com.jetbrains.dart.vmService
+
+import com.google.gson.JsonObject
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.VmService
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.consumer.Consumer
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.consumer.PerfettoTimelineConsumer
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.PerfettoTimeline
+import com.jetbrains.lang.dart.ide.runner.server.vmService.vmServiceDrivers.service.element.RPCError
+import junit.framework.TestCase
+
+class VmServiceDriverRequestTest : TestCase() {
+
+  fun testPerfettoTimelineRequestSupportsLongTimestamps() {
+    val service = RecordingVmService()
+    val consumer = object : PerfettoTimelineConsumer {
+      override fun received(response: PerfettoTimeline) = Unit
+      override fun onError(error: RPCError) = Unit
+    }
+
+    service.getPerfettoVMTimeline(3_000_000_000L, 4_000_000_000L, consumer)
+
+    assertEquals("getPerfettoVMTimeline", service.method)
+    assertEquals(3_000_000_000L, service.params.get("timeOriginMicros").asLong)
+    assertEquals(4_000_000_000L, service.params.get("timeExtentMicros").asLong)
+    assertSame(consumer, service.consumer)
+  }
+
+  private class RecordingVmService : VmService() {
+    lateinit var method: String
+    lateinit var params: JsonObject
+    lateinit var consumer: Consumer
+
+    override fun request(method: String, params: JsonObject, consumer: Consumer) {
+      this.method = method
+      this.params = params
+      this.consumer = consumer
+    }
+  }
+}


### PR DESCRIPTION
## Summary

  - Upgraded the generated VM Service driver from protocol 4.4 to 4.5.
  - Added the getPerfettoVMTimeline RPC, including optional time-range parameters.
  - Added PerfettoTimelineConsumer and PerfettoTimeline.
  - Added response routing for PerfettoTimeline.
  - Synchronized related generated documentation changes.
 
## What is PerfettoVMTimeline?

  PerfettoVMTimeline is a VM performance trace encoded in Perfetto’s protobuf format and returned as a Base64 string. It can events such as VM activity, garbage collection, and thread execution.

  The trace can then be opened in Perfetto-compatible tools for performance analysis. This RPC gives clients a standard, compact alternative to the JSON events returned by getVMTimeline.

  This PR exposes the data through the Java driver; it does not add a new IDE interface for viewing it yet.

  ## Unit testing

  Added a test that builds a PerfettoTimeline from JSON and verifies:

  - The Base64 trace.
  - timeOriginMicros.
  - timeExtentMicros.

  Both VmServiceDriverElementTest and the existing VmServiceTest passed.

  ## Manual testing

  - Launched the Sandbox IDE under the Java debugger.
  - Started a Dart debugging session.
  - Used Evaluate Expression to call getPerfettoVMTimeline.
  - Confirmed the response reached PerfettoTimelineConsumer.
  - Confirmed the response type was PerfettoTimeline.
  - Verified the raw response contained trace, timeOriginMicros, and timeExtentMicros.
  - Confirmed PerfettoTimeline parsed the response successfully; the returned trace contained 572 characters.

<img width="1382" height="978" alt="Screenshot 2026-09-10 at 17 31 39" src="https://github.com/user-attachments/assets/ef47ba0d-b082-4b57-9440-1d94d6dec8cd" />

<img width="956" height="619" alt="Screenshot 2026-09-10 at 17 32 47" src="https://github.com/user-attachments/assets/35de6cec-464e-41de-a3af-4c9ffcba791b" />

<img width="1066" height="645" alt="Screenshot 2026-09-10 at 17 33 25" src="https://github.com/user-attachments/assets/31c0ec4c-027d-4185-bd30-a7cc6710ea24" />

<img width="953" height="614" alt="Screenshot 2026-09-10 at 17 30 58" src="https://github.com/user-attachments/assets/4a7f1ab3-f9b8-47bd-9bd9-b44d90eec278" />
